### PR TITLE
disable phpcs check workflow; no actions in private repo

### DIFF
--- a/.github/disabled-workflows/php-coding-standards.yml
+++ b/.github/disabled-workflows/php-coding-standards.yml
@@ -1,4 +1,5 @@
 name: PHP Coding Standards
+# All workflows are currently disabled – private WooCommerce repos do not have access to GitHub actions.
 
 on:
   push:


### PR DESCRIPTION
Disabling our GitHub Action for phpcs. WooCommerce private repos do not have access to workflows, due to limitations of the current plan for the WooCommerce org. 

We can reinstate this and set up more actions when the repo goes public.