### PR TITLE
Fix title breadcrumbs in WC 5.8

### DIFF
--- a/assets/source/setup-guide/index.js
+++ b/assets/source/setup-guide/index.js
@@ -3,6 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781
 
 /**
  * Internal dependencies
@@ -21,7 +24,7 @@ addFilter(
 	( pages ) => {
 		const navigationEnabled = !! window.wcAdminFeatures?.navigation;
 		const initialBreadcrumbs = [
-			[ '', wcSettings.woocommerceTranslation ],
+			[ '', getSetting( 'woocommerceTranslation' ) ],
 		];
 
 		/**

--- a/assets/source/setup-guide/index.js
+++ b/assets/source/setup-guide/index.js
@@ -3,9 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-import { getSetting } from '@woocommerce/wc-admin-settings'; // eslint-disable-line import/no-unresolved
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
-// See https://github.com/woocommerce/woocommerce-admin/issues/7781
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781,
+// https://github.com/woocommerce/woocommerce-admin/issues/7810
+// Please note, that this is NOT https://www.npmjs.com/package/@woocommerce/settings,
+// or https://github.com/woocommerce/woocommerce-admin/tree/main/packages/wc-admin-settings
+// but https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/settings/shared/index.ts
+// (at an unknown version).
 
 /**
  * Internal dependencies
@@ -18,14 +23,18 @@ import CatalogSyncApp from '../catalog-sync/App';
 
 import './app/style.scss';
 
+const woocommerceTranslation =
+	// Pre WC 5.8
+	getSetting( 'woocommerceTranslation' ) ||
+	// WC 5.8+
+	getSetting( 'admin' )?.woocommerceTranslation;
+
 addFilter(
 	'woocommerce_admin_pages_list',
 	'woocommerce-marketing',
 	( pages ) => {
 		const navigationEnabled = !! window.wcAdminFeatures?.navigation;
-		const initialBreadcrumbs = [
-			[ '', getSetting( 'woocommerceTranslation' ) ],
-		];
+		const initialBreadcrumbs = [ [ '', woocommerceTranslation ] ];
 
 		/**
 		 * If the WooCommerce Navigation feature is not enabled,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3517,9 +3517,9 @@
       }
     },
     "@woocommerce/dependency-extraction-webpack-plugin": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.6.0.tgz",
-      "integrity": "sha512-IUALZQ736vXRysfwoou5zPbuvf4NsvKEfQnbi6JzQ+ftZiNzsjOLkCqlIG8p5MKHWBRTIJheBbjUylfEqI+15Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.7.0.tgz",
+      "integrity": "sha512-1Wc8KA6keZ97FMP67c9kD9761I+IC8p6pwWUl/lSXbpanxNmFPq1kiUa9en8kHThuG8gxKofkd/kLSRKw2j34A==",
       "dev": true,
       "requires": {
         "@wordpress/dependency-extraction-webpack-plugin": "^2.8.0"
@@ -3586,6 +3586,12 @@
             "path-type": "^4.0.0",
             "yaml": "^1.10.0"
           }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+          "dev": true
         }
       }
     },
@@ -4354,6 +4360,12 @@
             "path-type": "^4.0.0",
             "yaml": "^1.10.0"
           }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+          "dev": true
         }
       }
     },
@@ -4803,6 +4815,12 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
           "dev": true
         },
         "read-pkg": {
@@ -20460,12 +20478,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@2.2.1-beta-1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@woocommerce/dependency-extraction-webpack-plugin": "^1.6.0",
+    "@woocommerce/dependency-extraction-webpack-plugin": "^1.7.0",
     "@woocommerce/eslint-plugin": "^1.2.0",
     "@wordpress/base-styles": "^3.6.0",
     "@wordpress/eslint-plugin": "^9.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,21 @@ const requestToExternal = ( request ) => {
 	if ( bundled.includes( request ) ) {
 		return false;
 	}
+	// Since WooCommerce 5.8, the `window.wcSettings` no longer contains `woocommerceTranslation`,
+	// to be able to fetch that, we use unpublished `@woocommerce/wc-admin-settings` package.
+	// It's delivered with WC, so we use DEWP to import it.
+	// See https://github.com/woocommerce/woocommerce-admin/issues/7781
+	const wcDepMap = {
+		'@woocommerce/wc-admin-settings': [ 'wc', 'wcSettings' ],
+	}
+	return wcDepMap[ request ];
+};
+const requestToHandle = ( request ) => {
+	const wcHandleMap = {
+		'@woocommerce/wc-admin-settings': 'wc-settings',
+	};
+
+	return wcHandleMap[ request ];
 };
 
 // Replace the default DependencyExtractionWebpackPlugin with the Woo version
@@ -20,6 +35,7 @@ const ourPlugins = [
 	new WooCommerceDependencyExtractionWebpackPlugin( {
 		injectPolyfill: true, // TBD Confirm this is needed for Pinterest.
 		requestToExternal,
+		requestToHandle,
 	} ),
 ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,21 +8,6 @@ const requestToExternal = ( request ) => {
 	if ( bundled.includes( request ) ) {
 		return false;
 	}
-	// Since WooCommerce 5.8, the `window.wcSettings` no longer contains `woocommerceTranslation`,
-	// to be able to fetch that, we use unpublished `@woocommerce/wc-admin-settings` package.
-	// It's delivered with WC, so we use DEWP to import it.
-	// See https://github.com/woocommerce/woocommerce-admin/issues/7781
-	const wcDepMap = {
-		'@woocommerce/wc-admin-settings': [ 'wc', 'wcSettings' ],
-	}
-	return wcDepMap[ request ];
-};
-const requestToHandle = ( request ) => {
-	const wcHandleMap = {
-		'@woocommerce/wc-admin-settings': 'wc-settings',
-	};
-
-	return wcHandleMap[ request ];
 };
 
 // Replace the default DependencyExtractionWebpackPlugin with the Woo version
@@ -35,7 +20,6 @@ const ourPlugins = [
 	new WooCommerceDependencyExtractionWebpackPlugin( {
 		injectPolyfill: true, // TBD Confirm this is needed for Pinterest.
 		requestToExternal,
-		requestToHandle,
 	} ),
 ];
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
- Use ~`@woocommerce/wc-admin-settings`~ `@woocommerce/settings` imported via DEWP,
   instead of global `window.wcSettings` or settings store `getSetting`.
   Improves WC5.8 compatibility.
	  
   Note, that the package is not published and not added to dependencies.

   Works around https://github.com/woocommerce/woocommerce-admin/issues/7781
- It also updates DEWP to the latest version, it is not required for the fix.


#### Screenshots
<!--- Optional --->

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Checkout the branch
2. `npm install`
3. `npm run build`
4. Open any Pinterest page, like [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding`](https://gla1.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding)
5. Check the page title, `document.title` in console

You should see 
```
'Onboarding Guide ‹ Pinterest ‹ Marketing ‹ WooCommerce ‹ gla1.test title — WooCommerce'
```
instead of 
```
'Onboarding Guide ‹ Pinterest ‹ Marketing ‹ ‹ gla1.test title — WooCommerce'
'Onboarding Guide ‹ Pinterest ‹ Marketing ‹ false ‹ gla1.test title — WooCommerce'
```

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog note
<!-- Changelog notes highlight what's fixed or added in a release. -->

> Fix|New|Dev: Add suggested changelog note here


### Todo
- [x] figure out why sometimes it returns `false`
- [x] Check if webpack config change is needed, if we update the WooDEWP 

### Additional notes

This PR introduces a dependency that is not mentioned in `package.json` which may break local unit tests in the future, but at least it somewhat indicates where the `wcSettings` global comes from. Still, behind DEWP mystery, but at least "somewhat".