### PR TITLE
fixing typo pointed out at issue #47

### DIFF
--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -98,7 +98,7 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 							'pinterest-for-woocommerce'
 						) }
 						description={ __(
-							'Claim your website get access to analytics for the Pins you publish from your site, the analytics on Pins that other people create from your site and let people know where they can find more of you content.'
+							'Claim your website to get access to analytics for the Pins you publish from your site, the analytics on Pins that other people create from your site and let people know where they can find more of you content.'
 						) }
 						link={ wcSettings.pin4wc.pinterestLinks.claimWebsite }
 					/>


### PR DESCRIPTION
Fixes #47 

Adding typo fix at the text "Claim your site" step during the account set up process, this Pull request is related the issue #47  

### Changes proposed in this pull request
This pull request changes the string on the stepOverview component at account setup process

#### Screenshots
<!--- Optional --->
![Screen Shot 2021-06-29 at 00 31 51](https://user-images.githubusercontent.com/330792/123716007-71f94e00-d871-11eb-9d0b-3d5e92e53483.png)

### Detailed test instructions
1. Go to settings at Pinterest section
2. Connect your Pinterest account to 
3. After connected, the text is going to be show at right side on the text description

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog note
<!-- Changelog notes highlight what's fixed or added in a release. -->

> Fix