### PR TITLE
Adding browserlist for automatic cross-browsing on CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "lint:css": "wp-scripts lint-style ./assets/source",
     "build:zip": "composer install && wp-scripts build && gulp build && gulp package"
   },
+  "browserslist": [
+    "last 5 versions",
+    "> 1%",
+    "maintained node versions",
+    "not dead"
+  ],
   "keywords": [
     "pinterest for wordpress",
     "pinterest for woocommerce",


### PR DESCRIPTION
 ### Objective of this pull request
I've noticed some files have included a fallback for CSS variables manually, I have included this config to do this task automatically avoiding miss some fallback.

 ### How to test it
1. Run the project with: ```npm run start```
2. Add some new CSS feature such as CSS variables and check the compiled code to see the fallback
