### PR TITLE
Flush caches for domain verification

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -710,7 +710,14 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			if ( $filename ) {
 				$escaped = preg_quote( $filename, '/' );
-				add_rewrite_rule( '^' . $escaped . '$', 'index.php?pinterest_verification=true', 'top' );
+				$rewrite_regex = "^{$escaped}$";
+				add_rewrite_rule( $rewrite_regex, 'index.php?pinterest_verification=true', 'top' );
+
+				// Flush rewrite rules as we need to serve the URL for the pinterest-XXXXX.html file.
+				$rewrite_rules = get_option( 'rewrite_rules' );
+				if ( ! is_array( $rewrite_rules ) || ! array_key_exists( $rewrite_regex, $rewrite_rules ) ) {
+					flush_rewrite_rules();
+				}
 			}
 		}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -773,6 +773,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				$verification_data = self::get_data( 'verification_data' );
 				$verification_code = $verification_data['verification_code'];
 
+				wc_nocache_headers();
 				header( 'Content-Type: text/html' );
 				echo '<!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><meta name="p:domain_verify" content="' . esc_attr( $verification_code ) . '"/><title></title></head><body>' . esc_html__( 'Pinterest for WooCommerce verification page', 'pinterest-for-woocommerce' ) . '</body></html>';
 				exit;

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -236,10 +236,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 
-			// Handle rewrite for Pinterest verification URL.
-			add_action( 'init', array( $this, 'verification_rewrite' ) );
-			add_filter( 'query_vars', array( $this, 'verification_query_var' ), 10, 1 );
-			add_action( 'parse_request', array( $this, 'verification_request' ), 10, 1 );
+			// Handle the Pinterest verification URL.
+			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
 			// Allow access to our option through the REST API.
 			add_filter( 'woocommerce_rest_api_option_permissions', array( $this, 'add_option_permissions' ), 10, 1 );
@@ -695,33 +693,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			return isset( $account_data['id'] ) ? $account_data['id'] : false;
 		}
 
-
-		/**
-		 * Register the rewrite rule for verification request.
-		 */
-		public function verification_rewrite() {
-
-			if ( ! self::get_data( 'verification_data' ) ) {
-				return;
-			}
-
-			$verification_data = self::get_data( 'verification_data' );
-			$filename          = isset( $verification_data['filename'] ) ? $verification_data['filename'] : false;
-
-			if ( $filename ) {
-				$escaped = preg_quote( $filename, '/' );
-				$rewrite_regex = "^{$escaped}$";
-				add_rewrite_rule( $rewrite_regex, 'index.php?pinterest_verification=true', 'top' );
-
-				// Flush rewrite rules as we need to serve the URL for the pinterest-XXXXX.html file.
-				$rewrite_rules = get_option( 'rewrite_rules' );
-				if ( ! is_array( $rewrite_rules ) || ! array_key_exists( $rewrite_regex, $rewrite_rules ) ) {
-					flush_rewrite_rules();
-				}
-			}
-		}
-
-
 		/**
 		 * Sets the default settings based on the
 		 * given values in self::$default_settings
@@ -737,45 +708,32 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 		}
 
-
-		/**
-		 * Filter the list of public query vars in order to allow the WP::parse_request
-		 * to register the query variable.
-		 *
-		 * @param array $public_query_vars The array of whitelisted query variables.
-		 *
-		 * @return array
-		 */
-		public function verification_query_var( $public_query_vars ) {
-
-			if ( ! self::get_data( 'verification_data' ) ) {
-				return $public_query_vars;
-			}
-
-			$public_query_vars[] = 'pinterest_verification';
-			return $public_query_vars;
-		}
-
-
 		/**
 		 * Hook the parse_request action and serve the html
 		 *
 		 * @param WP $wp Current WordPress environment instance.
 		 */
 		public function verification_request( $wp ) {
-
-			if ( ! self::get_data( 'verification_data' ) ) {
+			$verification_data = self::get_data( 'verification_data' );
+			if ( ! $verification_data || ! array_key_exists( 'filename', $verification_data ) ) {
 				return;
 			}
 
-			if ( isset( $wp->query_vars['pinterest_verification'] ) && 'true' === $wp->query_vars['pinterest_verification'] ) {
-
-				$verification_data = self::get_data( 'verification_data' );
-				$verification_code = $verification_data['verification_code'];
-
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			$request = trim( $wp->request ?? $_SERVER['PHP_SELF'] ?? '', '/' );
+			if ( $verification_data['filename'] === $request ) {
 				wc_nocache_headers();
 				header( 'Content-Type: text/html' );
-				echo '<!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><meta name="p:domain_verify" content="' . esc_attr( $verification_code ) . '"/><title></title></head><body>' . esc_html__( 'Pinterest for WooCommerce verification page', 'pinterest-for-woocommerce' ) . '</body></html>';
+				?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta name="p:domain_verify" content="<?php echo esc_attr( $verification_data['verification_code'] ); ?>"/>
+	<title></title>
+</head>
+<body><?php esc_html_e( 'Pinterest for WooCommerce verification page', 'pinterest-for-woocommerce' ); ?></body>
+</html>
+				<?php
 				exit;
 			}
 		}

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -398,7 +398,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 						admin_url( 'admin.php' )
 					)
 				),
