### PR TITLE
Fix issue where the advertiser changes and the tracking_tag doesn't.

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -137,7 +137,11 @@ const SetupTracking = ( { view } ) => {
 				setTagsList( results );
 
 				if ( Object.keys( results ).length > 0 ) {
-					if ( ! appSettings?.tracking_tag ) {
+					if (
+						! appSettings?.tracking_tag ||
+						typeof results[ appSettings?.tracking_tag ] ===
+							'undefined'
+					) {
 						handleOptionChange(
 							'tracking_tag',
 							Object.keys( results )[ 0 ]


### PR DESCRIPTION
Fixes #144.

### Changes proposed in this pull request

There was an issue that appeared only when multiple advertisers were available on the connected pinterest account.

After switching advertisers, the tracking tag list changed, but the option value was never changed no the data store, and by result, neither on the settings.

Therefore this setting was never changing. This PR fixes that.

### Detailed test instructions
1. Install Pinterest Plugin on a fresh WP+Woo site
2. do the onboarding with a merchant that has 2 or more advertisers and select 1 o them 
3. navigate through the site to send the tracking conversion to the Pinterest account.
4. go to the "Connection" tab on the Settings page of Pinterest plugin and change Advertiser
5. Navigate through the site to send the tracking conversion to the Pinterest account.