### PR TITLE
Fix wrong meta attribute.

### DIFF
--- a/src/RichPins.php
+++ b/src/RichPins.php
@@ -107,7 +107,7 @@ class RichPins {
 		$tags = array(
 			'og:url'       => esc_url( get_the_permalink() ),
 			'og:site_name' => get_bloginfo( 'name' ),
-			'og:type'      => is_singular( 'product' ) ? 'og:product' : 'article',
+			'og:type'      => is_singular( 'product' ) ? 'product' : 'article',
 			'og:title'     => get_the_title(),
 		);
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->

Fixes [Issue ](https://app.clickup.com/t/n7a3jq) where we are are serving a wrong meta attibute the OpenGraph schema. related[ Pinterest Docs](https://developers.pinterest.com/docs/rich-pins/products/?)



### Detailed test instructions
Validate that the page includes this
`<meta property="og:type" content="product" />`
instead of 
`<meta property="og:type" content="og:product" />`
