### PR TITLE
Add a delay while waiting for domain verification.

### DIFF
--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -97,7 +97,8 @@ class DomainVerification extends VendorAPI {
 
 			if ( 403 === $error_code && $this->verification_attempts_remaining > 0 ) {
 				$this->verification_attempts_remaining--;
-				Logger::log( sprintf( 'Retrying domain verification. Attempts left: %d', $this->verification_attempts_remaining ), 'debug' );
+				Logger::log( sprintf( 'Retrying domain verification in 5 seconds. Attempts left: %d', $this->verification_attempts_remaining ), 'debug' );
+				sleep( 5 );
 				return call_user_func( __METHOD__ );
 			}
 


### PR DESCRIPTION
While exploring #154, which exposes an error when domain validation takes too much time on the pinterest side, I've thought of adding a delay to increase the change of validation getting through.

This doesn't actually fixes the issue, so i'm not closing / linking this PR with the issue.