### PR TITLE
add built zip file to gitignore list so can't be accidentally committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ assets/source/_maps
 
 # Composer
 /vendor/
+
+# build products
+pinterest-for-woocommerce.zip


### PR DESCRIPTION
### Changes proposed in this pull request
When the plugin is built (`npm run build:zip`), the generated zip file shows up as a new file which could be accidentally committed. This PR ignores it to prevent any accidental commits :)

### Detailed test instructions
1. Check out this branch.
2. Build - `npm run build:zip`.
3. Git status should not show the zip file as committable.
