### PR TITLE
Fix overview text disappearing behind settings cards.

### DIFF
--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -149,7 +149,10 @@ $root: ".woocommerce-setup-guide";
 
 				&-overview {
 					margin-top: var(--large-gap);
-					position: absolute;
+
+					@media (min-width: 783px) {
+						position: absolute;
+					}
 
 					> div {
 						margin: 8px 0;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #46 

Fixes [issue ](https://app.clickup.com/t/9r2y5y)with Overview/Instruction text disapearing behind the actual settings on mobile devices (when things get stacked).


### Detailed test instructions
Verify fix based on the screenshots above. 
