### PR TITLE
Fire `get_started_faq` tracking event

### DIFF
--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -212,7 +212,7 @@ const FaqSection = () => {
 const FaqQuestion = ( { questionId, question, answer } ) => {
 	const panelToggled = useCallback(
 		( isOpened ) => {
-			recordEvent( 'wcadmin_pfw_get_started_faq', {
+			recordEvent( 'pfw_get_started_faq', {
 				question_id: questionId,
 				action: isOpened ? 'expand' : 'collapse',
 			} );

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -191,6 +191,15 @@ const FaqSection = () => {
 };
 
 /**
+ * Clicking on getting started page faq item to collapse or expand it.
+ *
+ * @event wcadmin_pfw_get_started_faq
+ *
+ * @property {string} action `'expand' | 'collapse'` What action was initiated.
+ * @property {string} question_id Identifier of the clicked question.
+ */
+
+/**
  * FAQ component.
  *
  * @fires wcadmin_pfw_get_started_faq whenever the FAQ is toggled.

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -187,9 +188,33 @@ const FaqSection = () => {
 	);
 };
 
-const FaqQuestion = ( { question, answer } ) => {
+/**
+ * FAQ component.
+ *
+ * @fires wcadmin_pfw_get_started_faq whenever the FAQ is toggled.
+ * @param {Object} props React props
+ * @param {string} props.questionId Question identifier , to be forwarded to the trackign event.
+ * @param {string} props.question Text of the question.
+ * @param {string} props.answer Text of the answer.
+ * @return {JSX.Element} FAQ component.
+ */
+const FaqQuestion = ( { questionId, question, answer } ) => {
+	const panelToggled = useCallback(
+		( isOpened ) => {
+			recordEvent( 'wcadmin_pfw_get_started_faq', {
+				questionId,
+				action: isOpened ? 'expand' : 'collapse',
+			} );
+		},
+		[ questionId ]
+	);
+
 	return (
-		<PanelBody title={ question } initialOpen={ false }>
+		<PanelBody
+			title={ question }
+			initialOpen={ false }
+			onToggle={ panelToggled }
+		>
 			<PanelRow>{ answer }</PanelRow>
 		</PanelBody>
 	);

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -164,6 +164,7 @@ const FaqSection = () => {
 				) }
 			>
 				<FaqQuestion
+					questionId={ 'why-account-not-connected-error' }
 					question={ __(
 						'Why am I getting an “Account not connected” error message?',
 						'pinterest-for-woocommerce'
@@ -174,6 +175,7 @@ const FaqSection = () => {
 					) }
 				/>
 				<FaqQuestion
+					questionId={ 'can-i-connect-to-multiple-accounts' }
 					question={ __(
 						'I have more than one Pinterest Advertiser account. Can I connect my WooCommerce store to multiple Pinterest Advertiser accounts?',
 						'pinterest-for-woocommerce'
@@ -193,7 +195,7 @@ const FaqSection = () => {
  *
  * @fires wcadmin_pfw_get_started_faq whenever the FAQ is toggled.
  * @param {Object} props React props
- * @param {string} props.questionId Question identifier , to be forwarded to the trackign event.
+ * @param {string} props.questionId Question identifier, to be forwarded to the trackign event.
  * @param {string} props.question Text of the question.
  * @param {string} props.answer Text of the answer.
  * @return {JSX.Element} FAQ component.
@@ -202,7 +204,7 @@ const FaqQuestion = ( { questionId, question, answer } ) => {
 	const panelToggled = useCallback(
 		( isOpened ) => {
 			recordEvent( 'wcadmin_pfw_get_started_faq', {
-				questionId,
+				question_id: questionId,
 				action: isOpened ? 'expand' : 'collapse',
 			} );
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -3750,6 +3750,24 @@
         }
       }
     },
+    "@woocommerce/tracks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/tracks/-/tracks-1.1.0.tgz",
+      "integrity": "sha512-bQ/qS530bKIuAsedBCegT3QidCYw4SulXF2XqbDcZwg7LucpOZO7jJIKv94dFup3PmS0DUjrp27gAudePSZ9lA==",
+      "requires": {
+        "debug": "4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "@wordpress/a11y": {
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.15.3.tgz",
@@ -18181,8 +18199,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@woocommerce/components": "^5.1.2",
     "@woocommerce/data": "^1.1.1",
     "@woocommerce/navigation": "^5.2.0",
+    "@woocommerce/tracks": "^1.1.0",
     "@wordpress/api-fetch": "^3.23.0",
     "@wordpress/components": "^12.0.8",
     "@wordpress/compose": "^3.13.1",


### PR DESCRIPTION

Addresses a part of https://github.com/woocommerce/pinterest-for-woocommerce/issues/232

<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

When clicking on getting started page faq item to collapse or expand it.
Fire `get_started_faq` tracking event,
Install `@woocommerce/tracks` locally, for linting and testing. It's externalized with DEWP.

#### Screenshots
<!--- Optional --->
![track](https://user-images.githubusercontent.com/17435/140065093-5689a1f2-6283-4ae2-92d6-6327cc7356e1.gif)


### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
0. Enable logging tracking events in your browser `localStorage.setItem('debug', 'wc-admin*')`
1. Visit getting started page [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding)
1. Expand and collapse the FAQ questions

<!-- Please add details of other areas that might be impacted by the change. -->

### Additional notes:
1. The docs `.md` will be added in a separate PR with JSDoc automation.
2. I do not add a specific changelog note, as I'd rather add a single entry when merging the entire feature branch.
3. Sorry for the unfortunate branch name :( this PR's branch should be called like `add/232-faq-tracking`)

### Changelog note

