### PR TITLE
Add link to generated feed (to help debugging)

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -202,12 +202,10 @@ class FeedState extends VendorAPI {
 				$status       = 'success';
 				$status_label = esc_html__( 'Up to date', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s text string indicating progress, %3$s hyperlink open tag, %4$s hyperlink close tag */
-					esc_html__( '%3$sFeed%4$s generated %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
+					/* Translators: %1$s Time string, %2$s text string indicating progress */
+					esc_html__( 'Successfully generated %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['progress'],
-					'<a href="' . $state['feed_url'] . '" target="_blank">',
-					'</a>'
+					$state['progress']
 				);
 				break;
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -422,8 +422,14 @@ class ProductSync {
 				'in_progress',
 				array(
 					'current_index' => self::$current_index,
-					/* Translators: %1$s number of products written, %2$s total number of products */
-					'progress'      => sprintf( esc_html__( 'Wrote %1$s out of %2$s products.', 'pinterest-for-woocommerce' ), self::$current_index, $state['products_count'] ),
+					'progress'      => sprintf(
+						/* Translators: %1$s number of products written, %2$s total number of products, %3$s hyperlink open tag, %4$s hyperlink close tag */
+						esc_html__( 'wrote %1$s out of %2$s products to %3$sfeed file%4$s.', 'pinterest-for-woocommerce' ),
+						self::$current_index,
+						$state['products_count'],
+						'<a href="' . $state['feed_url'] . '" target="_blank">',
+						'</a>'
+					),
 				)
 			);
 


### PR DESCRIPTION
Closes #158

### Changes proposed in this pull request
Add a link to the generated feed, which could help debug the feed ingestion URL.

#### Screenshots
![image](https://user-images.githubusercontent.com/6192180/129821023-5a4f0006-9b84-490e-9823-175aa459fc0e.png)

### Detailed test instructions
1. Link should be visible in the catalog section of the settings area of the plugin