### PR TITLE
Reduce minimum PHP version requirement to 7.3

### DIFF
--- a/.github/disabled-workflows/php-coding-standards.yml
+++ b/.github/disabled-workflows/php-coding-standards.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '7.3'
           coverage: none
           tools: composer, cs2pr
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository is not suitable for support. Please don't use our issue tracker 
 
 ### Requirements
 
-Pinterest for WooCommerce requires recent versions of PHP (7.4 or newer), and WordPress and WooCommerce (we recommend the latest, and support the last two versions, a.k.a. L-2).
+Pinterest for WooCommerce requires recent versions of PHP (7.3 or newer), and WordPress and WooCommerce (we recommend the latest, and support the last two versions, a.k.a. L-2).
 
 See [pinterest-for-woocommerce.php](https://github.com/woocommerce/pinterest-for-woocommerce/blob/develop/pinterest-for-woocommerce.php) for current required versions.
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * Set the minimum required versions for the plugin.
 		 */
 		const PLUGIN_REQUIREMENTS = array(
-			'php_version' => '7.4',
+			'php_version' => '7.3',
 			'wp_version'  => '5.6',
 			'wc_version'  => '5.3',
 		);

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
+		"php": ">=7.3",
 		"composer/installers": "^1.7.0",
 		"automattic/jetpack-autoloader": "^2.10.1",
 		"defuse/php-encryption": "^2.2"
@@ -21,6 +22,11 @@
 	"autoload": {
 		"psr-4": {
 			"Automattic\\WooCommerce\\Pinterest\\": "src/"
+		}
+	},
+	"config": {
+		"platform": {
+			"php": "7.3.0"
 		}
 	},
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="WooCommerce Coding Standards">
 	<description>Pinterest for WooCommerce ruleset.</description>
-	
+
 	<!-- Οnly files with a php extension -->
 	<arg name="extensions" value="php" />
 
@@ -13,7 +13,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.6" />
-	<config name="testVersion" value="7.4-" />
+	<config name="testVersion" value="7.3-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core">

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -23,7 +23,7 @@
  *
  * Requires at least: 5.6
  * Tested up to: 5.8
- * Requires PHP: 7.4
+ * Requires PHP: 7.3
  *
  * WC requires at least: 5.3
  * WC tested up to: 5.5


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #215 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

This PR reduces the minimum required PHP version to 7.3 (from 7.4). I couldn't find any incompatible code so most of the changes in this PR are basically replacing the 7.4 texts with 7.3. I also added a new `config > platform` field to `composer.json` so that it mocks the platform's PHP version and no incompatible packages can be installed even if the host PHP version is greater than 7.3.

### Detailed test instructions

Nothing specific to test here so I think it'd be good to just configure your local to use PHP 7.3 and do some basic smoke testing.

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog note
<!-- Changelog notes highlight what's fixed or added in a release. -->

> Dev: Reduce minimum PHP version requirement to 7.3
