### PR TITLE
Cancel ActionScheduler jobs on account disconnection

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -578,6 +578,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			self::save_setting( 'tracking_advertiser', null );
 			self::save_setting( 'tracking_tag', null );
 
+			// Cancel scheduled jobs
+			Pinterest\ProductSync::cancel_jobs();
+
 			// At this point we're disconnected.
 			return true;
 		}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -811,4 +811,15 @@ class ProductSync {
 			self::feed_reschedule();
 		}
 	}
+
+
+	/**
+	 * Cancels the scheduled product sync jobs.
+	 *
+	 * @return void
+	 */
+	public static function cancel_jobs() {
+		as_unschedule_all_actions( ProductSync::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		as_unschedule_all_actions( ProductSync::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+	}
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Related to #166 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

This PR cancels the feed generation and product sync jobs when the user disconnects their Pinterest account.

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Connect your account and wait for the action scheduler jobs to be scheduled (by checking in `WooCommerce > Status > Action Scheduler`).
2. Disconnect your Pinterest account and make sure the jobs are canceled.

<!-- Please add details of other areas that might be impacted by the change. -->
