### PR TITLE
Desc. field -> Fallback to the objects excerpt. Closes #79

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -140,6 +140,10 @@ class ProductsXmlFeed {
 		$description = $product->get_parent_id() ? $product->get_description() : $product->get_short_description();
 
 		if ( empty( $description ) ) {
+			$description = get_the_excerpt( $product->get_id() );
+		}
+
+		if ( empty( $description ) ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #79

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
As discussed in #79 if the short description field is empty get the excerpt for the content of the product so that we don't serve the full content of description field which may be big and contain shortcodes etc. 

#### Screenshots
<!--- Optional --->
![image](https://user-images.githubusercontent.com/4016167/124648568-18f86e00-dea0-11eb-818d-108d378a96eb.png)


### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Set up and connect to Pinterest.
2. Configure product with text in the (full) description field, and leave the short description empty. 
3. Wait till the feed is regenerated or force via wc-cli: `wp eval "Automattic\WooCommerce\Pinterest\ProductSync::feed_reschedule();" && wp action-scheduler run`
4. Validate that the generated XML feed contains the excerpt of that content.

