### PR TITLE
Bundle @wordpress/compose

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/depe
 const requestToExternal = ( request ) => {
 	// Bundle these packages & components so we can use the latest, independent of WordPress version.
 	// Without bundling these specific recent versions, components like LandingPageApp don't render correctly.
-	const bundled = [ '@wordpress/components' ];
+	const bundled = [ '@wordpress/components', '@wordpress/compose' ];
 	if ( bundled.includes( request ) ) {
 		return false;
 	}


### PR DESCRIPTION
There seems to be an incompatibility with the bundled @wordpress/components, and it's dependencies with @wordpress/compose.

By bundling this we make sure that the Modal component works with WP 5.6 (which is the minimum supported version of WP).

Reported in #131