### PR TITLE
Fix "double pasting" and add more feature explanation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A native integration which allows you to market your store on Pinterest, including:
 
 -   [Sync your WooCommerce products to Pinterest.](https://help.pinterest.com/en/business/article/before-you-get-started-with-catalogs)
--   Add [Save button](https://help.pinterest.com/en/business/article/save-button) to your products' images, so your visitors can save them straight to a Pinterest board.
+-   Allow your visitors to [save products to their Pinterest boards](https://help.pinterest.com/en/business/article/save-button).
 -   Make your products and posts show up as [Rich Pins](https://help.pinterest.com/en/business/article/rich-pins) on Pinterest.
 -   Track conversions with [Pinterest tag](https://help.pinterest.com/en/business/article/track-conversions-with-pinterest-tag).
 


### PR DESCRIPTION
### Changes proposed in this pull request

This is a continuation from https://github.com/woocommerce/pinterest-for-woocommerce/pull/175#issuecomment-902799523.

- Fix "double pasting" issue.
- Added more explanation on the plugin features, with links to Pinterest documentation. 

### Detailed test instructions

- Review the diff and click the `Display the rich diff` button so it looks like a nice doc.
- Review the content.
 
### Changelog note

> Fix: "Double pasting" issue in README.md.
> Add: More feature explanation in README.md.
