### PR TITLE
Fire Track Events on Account connection step.

### DIFF
--- a/assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js
+++ b/assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js
@@ -45,7 +45,7 @@ const BusinessAccountSelection = ( { businessAccounts } ) => {
 	);
 
 	const handleConnectToBusiness = () => {
-		recordEvent( 'wcadmin_pfw_business_account_connect_button_click' );
+		recordEvent( 'pfw_business_account_connect_button_click' );
 		const newURL = addQueryArgs(
 			wcSettings.pinterest_for_woocommerce.switchBusinessAccountUrl,
 			{ business_id: targetBusinessId }
@@ -117,7 +117,7 @@ const BusinessAccountSelection = ( { businessAccounts } ) => {
 							}
 							onClick={ () =>
 								recordEvent(
-									'wcadmin_pfw_business_account_create_button_click'
+									'pfw_business_account_create_button_click'
 								)
 							}
 							target="_blank"

--- a/assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js
+++ b/assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@woocommerce/components';
+import { recordEvent } from '@woocommerce/tracks';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from '@wordpress/element';
 import {
@@ -15,6 +16,27 @@ import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 
+/**
+ * Clicking on "Create business account" button.
+ *
+ * @event wcadmin_pfw_business_account_create_button_click
+ */
+/**
+ * Clicking on "Connect" business account button.
+ *
+ * @event wcadmin_pfw_business_account_connect_button_click
+ */
+
+/**
+ * Business Account Connection card.
+ *
+ * @fires wcadmin_pfw_business_account_create_button_click
+ * @fires wcadmin_pfw_business_account_connect_button_click
+ *
+ * @param {Object} props React props.
+ * @param {Array<Object>} props.businessAccounts
+ * @return {JSX.Element} Rendered component.
+ */
 const BusinessAccountSelection = ( { businessAccounts } ) => {
 	const [ targetBusinessId, setTargetBusinessId ] = useState(
 		undefined !== businessAccounts && businessAccounts.length > 0
@@ -23,6 +45,7 @@ const BusinessAccountSelection = ( { businessAccounts } ) => {
 	);
 
 	const handleConnectToBusiness = () => {
+		recordEvent( 'wcadmin_pfw_business_account_connect_button_click' );
 		const newURL = addQueryArgs(
 			wcSettings.pinterest_for_woocommerce.switchBusinessAccountUrl,
 			{ business_id: targetBusinessId }
@@ -91,6 +114,11 @@ const BusinessAccountSelection = ( { businessAccounts } ) => {
 							href={
 								wcSettings.pinterest_for_woocommerce
 									.createBusinessAccountUrl
+							}
+							onClick={ () =>
+								recordEvent(
+									'wcadmin_pfw_business_account_create_button_click'
+								)
 							}
 							target="_blank"
 						>

--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -66,7 +66,7 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 
 	const openConfirmationModal = () => {
 		setIsConfirmationModalOpen( true );
-		recordEvent( 'wcadmin_pfw_account_disconnect_button_click' );
+		recordEvent( 'pfw_account_disconnect_button_click' );
 	};
 
 	const closeConfirmationModal = () => {
@@ -209,7 +209,7 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 							}
 							onClick={ () =>
 								recordEvent(
-									'wcadmin_pfw_account_connect_button_click'
+									'pfw_account_connect_button_click'
 								)
 							}
 						>

--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	CardBody,
@@ -33,6 +34,29 @@ const PinterestLogo = () => {
 	);
 };
 
+/**
+ * Clicking on "Connect" Pinterest account button.
+ *
+ * @event wcadmin_pfw_account_connect_button_click
+ */
+/**
+ * Clicking on "Disconnect" Pinterest account button during account setup.
+ *
+ * @event wcadmin_pfw_account_disconnect_button_click
+ */
+
+/**
+ * Pinterest account connection component.
+ *
+ * @fires wcadmin_pfw_account_connect_button_click
+ * @fires wcadmin_pfw_account_disconnect_button_click
+ *
+ * @param {Object} props React props.
+ * @param {boolean} props.isConnected
+ * @param {Function} props.setIsConnected
+ * @param {Object} props.accountData
+ * @return {JSX.Element} Rendered element.
+ */
 const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 	const createNotice = useCreateNotice();
 
@@ -42,6 +66,7 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 
 	const openConfirmationModal = () => {
 		setIsConfirmationModalOpen( true );
+		recordEvent( 'wcadmin_pfw_account_disconnect_button_click' );
 	};
 
 	const closeConfirmationModal = () => {
@@ -181,6 +206,11 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 							href={
 								wcSettings.pinterest_for_woocommerce
 									.serviceLoginUrl
+							}
+							onClick={ () =>
+								recordEvent(
+									'wcadmin_pfw_account_connect_button_click'
+								)
 							}
 						>
 							{ __( 'Connect', 'pinterest-for-woocommerce' ) }

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -171,7 +171,7 @@ const SetupAccount = ( {
 									}
 									onClick={ () =>
 										recordEvent(
-											'wcadmin_pfw_account_create_button_click'
+											'pfw_account_create_button_click'
 										)
 									}
 									target="_blank"
@@ -198,7 +198,7 @@ const SetupAccount = ( {
 										}
 										onClick={ () =>
 											recordEvent(
-												'wcadmin_pfw_account_convert_button_click'
+												'pfw_account_convert_button_click'
 											)
 										}
 										target="_blank"

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -12,6 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Button, Card, CardFooter, CardDivider } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -22,6 +23,31 @@ import AccountConnection from '../components/Account/Connection';
 import BusinessAccountSelection from '../components/Account/BusinessAccountSelection';
 import { useSettingsSelect, useCreateNotice } from '../helpers/effects';
 
+/**
+ * Clicking on "… create a new Pinterest account" button.
+ *
+ * @event wcadmin_pfw_account_create_button_click
+ */
+/**
+ * Clicking on "… convert your personal account" button.
+ *
+ * @event wcadmin_pfw_account_convert_button_click
+ */
+
+/**
+ * Account setup step component.
+ *
+ * @fires wcadmin_pfw_account_create_button_click
+ * @fires wcadmin_pfw_account_convert_button_click
+ *
+ * @param {Object} props React props
+ * @param {Function} props.goToNextStep
+ * @param {string} props.view
+ * @param {boolean} props.isConnected
+ * @param {Function} props.setIsConnected
+ * @param {boolean} props.isBusinessConnected
+ * @return {JSX.Element} Rendered element.
+ */
 const SetupAccount = ( {
 	goToNextStep,
 	view,
@@ -143,6 +169,11 @@ const SetupAccount = ( {
 										wcSettings.pinterest_for_woocommerce
 											.pinterestLinks.newAccount
 									}
+									onClick={ () =>
+										recordEvent(
+											'wcadmin_pfw_account_create_button_click'
+										)
+									}
 									target="_blank"
 								>
 									{ __(
@@ -164,6 +195,11 @@ const SetupAccount = ( {
 											wcSettings.pinterest_for_woocommerce
 												.pinterestLinks
 												.convertToBusinessAcct
+										}
+										onClick={ () =>
+											recordEvent(
+												'wcadmin_pfw_account_convert_button_click'
+											)
 										}
 										target="_blank"
 									>


### PR DESCRIPTION
:warning:  This PR requires #237 as that adds `@woo…/tracks`



<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Implements part of https://github.com/woocommerce/pinterest-for-woocommerce/issues/232

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

Fire Track Events on Account connection step.
- `wcadmin_pfw_account_connect_button_click`
- `wcadmin_pfw_account_create_button_click`

From https://github.com/woocommerce/pinterest-for-woocommerce/issues/232

Plus additional:
- `wcadmin_pfw_account_convert_button_click`
- `wcadmin_pfw_account_disconnect_button_click`
- `wcadmin_pfw_business_account_create_button_click`
- `wcadmin_pfw_business_account_connect_button_click`

#### Screenshots
<!--- Optional --->

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
0. Disconnect any account (if applicable)
1. Go to Account setup page [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-account`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-account)
2. Enable tracks logging, by `localStorage.setItem('debug', 'wc-admin*')`
3. Click "Connect" - event should be logged
4. go back
3. Click "Or, create …" - event should be logged
4. go back
5. Connect personal account
3. Click "convert your personal account" button." - event should be logged
4. go back
6. Click "Disconnect"  - event should be logged
7. Reconnect personal account again
8. Click "Create business account" - event should be logged
9. go back
10. Pick an account from the dropdown, and click "Connect" - event should be logged
4. go back
6. Click "Disconnect"  - event should be logged

<!-- Please add details of other areas that might be impacted by the change. -->
### Additional notes:
1. Docs will be generated by #238 
2. I do not add any changelog not, to add a single entry for all events.
3. I added a few more events to track, as I think they may be useful, WDYT @jconroy ?

### Changelog note