### PR TITLE
use add_query_arg to create redirect url. Fixes #107

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -508,9 +508,16 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$control_key = uniqid();
 			$view        = is_null( $view ) ? 'settings' : $view;
+			$rest_url    = get_rest_url( null, PINTEREST_FOR_WOOCOMMERCE_API_NAMESPACE . '/v' . PINTEREST_FOR_WOOCOMMERCE_API_VERSION . '/' . PINTEREST_FOR_WOOCOMMERCE_API_AUTH_ENDPOINT );
 			$state       = http_build_query(
 				array(
-					'redirect' => get_rest_url( null, PINTEREST_FOR_WOOCOMMERCE_API_NAMESPACE . '/v' . PINTEREST_FOR_WOOCOMMERCE_API_VERSION . '/' . PINTEREST_FOR_WOOCOMMERCE_API_AUTH_ENDPOINT ) . '?control=' . $control_key . '&view=' . $view,
+					'redirect' => add_query_arg(
+						array(
+							'control' => $control_key,
+							'view'    => $view,
+						),
+						$rest_url
+					),
 				)
 			);
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #107

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
Previously the redirect URL passed to Pinterest for auth was created using a hardcoded `?`, thus breaking when the non-pretty-url Rest route already contained a `?` of its own. 

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Start onboarding from scratch be deleting `pinterest_for_woocommerce` && `pinterest_for_woocommerce_data` options.
2. Verify that the Connect your account step works properly and you are redirected back to the site. 
