### PR TITLE
Adding try again button at "Select your advertiser" step

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -349,7 +349,7 @@ const SetupTracking = ( { goToNextStep, view } ) => {
 											</>
 										)
 									) : (
-										<Spinner />
+										<StepButton />
 									) ) }
 							</CardBody>
 						) : (


### PR DESCRIPTION
This pull request has included a fix to adding a try again button ate the third step on the setup process, this pull request is a fix for the issue #48 

### Changes proposed in this pull request
The file setupTracking.js has included a component StepButton instead a Spinner component

#### Screenshots
![Screen Shot 2021-06-29 at 00 03 53](https://user-images.githubusercontent.com/330792/123714208-ca2e5100-d86d-11eb-9483-ed1d64e28aca.png)


### Detailed test instructions
1. The account should not contain a business account connect
2. Start a process to connect your new Pinterest account to the plugin
3. Click on claim your domain once the domain is validated the message will appear on "Select your advertiser and tag" block

### Changelog note

>Fix