### PR TITLE
remove extra padding in Catalog sync table & tidy issues pagination (redo of #129)

### DIFF
--- a/assets/source/catalog-sync/sections/SyncState.js
+++ b/assets/source/catalog-sync/sections/SyncState.js
@@ -6,7 +6,6 @@ import { useSelect } from '@wordpress/data';
 import {
 	Card,
 	CardHeader,
-	CardBody,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 
@@ -29,10 +28,8 @@ const SyncState = () => {
 					{ __( 'Overview', 'pinterest-for-woocommerce' ) }
 				</Text>
 			</CardHeader>
-			<CardBody className="no-padding">
-				<SyncStateSummary overview={ feedState?.overview } />
-				<SyncStateTable workflow={ feedState?.workflow } />
-			</CardBody>
+			<SyncStateSummary overview={ feedState?.overview } />
+			<SyncStateTable workflow={ feedState?.workflow } />
 		</Card>
 	);
 };

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -535,17 +535,6 @@ $root: ".woocommerce-setup-guide";
 			white-space: nowrap;
 			width: 1%;
 		}
-
-		.woocommerce-pagination {
-			border-top: 1px solid rgb(226, 228, 231);
-			margin-bottom: 0;
-			padding-bottom: 0.875rem;
-			padding-top: 0.875rem;
-		}
-	}
-
-	.no-padding {
-		padding: 0;
 	}
 
 	.error-text {


### PR DESCRIPTION
This PR is a redo of changes in #129, fixing some cosmetic style issues in `Catalog sync` admin screen. 

Changes:

- Remove unnecessary padding in the summary table footer. 
- Remove unnecessary padding in issues pagination.
- Remove unnecessary separator above issues pagination.

Note: @ecgan authored these changes, but they were merged into different PR branch (#137) so I'm re-applying as a clean new PR, since we want these changes merged asap for 1.0.

#### Screenshots

![128402160-d34136f2-50e8-49a7-90df-2064fad47dc7](https://user-images.githubusercontent.com/4167300/128778394-4aedced0-f571-48e5-804f-6f2bc93f4a7d.png)

<img width="1230" alt="Screen Shot 2021-08-10 at 9 28 11 AM" src="https://user-images.githubusercontent.com/4167300/128778143-21549611-b91e-4777-b257-aab10415729a.png">

### Detailed test instructions
1. Activate & onboard in a store with a large catalog.
2. Wait for sync.
3. Go to `Marketing > Pinterest > Catalog` and confirm the status table and issues list looks good.

Note: you'll need a large number of issues to trigger pagination. If you need to hack in fake issues to test you can do something like this in `FeedIssues::get_feed_issues()`:

```php
		$fake_issues = [];
		for ( $i = 0; $i < 100; $i ++) {
			$fake_issues[] = [
				'status'            => 'bad',
				'product_name'      => "Product #$i",
				'product_edit_link' => 'https//w.a',
				'issue_description' => 'just wrong',
			];
		}

		$response = new WP_REST_Response(
			array(
				'lines'      => $fake_issues,
				'total_rows' => count( $fake_issues ),
			)
		);

		$response->header( 'X-WP-Total', $issues_data['total'] );
		$response->header( 'X-WP-TotalPages', ceil( $issues_data['total'] / $per_page ) );

		return $response;
```


### Changelog note

> Fix: Tidy styling of Catalog sync - remove unnecessary padding and separator 
