### PR TITLE
Generate local feed no matter the result of the registration feed process

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -210,6 +210,12 @@ class ProductSync {
 		$state         = self::feed_job_status( 'check_registration' );
 		$force_new_reg = false;
 
+		if ( 'generated' !== $state['status'] ) {
+			self::log( 'Feed didn\'t fully generate yet. Retrying later.', 'debug' );
+			// Feed is not generated yet, lets wait a bit longer.
+			return true;
+		}
+
 		$feed_args = array(
 			'feed_location'             => $state['feed_url'],
 			'feed_format'               => 'XML',


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Related (doesn't close yet) #161, fixes #179

### Changes proposed in this pull request
This PR address the issue of feed generation logic not being in the right place. As a side effect of this PR, I've also improved the expiration logic to be more accurate, and not depend on the ingestion.

#### Screenshots

Initial status on a Declined account
![image](https://user-images.githubusercontent.com/6192180/129821709-9277c2da-de05-44b2-aade-aed8325e9123.png)

**After feed registration is attempted (discovering it's already declined)**

Before this PR, it got stuck in this state, missleading the real status of things.
![image](https://user-images.githubusercontent.com/6192180/129821814-c0c1c5a9-df3e-4687-8ff1-38f6bfc3e724.png)

After this PR, the feed is generated anyway.
![image](https://user-images.githubusercontent.com/6192180/129822337-6e1e51ff-e943-452b-ba65-4be4b1e5a1d0.png)