### PR TITLE
Remove unnecessary separator and padding in Issues table pagination

### DIFF
--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -541,13 +541,6 @@ $root: ".woocommerce-setup-guide";
 			white-space: nowrap;
 			width: 1%;
 		}
-
-		.woocommerce-pagination {
-			border-top: 1px solid rgb(226, 228, 231);
-			margin-bottom: 0;
-			padding-bottom: 0.875rem;
-			padding-top: 0.875rem;
-		}
 	}
 
 	.error-text {


### PR DESCRIPTION
### Changes proposed in this pull request

Version tested: c7d3c3f70fcfba6fa220da2e1a17a5e47b076df5

Prior to this PR, in the Issues section, there are unnecessary top border and padding around the pagination area:

![image](https://user-images.githubusercontent.com/417342/128403990-a0768a5a-626d-4643-92c3-8e5c0c9ed08f.png)

This PR fixes the issue to make it look like the following:

![image](https://user-images.githubusercontent.com/417342/128404154-6056d6a4-c1bb-462d-8f3f-3c709cd3f595.png)

### Detailed test instructions

1. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fcatalog
2. Scroll to the bottom of the page and see the pagination area for the Issues table. It should look like the above fixed screenshot.

### Changelog note

Fix: Remove unnecessary separator and padding in Issues table pagination.