### PR TITLE
add issue & PR templates to get consistent info on all issues/changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a bug if something isn't working as expected
+title: ''
+labels: 'type: bug'
+assignees: ''
+
+---
+
+### Describe the bug:
+<!-- 
+	A clear and concise description of what the bug is, and how it impacts your store or site.
+	If applicable, add screenshots or other data to help explain your problem.
+-->
+
+### Steps to reproduce:
+<!-- 
+	Describe the steps to reproduce the behavior.
+	Please be as descriptive as possible, and include as much detail as you can.
+-->
+1.
+2.
+3.
+
+#### Expected behavior
+<!-- What did you expect to happen? -->
+
+#### Actual behavior
+<!-- What actually happens? -->
+
+### Additional details:
+<!-- Any additional details you think might be helpful. For example: logs, WooCommerce status report, product details etc. -->
+

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,24 @@
+---
+name: Enhancement
+about: Add a new feature or improve an existing feature
+title: ''
+labels: 'type: enhancement'
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? 
+<!-- Clearly and concisely describe of what the problem is and how it impacts the site/store. -->
+
+#### How to reproduce the problem
+<!-- Include steps for how to reproduce or see the problem in context. -->
+
+### Describe the solution you'd like 
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered 
+<!-- Outline any alternative solutions or workarounds that might help with this problem. -->
+
+### Additional context 
+<!-- Add any other context or screenshots about the feature request here. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- You can erase any parts of this template not applicable to your pull request. -->
+
+<!-- Reference issue(s) that this PR fixes or addresses -->
+Closes # 
+
+### Changes proposed in this pull request
+<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
+
+#### Screenshots
+<!--- Optional --->
+
+### Detailed test instructions
+<!-- Add steps to confirm the fix or change. -->
+1. 
+2. 
+3. 
+
+<!-- Please add details of other areas that might be impacted by the change. -->
+
+### Changelog note
+<!-- Changelog notes highlight what's fixed or added in a release. -->
+
+> Fix|New|Dev: Add suggested changelog note here


### PR DESCRIPTION
Add templates to gather consistent info when logging issues, enhancements or opening PRs.

Will merge this immediately, we can tweak or adjust the templates further if needed.