### PR TITLE
Use stored feed profile ID to retrieve catalog status and issues

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -464,7 +464,7 @@ class Base {
 			"catalogs/datasource/feed_report/{$merchant_id}/",
 			'GET',
 			array(
-				'feed_profile' => $feed_id
+				'feed_profile' => $feed_id,
 			),
 			'',
 			MINUTE_IN_SECONDS

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -461,7 +461,7 @@ class Base {
 	 */
 	public static function get_merchant_feed( $merchant_id, $feed_id ) {
 		return self::make_request(
-			'catalogs/datasource/feed_report/' . $merchant_id . '/',
+			"catalogs/datasource/feed_report/{$merchant_id}/",
 			'GET',
 			array(
 				'feed_profile' => $feed_id

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -455,29 +455,20 @@ class Base {
 	 * Get a specific merchant's feed using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
-	 * @param string $feed_id     The ID of the feed to be updated.
+	 * @param string $feed_id     The ID of the feed.
 	 *
 	 * @return mixed
 	 */
 	public static function get_merchant_feed( $merchant_id, $feed_id ) {
-		$args = array( 'feed_profile' => $feed_id );
-
 		return self::make_request(
-			add_query_arg( $args, 'catalogs/datasource/feed_report/' . $merchant_id . '/' ),
-			'GET'
+			'catalogs/datasource/feed_report/' . $merchant_id . '/',
+			'GET',
+			array(
+				'feed_profile' => $feed_id
+			),
+			'',
+			MINUTE_IN_SECONDS
 		);
-	}
-
-
-	/**
-	 * Request the feed report data from the API and return the response.
-	 *
-	 * @param string $merchant_id The ID of the merchant for the request.
-	 *
-	 * @return mixed
-	 */
-	public static function get_feed_report( $merchant_id ) {
-		return self::make_request( 'catalogs/datasource/feed_report/' . $merchant_id . '/', 'GET', array(), '', MINUTE_IN_SECONDS );
 	}
 
 

--- a/src/API/FeedIssues.php
+++ b/src/API/FeedIssues.php
@@ -56,7 +56,7 @@ class FeedIssues extends VendorAPI {
 	public function get_feed_issues( WP_REST_Request $request ) {
 
 		try {
-			$feed_id = Pinterest\ProductSync::is_feed_registered();
+			$feed_id = Pinterest\ProductSync::get_registered_feed_id();
 			if ( ! Pinterest\ProductSync::is_product_sync_enabled() || ! $feed_id ) {
 				return array( 'lines' => array() );
 			}

--- a/src/API/FeedIssues.php
+++ b/src/API/FeedIssues.php
@@ -56,8 +56,8 @@ class FeedIssues extends VendorAPI {
 	public function get_feed_issues( WP_REST_Request $request ) {
 
 		try {
-
-			if ( ! Pinterest\ProductSync::is_product_sync_enabled() || ! Pinterest\ProductSync::is_feed_registered() ) {
+			$feed_id = Pinterest\ProductSync::is_feed_registered();
+			if ( ! Pinterest\ProductSync::is_product_sync_enabled() || ! $feed_id ) {
 				return array( 'lines' => array() );
 			}
 
@@ -67,7 +67,7 @@ class FeedIssues extends VendorAPI {
 			$per_page        = $request->has_param( 'per_page' ) ? (int) $request->get_param( 'per_page' ) : 25;
 
 			if ( false === $issues_file_url ) {
-				$workflow = self::get_last_feed_workflow();
+				$workflow = self::get_feed_workflow( $feed_id );
 
 				if ( $workflow && isset( $workflow->s3_validation_url ) ) {
 					$issues_file_url = $workflow->s3_validation_url;
@@ -271,14 +271,15 @@ class FeedIssues extends VendorAPI {
 	 * Get the latest Workflow of the
 	 * active feed related to the last attempt to process and ingest our feed, for the Merchant saved in the settings.
 	 *
+	 * @param string $feed_id The ID of the feed.
+	 *
 	 * @return object
 	 *
 	 * @throws \Exception PHP Exception.
 	 */
-	private static function get_last_feed_workflow() {
-
+	private static function get_feed_workflow( $feed_id ) {
 		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
-		$feed_report = $merchant_id ? Base::get_feed_report( $merchant_id ) : false;
+		$feed_report = $merchant_id ? Base::get_merchant_feed( $merchant_id, $feed_id ) : false;
 
 		if ( ! $feed_report || 'success' !== $feed_report['status'] ) {
 			throw new \Exception( esc_html__( 'Could not get feed report from Pinterest.', 'pinterest-for-woocommerce' ), 400 );

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -331,13 +331,18 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_sync_status( $result ) {
 
+		$feed_id = Pinterest\ProductSync::is_feed_registered();
+		if ( ! $feed_id ) {
+			throw new \Exception( esc_html__( 'Feed is not registered with Pinterest.', 'pinterest-for-woocommerce' ) );
+		}
+
 		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
 		$extra_info  = '';
 
 		try {
 
 			// Get feed ingestion status.
-			$feed_report = $merchant_id ? Base::get_feed_report( $merchant_id ) : false;
+			$feed_report = $merchant_id ? Base::get_merchant_feed( $merchant_id, $feed_id ) : false;
 
 			if ( ! $feed_report || 'success' !== $feed_report['status'] ) {
 				throw new \Exception( esc_html__( 'Response error when trying to get feed report from Pinterest.', 'pinterest-for-woocommerce' ) );

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -331,7 +331,7 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_sync_status( $result ) {
 
-		$feed_id = Pinterest\ProductSync::is_feed_registered();
+		$feed_id = Pinterest\ProductSync::get_registered_feed_id();
 		if ( ! $feed_id ) {
 			throw new \Exception( esc_html__( 'Feed is not registered with Pinterest.', 'pinterest-for-woocommerce' ) );
 		}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -62,7 +62,7 @@ class ProductSync {
 	 */
 	public static function maybe_init() {
 
-		if ( ! self::is_product_sync_enabled() && ! self::is_feed_registered() ) {
+		if ( ! self::is_product_sync_enabled() && ! self::get_registered_feed_id() ) {
 			return;
 		}
 
@@ -198,11 +198,11 @@ class ProductSync {
 
 
 	/**
-	 * Checks if the feature is enabled, and all requirements are met.
+	 * Returns the feed profile ID if it's registered. Returns `false` otherwise.
 	 *
-	 * @return boolean
+	 * @return string|boolean
 	 */
-	public static function is_feed_registered() {
+	public static function get_registered_feed_id() {
 		return Pinterest_For_Woocommerce()::get_data( 'feed_registered' ) ?? false;
 	}
 
@@ -239,7 +239,7 @@ class ProductSync {
 			'locale'                    => str_replace( '_', '-', determine_locale() ),
 		);
 
-		$registered = self::is_feed_registered();
+		$registered = self::get_registered_feed_id();
 
 		if ( ! self::is_product_sync_enabled() ) {
 			// Handle feed deregistration.
@@ -520,7 +520,7 @@ class ProductSync {
 		} else {
 			$product_pin_feed_profile    = $merchant['data']->product_pin_feed_profile;
 			$product_pin_feed_profile_id = false;
-			$prev_registered             = self::is_feed_registered();
+			$prev_registered             = self::get_registered_feed_id();
 			if ( false !== $prev_registered ) {
 				try {
 					$feed                        = API\Base::get_merchant_feed( $merchant['data']->id, $prev_registered );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #183 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
This PR modifies the calls made to the catalog feed report API to include the stored feed profile ID instead of fetching the report for the last generated feed.

It resolves an issue where if the user has two or more ingestion feed profiles registered in their merchant account, we erroneously displayed the issues and status of an irrelevant feed profile in the app instead of the one that's generated by the plugin for the user's store.

I've also renamed the `ProductSync::is_feed_registered` to `ProductSync::get_registered_feed_id` and fixed the doc block because it doesn't return a boolean at all times and its main purpose seems to be to return the registered feed ID.

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Make sure you have at least two ingestion feed profiles registered in your merchant account. You can connect two test stores to your Pinterest merchant account.
2. Check `Marketing > Pinterest > Catalog` and make sure it displays the correct number of Active, Not Synced, Warnings, etc. for your store and also confirm that the product issues are displayed correctly for your products.