### PR TITLE
Log everything but debug information by default.

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -43,9 +43,12 @@ class Logger {
 	 */
 	public static function log( $message, $level = 'debug', $feature = null ) {
 
-		$logging = 'debug' !== $level ? true : Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' );
+		$allow_logging = true;
+		if ( 'debug' === $level ) {
+			$allow_logging = Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' );
+		}
 
-		if ( empty( $logging ) || ! function_exists( 'wc_get_logger' ) ) {
+		if ( empty( $allow_logging ) || ! function_exists( 'wc_get_logger' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This is something I discovered while doing other changes.

The logic before this PR logged only errors when debug logging was disabled.

After this PR, everything that's not `debug` level is logged, allowing to log other levels like `warn`, `critical`, `info`.

Most of these are not used, but still is useful.