### PR TITLE
Account for quantity on value of add2cart event

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -200,7 +200,7 @@ class Tracking {
 			array(
 				'product_id'     => $product->get_id(),
 				'product_name'   => $product->get_name(),
-				'value'          => $product->get_price(),
+				'value'          => ( $product->get_price() * $quantity ),
 				'order_quantity' => $quantity,
 				'currency'       => get_woocommerce_currency(),
 			)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #72 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
Multiple price by quantity to sent the total of the add-to-cart action as the value of the event. 

#### Screenshots
<!--- Optional --->

### Detailed test instructions (from #72)
<!-- Add steps to confirm the fix or change. -->
1. Ensure Pinterest (`develop` branch) and Woo are installed and set up with some products with prices.
2. As shopper, view a product.
3. Select a quantity (more than 1!) and add to cart.
4. Observe the event `value` prop using [_Pinterest Tag Helper_](https://chrome.google.com/webstore/detail/pinterest-tag-helper/gmlcbajhgoaaegmlbaclmmmhpmfdajmp/) (chrome plugin) or `Ads > Conversions > Test events` in Pinterest business.
<!-- Please add details of other areas that might be impacted by the change. -->
