### PR TITLE
we should always return the regular price in the price field. 

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -237,9 +237,9 @@ class ProductsXmlFeed {
 	private static function get_property_g_price( $product, $property ) {
 
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
-			$price = $product->get_variation_price();
+			$price = $product->get_variation_regular_price();
 		} else {
-			$price = $product->get_price();
+			$price = $product->get_regular_price();
 		}
 
 		if ( empty( $price ) ) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Fixes an [issue](https://app.clickup.com/t/nb9m33) where on the xml file the value registered for both  g:price and sale_price is the sale price value

### Changes proposed in this pull request
Returns the regular price for the price field on all cases. 

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Add a product and set a sale price. Do not set any schedule dates.
2. Wait for the feed to be generated. 
3. Validate that the regular price is sent in the price field and the sale price in the sale price field.

