### PR TITLE
Bugfix/track events on redirect

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -186,7 +186,9 @@ class Tracking {
 	 */
 	public static function hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
 
-		if ( wp_doing_ajax() ) {
+		$redirect_to_cart = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
+
+		if ( wp_doing_ajax() && ! $redirect_to_cart ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Fixes [Issue ](https://app.clickup.com/t/5d3gzg) (partially) where when `Redirect to the cart page after successful addition` was enable in WooCommerce, the Add to Cart events were not tracked. 

### Changes proposed in this pull request
Uses a transient to store any Event snippets that were not printed on `shutdown`. When the class is initialized on the next page load - which should be the redirect to cart, but even if it is not, it shouldn't be an issue - the stored events snippets are read printed in the normal flow of this feature.

Has no UI changes, and doesn't affect any user flows. 

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Enable `Redirect to the cart page after successful addition` in WooCommerce settings.
2. Check that Add-to-cart events are tracked properly (more info on testing Tracking events on the original PR #19 
