### PR TITLE
Add product category and order_id to checkout event

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -185,11 +185,15 @@ class Tracking {
 
 			$product = $order_item->get_product();
 
+			$terms      = wc_get_object_terms( $product->get_id(), 'product_cat' );
+			$categories = ! empty( $terms ) ? wp_list_pluck( $terms, 'name' ) : array();
+
 			$order_items[] = array(
 				'product_id'       => $order_item->get_id(),
 				'product_name'     => $order_item->get_name(),
 				'product_price'    => $product->get_price(),
 				'product_quantity' => $order_item->get_quantity(),
+				'product_category' => $categories,
 			);
 
 			$total_quantity += $order_item->get_quantity();
@@ -198,6 +202,7 @@ class Tracking {
 		self::add_event(
 			'checkout',
 			array(
+				'order_id'       => $order_id,
 				'value'          => $order->get_total(),
 				'order_quantity' => $total_quantity,
 				'currency'       => $order->get_currency(),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Fixes [Issue ](https://app.clickup.com/t/5fbvpd) where OrderID and product category for the order's line items where not sent to the checkout event.

### Changes proposed in this pull request
Adds product category and order_id to checkout event

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Checkout and validate that Order ID and product category are added to the data sent on the checkout event.