-				'domainToVerify'  => wp_parse_url( site_url(), PHP_URL_HOST ),
+				'domainToVerify'  => wp_parse_url( home_url(), PHP_URL_HOST ),
 				'isConnected'     => ! empty( Pinterest_For_Woocommerce()::get_token()['access_token'] ),
 				'apiRoute'        => PINTEREST_FOR_WOOCOMMERCE_API_NAMESPACE . '/v' . PINTEREST_FOR_WOOCOMMERCE_API_VERSION,
 				'optionsName'     => PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME,

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -261,7 +261,7 @@ class Base {
 	 */
 	public static function trigger_verification( $allow_multiple = true ) {
 
-		$domain      = wp_parse_url( site_url(), PHP_URL_HOST );
+		$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
 		$request_url = 'domains/' . $domain . '/verification/metatag/realtime/';
 
 		if ( $allow_multiple ) {

--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -81,8 +81,6 @@ class DomainVerification extends VendorAPI {
 
 				$result = Base::trigger_verification();
 
-				flush_rewrite_rules(); // Rewrite rules as we need to serve the URL for the pinterest-XXXXX.html file.
-
 				if ( 'success' === $result['status'] ) {
 					$account_data = Pinterest_For_Woocommerce()::update_account_data();
 					return array_merge( (array) $result['data'], array( 'account_data' => $account_data ) );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #154

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
To make sure that caching doesn't cause issues with the domain verification, the WordPress rewrite rules are flushed whenever the rule is added. Since the `verification_rewrite` method is run on every page load (on `init`), I've added a simple check that fetches the WP rewrite rules from DB and makes sure that the new rule doesn't exist before flushing the rules. This still adds an extra DB call to EVERY page load, which isn't ideal.

There's also the option of removing the meta tag and the verification HTML from the site once the domain is claimed. This should be the preferred way of handling domain verification because once the domain is claimed users no longer need those tags and URLs on their site. However, it might not be that easy for the user to claim another domain without disconnecting the plugin and removing data.

As an extra measure, the `home_url` WordPress function is now used to obtain the domain because we've had issues with `site_url` in other extensions:

> We've seen problems with other integrations where it is preferable to use home_url() to cover situations where merchant sites might have a more complicated setup with wp files being located somewhere different to where the front end of the site is accesible. e.g. woocommerce/google-listings-and-ads#798

(from https://github.com/woocommerce/pinterest-for-woocommerce/issues/154#issuecomment-920977632)

This PR also adds `no-cache` headers when loading the **pinterest-XXXXX.html** file. I originally wanted to add the no-cache headers to the site whenever the domain verification meta tag is added but then I realized it's always added so that's not an option. If we decide to hide the meta tag once the domain gets claimed then we can add the no-cache headers temporarily until then. Another option would be to check for the `user-agent` of the Pinterest bot that checks for verification meta tag and only reset cache if it's a match. However, I'm not sure if `user-agent` or any other identifying information is provided by Pinterest when they check the user's website for the verification meta tag.

#### Screenshots
<!--- Optional --->

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Connect your Pinterest account and claim your domain

<!-- Please add details of other areas that might be impacted by the change. -->
