### PR TITLE
In case the user has dismissed the setup task, go to settings. 

### DIFF
--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -72,7 +72,7 @@ class Auth extends VendorAPI {
 
 		if ( 401 === $result->get_status() ) {
 			$error_message = esc_html__( 'Something went wrong with your attempt to authorize this App. Please try agagin.', 'pinterest-for-woocommerce' );
-			wp_safe_redirect( add_query_arg( 'error', rawurlencode( $error_message ), $this->get_redirect_url( $request->get_param( 'view' ) ) ) );
+			wp_safe_redirect( add_query_arg( 'error', rawurlencode( $error_message ), $this->get_redirect_url( $request->get_param( 'view' ), true ) ) );
 			exit;
 		}
 
@@ -114,18 +114,19 @@ class Auth extends VendorAPI {
 			do_action( 'pinterest_for_woocommerce_token_saved' );
 		}
 
-		wp_safe_redirect( $this->get_redirect_url( $request->get_param( 'view' ) ) . $error_args );
+		wp_safe_redirect( $this->get_redirect_url( $request->get_param( 'view' ), ! empty( $error ) ) . $error_args );
 		exit;
 	}
 
 	/**
 	 * Returns the redirect URI based on the current request's parameters and plugin settings.
 	 *
-	 * @param string $view The context of the view.
+	 * @param string $view      The context of the view.
+	 * @param string $has_error Whether there was an error with the auth process.
 	 *
 	 * @return string
 	 */
-	private function get_redirect_url( $view = null ) {
+	private function get_redirect_url( $view = null, $has_error = false ) {
 
 		$redirect_url            = admin_url( 'admin.php?page=' . \PINTEREST_FOR_WOOCOMMERCE_SETUP_GUIDE );
 		$is_setup_complete       = Pinterest_For_Woocommerce()::get_setting( 'is_setup_complete', true );
@@ -148,7 +149,7 @@ class Auth extends VendorAPI {
 		}
 
 		// Go to WC-Admin to render our App there.
-		$step         = empty( $error ) ? 'claim-website' : 'setup-account';
+		$step         = empty( $has_error ) ? 'claim-website' : 'setup-account';
 		$redirect_url = add_query_arg(
 			array(
 				'page' => 'wc-admin',


### PR DESCRIPTION
Fixes Issue where dismissing the setup task doesn't allow the React app to render.
For more info [here](https://app.clickup.com/t/m7beat).

### To reproduce issue
1. Install Pinterest plugin
2. Go to WooCommerce > Home
3. Dismiss the task for setting up Pinterest
    - Note: if you're not seeing it, you may have previously dismissed it. You can get it back by deleting or editing options, e.g. `woocommerce_task_list_dismissed_tasks` and/or `woocommerce_extended_task_list_complete`
4. Go to "Marketing > Pinterest"
5. Connect to Pinterest Business account

This PR ensures the merchant can complete onboarding. 

Previously the merchant would be redirected to an empty admin screen:

<img width="1393" alt="Screen Shot 2021-06-23 at 2 53 41 PM" src="https://user-images.githubusercontent.com/4167300/123028091-f80d3300-d432-11eb-94a3-9745030c079e.png">
