### PR TITLE
Undo reverted PR #129 changes in 1ed59a7

### DIFF
--- a/assets/source/catalog-sync/sections/SyncState.js
+++ b/assets/source/catalog-sync/sections/SyncState.js
@@ -6,7 +6,6 @@ import { useSelect } from '@wordpress/data';
 import {
 	Card,
 	CardHeader,
-	CardBody,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 
@@ -29,10 +28,8 @@ const SyncState = () => {
 					{ __( 'Overview', 'pinterest-for-woocommerce' ) }
 				</Text>
 			</CardHeader>
-			<CardBody className="no-padding">
-				<SyncStateSummary overview={ feedState?.overview } />
-				<SyncStateTable workflow={ feedState?.workflow } />
-			</CardBody>
+			<SyncStateSummary overview={ feedState?.overview } />
+			<SyncStateTable workflow={ feedState?.workflow } />
 		</Card>
 	);
 };

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -541,17 +541,6 @@ $root: ".woocommerce-setup-guide";
 			white-space: nowrap;
 			width: 1%;
 		}
-
-		.woocommerce-pagination {
-			border-top: 1px solid rgb(226, 228, 231);
-			margin-bottom: 0;
-			padding-bottom: 0.875rem;
-			padding-top: 0.875rem;
-		}
-	}
-
-	.no-padding {
-		padding: 0;
 	}
 
 	.error-text {


### PR DESCRIPTION
### Changes proposed in this pull request

In 1ed59a7, a revert on PR https://github.com/saucal/pinterest-for-woocommerce/pull/129 was done so that PR https://github.com/saucal/pinterest-for-woocommerce/pull/137 only includes stylelint changes. 

This PR reverts the revert done in 1ed59a7 so that we will have the changes done in PR #129 again. 

#### Screenshots

See PR https://github.com/saucal/pinterest-for-woocommerce/pull/129.

### Detailed test instructions

See PR #129.
