### PR TITLE
Await for settings to be saved to display checkbox.

### DIFF
--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -31,10 +31,10 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 	const createNotice = useCreateNotice();
 
 	useEffect( () => {
-		if ( isDomainVerified ) {
+		if ( status !== 'pending' && isDomainVerified ) {
 			setStatus( 'success' );
 		}
-	}, [ isDomainVerified ] );
+	}, [ status, isDomainVerified ] );
 
 	const handleClaimWebsite = async () => {
 		setStatus( 'pending' );
@@ -47,9 +47,9 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 				method: 'POST',
 			} );
 
-			setStatus( 'success' );
+			await setAppSettings( { account_data: results.account_data } );
 
-			setAppSettings( { account_data: results.account_data } );
+			setStatus( 'success' );
 		} catch ( error ) {
 			setStatus( 'error' );
 


### PR DESCRIPTION
While testing for #154, i've noticed that the button to continue after domain validation is available before settings are saved to the server.

This actually makes the button to be disabled until it's actually saved on the server.

This is not a fix related to the issue itself, just a nice improvement I thought would avoid some issues if someone clicks too fast on the continue button.