### PR TITLE
When feed not registered, show a declined status - if declined.

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -251,7 +251,7 @@ class FeedState extends VendorAPI {
 
 		try {
 
-			if ( empty( $merchant_id ) || ! Pinterest_For_Woocommerce()::get_data( 'feed_registered' ) ) {
+			if ( empty( $merchant_id ) ) {
 				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
 			}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

In case a user has a declined feed, and the feed was never registered throught the plugin (or the setting was removed somehow), the catalog screen returns `Product feed not yet configured on Pinterest.` to the user. 



### Changes proposed in this pull request
Removes a check for is_registered of the feed, to allow the "Declined" state of a feed reach the user.

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/4016167/124319987-bfccc980-db83-11eb-9447-db1f789c2859.png)
After
![image](https://user-images.githubusercontent.com/4016167/124320319-50a3a500-db84-11eb-9594-4ba92f7784c2.png)


### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Setup the plugin and let it register a product feed, which will get denied by Pinterest (it usually does)
2. Verify that you the feed is reported to you as denied through the Product Catalog screen. 
3. Manually modify the feed_registered data to make the plugin think it is not registered: (through WP-CLI: `wp eval "Pinterest_For_Woocommerce()::save_data( 'feed_registered', false );"`
4. After the fix, you should see a "product feed declined by Pinterest" status in the Remote feed setup. 

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog note
<!-- Changelog notes highlight what's fixed or added in a release. -->
