### PR TITLE
Bugfix/getting stuck on scheduled state

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -133,7 +133,7 @@ class ProductSync {
 	 * This could be true as the feed is being generated, if its not the 1st time
 	 * its been generated.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function feed_file_exists() {
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #192

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
By following the exact steps on #192 we can get into a state where the feed is in state `scheduled_for_generation` which doesn't let us reschedule the task that will generate it. 

This PR:
- Allows rescheduling of the feed generation task even when its already scheduled. 
- Add a small buffer time of 10seconds to the first start of the Sync handling task, to make sure its not scheduled twice.
- Checks if the actual feed file is generated & exists or not, to bail early when trying to register it with Pinterest.

#### Screenshots
<!--- Optional --->

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Create a Pinterest business account (or re-use an existing one if you have)
2. Create new sandbox WP instance in https://jurassic.ninja/
3. Install WooCommerce plugin and Activate it
4. Compile & Install the version from this branch.
5. Upload sample products from CSV file included in WooCommerce plugin
6. Verify that feed generation works properly by visiting the Catalog tab.

<!-- Please add details of other areas that might be impacted by the change. -->
