### PR TITLE
Feature/improve feedstate logic

### DIFF
--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -111,3 +111,11 @@ function Pinterest_For_Woocommerce() { // phpcs:ignore WordPress.NamingConventio
 
 // Initiate the plugin.
 Pinterest_For_Woocommerce();
+
+// Register deactivation hook.
+register_deactivation_hook(
+	PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE,
+	function () {
+		Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
+	}
+);

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -11,7 +11,6 @@ namespace Automattic\WooCommerce\Pinterest\API;
 use Automattic\WooCommerce\Pinterest as Pinterest;
 
 use \WP_REST_Server;
-use \WP_REST_Request;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -164,7 +164,16 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_local_feed_state( $result ) {
 
-		$state      = Pinterest\ProductSync::feed_job_status() ?? array( 'status' => 'pending_config' );
+		$local_feed = Pinterest\ProductFeedStatus::get_local_feed();
+		$state      = Pinterest\ProductFeedStatus::get(
+			array(
+				'status',
+				'current_index',
+				'last_activity',
+				'error_message',
+				'product_count',
+			)
+		);
 		$extra_info = '';
 
 		switch ( $state['status'] ) {
@@ -178,9 +187,12 @@ class FeedState extends VendorAPI {
 				$status_label = esc_html__( 'Feed generation in progress.', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
 					/* Translators: %1$s Time string, %2$s text string indicating progress */
-					esc_html__( 'Last activity: %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
+					esc_html__( 'Last activity: %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['progress']
+					$state['current_index'],
+					$state['product_count'],
+					'<a href="' . $local_feed['feed_url'] . '" target="_blank">',
+					'</a>',
 				);
 				break;
 
@@ -189,9 +201,12 @@ class FeedState extends VendorAPI {
 				$status_label = esc_html__( 'Up to date', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
 					/* Translators: %1$s Time string, %2$s text string indicating progress */
-					esc_html__( 'Successfully generated %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
+					esc_html__( 'Successfully generated %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['progress']
+					$state['current_index'],
+					$state['product_count'],
+					'<a href="' . $local_feed['feed_url'] . '" target="_blank">',
+					'</a>',
 				);
 				break;
 
@@ -212,7 +227,7 @@ class FeedState extends VendorAPI {
 					/* Translators: %1$s Time string, %2$s text string indicating progress */
 					esc_html__( 'Last activity: %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['progress']
+					$state['error_message']
 				);
 				break;
 		}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -177,7 +177,7 @@ class FeedState extends VendorAPI {
 				$status       = 'pending';
 				$status_label = esc_html__( 'Feed generation in progress.', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s text string indicating progress */
+					/* Translators: %1$s Time string, %2$s current index of written products, %3$s total number of products, %4$s Opening link tag, %5$s closing link tag */
 					esc_html__( 'Last activity: %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
 					$state['current_index'],
@@ -191,7 +191,7 @@ class FeedState extends VendorAPI {
 				$status       = 'success';
 				$status_label = esc_html__( 'Up to date', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s text string indicating progress */
+					/* Translators: %1$s Time string, %2$s current index of written products, %3$s total number of products, %4$s Opening link tag, %5$s closing link tag */
 					esc_html__( 'Successfully generated %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
 					$state['current_index'],
@@ -215,7 +215,7 @@ class FeedState extends VendorAPI {
 				$status       = 'error';
 				$status_label = esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s text string indicating progress */
+					/* Translators: %1$s Time string, %2$s error message */
 					esc_html__( 'Last activity: %1$s ago - %2$s', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
 					$state['error_message']

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -164,15 +164,7 @@ class FeedState extends VendorAPI {
 	private function add_local_feed_state( $result ) {
 
 		$local_feed = Pinterest\ProductFeedStatus::get_local_feed();
-		$state      = Pinterest\ProductFeedStatus::get(
-			array(
-				'status',
-				'current_index',
-				'last_activity',
-				'error_message',
-				'product_count',
-			)
-		);
+		$state      = Pinterest\ProductFeedStatus::get();
 		$extra_info = '';
 
 		switch ( $state['status'] ) {

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -87,10 +87,6 @@ class ProductFeedStatus {
 
 		$state['last_activity'] = time();
 
-		if ( 'starting' === $state['status'] ) {
-			$state['started'] = time();
-		}
-
 		foreach ( $state as $key => $value ) {
 			self::$state[ $key ] = $value;
 			set_transient( $data_prefix . $key, ( false === $value ? null : $value ) ); // No expiration.

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -17,6 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProductFeedStatus {
 
+	const STATE_PROPS = array(
+		'status'        => 'pending_config',
+		'current_index' => false,
+		'last_activity' => 0,
+		'product_count' => 0,
+		'error_message' => '',
+	);
+
 	/**
 	 * The array that holds the parameters of the feed
 	 *
@@ -49,15 +57,7 @@ class ProductFeedStatus {
 		$local_feed  = self::get_local_feed();
 		$data_prefix = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_' . $local_feed['feed_id'] . '_';
 
-		$props = array(
-			'status'        => 'pending_config',
-			'current_index' => false,
-			'last_activity' => 0,
-			'product_count' => 0,
-			'error_message' => '',
-		);
-
-		foreach ( $props as $key => $default_value ) {
+		foreach ( self::STATE_PROPS as $key => $default_value ) {
 
 			if ( null === self::$state[ $key ] ) {
 				self::$state[ $key ] = get_transient( $data_prefix . $key );
@@ -183,5 +183,24 @@ class ProductFeedStatus {
 		}
 
 		return self::$local_feed;
+	}
+
+
+	/**
+	 * Removes all transients for the given feed_id.
+	 *
+	 * @param string $feed_id The ID of the feed to cleanup transients for.
+	 *
+	 * @return void
+	 */
+	public static function feed_transients_cleanup( $feed_id ) {
+
+		$data_prefix = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_' . $feed_id . '_';
+
+		foreach ( self::STATE_PROPS as $key => $default_value ) {
+			delete_transient( $data_prefix . $key );
+		}
+
+		delete_transient( 'pinterest-for-woocommerce_feed_dataset_' . $feed_id );
 	}
 }

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -132,8 +132,6 @@ class ProductFeedStatus {
 	/**
 	 * Cleanup the stored dataset.
 	 *
-	 * *** TODO: hoook
-	 *
 	 * @return void
 	 */
 	public static function feed_data_cleanup() {

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -35,26 +35,23 @@ class ProductFeedStatus {
 	 * - pending_config           The feed was reset or was never configured.
 	 * - error                    The generation process returned an error.
 	 *
-	 * @param array $props   The props that go along with the given status.
-	 *
 	 * @return array
 	 */
-	public static function get( $props = array() ) {
+	public static function get() {
 
 		$local_feed  = self::get_local_feed();
 		$data_prefix = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_' . $local_feed['feed_id'] . '_';
 		$status      = array();
-		$props       = is_array( $props ) ? $props : array( $props );
 
-		$all_props = array(
+		$props = array(
 			'status'        => 'pending_config',
 			'current_index' => false,
-			'error_message' => '',
 			'last_activity' => 0,
 			'product_count' => 0,
+			'error_message' => '',
 		);
 
-		$props = ! empty( $props ) ? array_intersect_key( $all_props, array_flip( $props ) ) : $all_props;
+		foreach ( $props as $key => $default_value ) {
 
 		foreach ( $props as $key => $default_value ) {
 			$stored         = get_transient( $data_prefix . $key );

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -59,7 +59,7 @@ class ProductFeedStatus {
 
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
 
-			if ( null === self::$state[ $key ] ) {
+			if ( ! isset( self::$state[ $key ] ) || null === self::$state[ $key ] ) {
 				self::$state[ $key ] = get_transient( $data_prefix . $key );
 			}
 

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -1,0 +1,152 @@
+
+<?php
+/**
+ * Pinterest for WooCommerce Rich Pins
+ *
+ * @package     Pinterest_For_WooCommerce/Classes/
+ * @version     1.0.0
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ *
+ */
+class ProductFeedStatus {
+
+
+	private static $local_feed = array();
+
+	/**
+	 * Saves or returns the Current state of the Feed generation job.
+	 * Status can be one of the following:
+	 *
+	 * - starting                 The feed job is being initialized. A new JobID will be assigned if none exists.
+	 * - check_registration       If a JobID already exists, it is returned, otherwise a new one will be assigned. // split into a new method.
+	 * - in_progress              Signifies that we are between iterations and generating the feed.
+	 * - generated                The feed is generated, no further action will be taken.
+	 * - scheduled_for_generation The feed needs to be (re)generated. If this status is set, the next run of __CLASS__::handle_feed_generation() will start the generation process.
+	 * - pending_config           The feed was reset or was never configured.
+	 * - error                    The generation process returned an error.
+	 *
+	 * @param array  $args   The arguments that go along with the given status.
+	 *
+	 * @return array
+	 */
+	public static function get( $props = array() ) {
+
+		$local_feed  = self::get_local_feed();
+		$data_prefix = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_' . $local_feed['feed_id'] . '_';
+		$status      = array();
+		$props       = is_array( $props ) ? $props : array( $props );
+
+		$all_props = array(
+			'status'        => 'pending_config',
+			'current_index' => false,
+			// 'progress'      => 0,
+			'error_message' => '',
+			'last_activity' => 0,
+			'product_count' => 0,
+		);
+
+		$props = ! empty( $props ) ? array_intersect_key( $all_props, array_flip( $props ) ) : $all_props;
+
+		foreach ( $props as $key => $default_value ) {
+			$stored         = get_transient( $data_prefix . $key );
+			$status[ $key ] = false === $stored ? $default_value : $stored;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * status
+	 * current_index
+	 *     //  * progress ???
+	 * error_message
+	 * last_activity
+	 *
+	 * @param array $state
+	 * @return void
+	 */
+	public static function set( $state ) {
+
+		$local_feed  = self::get_local_feed();
+		$data_prefix = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_' . $local_feed['feed_id'] . '_';
+
+		$state['last_activity'] = time();
+
+		if ( 'starting' === $state['status'] ) {
+			$state['started']  = time();
+		}
+
+		foreach ( $state as $key => $value ) {
+			set_transient( $data_prefix . $key, $value ); // No expiration.
+		}
+
+		if ( ! empty( $state['status'] ) ) {
+			do_action( 'pinterest_for_woocommerce_feed_' . $state['status'], $state );
+		}
+	}
+
+
+	public static function store_dataset( $dataset ) {
+
+		$local_feed = self::get_local_feed();
+
+		return set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $local_feed['feed_id'], $dataset, WEEK_IN_SECONDS );
+	}
+
+	public static function retrieve_dataset() {
+
+		$local_feed = self::get_local_feed();
+
+		return get_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $local_feed['feed_id'] );
+	}
+
+
+	public static function feed_data_cleanup() {
+
+		$local_feed = self::get_local_feed();
+
+		delete_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $local_feed['feed_id'] );
+	}
+
+
+
+	private static function init_local_feed() {
+
+		$feed_id = Pinterest_For_Woocommerce()::get_data( 'local_feed_id' );
+
+		if ( ! $feed_id ) {
+			$feed_id = wp_generate_password( 6, false, false );
+			Pinterest_For_Woocommerce()::save_data( 'local_feed_id', $feed_id );
+		}
+
+		$upload_dir = wp_get_upload_dir();
+
+		// Generate on the fly. That way the path/Urls follow the current site location.
+		self::$local_feed = array(
+			'feed_id'   => $feed_id,
+			'feed_file' => trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $feed_id . '.xml',
+			'tmp_file'  => trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $feed_id . '-tmp.xml',
+			'feed_url'  => trailingslashit( $upload_dir['baseurl'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $feed_id . '.xml',
+		);
+	}
+
+
+	public static function get_local_feed() {
+
+		if ( empty( self::$local_feed ) ) {
+			self::init_local_feed();
+		}
+
+		return self::$local_feed;
+	}
+}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -144,10 +144,10 @@ class ProductSync {
 			unlink( $local_feed['tmp_file'] );
 		}
 
+		ProductFeedStatus::feed_transients_cleanup( $local_feed['feed_id'] );
+
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_id', false );
 		Pinterest_For_Woocommerce()::save_data( 'feed_data_cache', false );
-
-		self::log( 'Product feed reset and file deleted.' );
 
 		self::log( 'Product feed reset and files deleted.' );
 	}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -80,8 +80,7 @@ class ProductSync {
 
 		if ( self::is_product_sync_enabled() ) {
 
-
-			$state = ProductFeedStatus::get( 'status' );
+			$state = ProductFeedStatus::get();
 			self::reschedule_if_expired();
 
 			if ( $state ) {

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -294,9 +294,9 @@ class ProductSync {
 	 * @return void
 	 */
 	private static function handle_feed_deregistration() {
-		Pinterest_For_Woocommerce()::save_data( 'feed_registered', false );
-
 		self::feed_reset();
+		self::cancel_jobs();
+		Pinterest_For_Woocommerce()::save_data( 'feed_registered', false );
 	}
 
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -57,6 +57,8 @@ class ProductSync {
 	 */
 	private static $iteration_buffer_size = 0;
 
+	private static $local_feed = array();
+
 	/**
 	 * Initiate class.
 	 */
@@ -77,10 +79,15 @@ class ProductSync {
 		}
 
 		if ( self::is_product_sync_enabled() ) {
-			$state = self::feed_job_status();
+
+
+			$state = ProductFeedStatus::get( 'status' );
+			self::reschedule_if_expired();
 
 			if ( $state ) {
 				// If local is not generated, or needs to be regenerated, schedule regeneration.
+
+
 				if ( 'starting' === $state['status'] || 'in_progress' === $state['status'] ) {
 					self::trigger_async_feed_generation();
 				} elseif ( 'scheduled_for_generation' === $state['status'] || 'pending_config' === $state['status'] ) {
@@ -101,6 +108,9 @@ class ProductSync {
 			// If feed is dirty on completion of feed generation, reschedule it.
 			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'reschedule_if_dirty' ) );
 
+			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'feed_data_cleanup' ) );
+			add_action( 'pinterest_for_woocommerce_feed_error', array( __CLASS__, 'feed_data_cleanup' ) );
+
 			// If feed is generated, but not yet registered, register it as soon as possible using an async task.
 			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'trigger_async_feed_registration_asap' ) );
 		}
@@ -114,20 +124,22 @@ class ProductSync {
 	 */
 	public static function feed_reset() {
 
-		$state = Pinterest_For_Woocommerce()::get_data( 'feed_job' ) ?? array();
+		$local_feed = ProductFeedStatus::get_local_feed();
 
-		if ( isset( $state['feed_file'] ) && file_exists( $state['feed_file'] ) ) {
-			unlink( $state['feed_file'] );
+		if ( isset( $local_feed['feed_file'] ) && file_exists( $local_feed['feed_file'] ) ) {
+			unlink( $local_feed['feed_file'] );
 		}
 
-		if ( isset( $state['tmp_file'] ) && file_exists( $state['tmp_file'] ) ) {
-			unlink( $state['tmp_file'] );
+		if ( isset( $local_feed['tmp_file'] ) && file_exists( $local_feed['tmp_file'] ) ) {
+			unlink( $local_feed['tmp_file'] );
 		}
 
-		Pinterest_For_Woocommerce()::save_data( 'feed_job', false );
+		Pinterest_For_Woocommerce()::save_data( 'local_feed_id', false );
 		Pinterest_For_Woocommerce()::save_data( 'feed_data_cache', false );
 
 		self::log( 'Product feed reset and file deleted.' );
+
+		self::log( 'Product feed reset and files deleted.' );
 	}
 
 
@@ -140,9 +152,9 @@ class ProductSync {
 	 */
 	public static function feed_file_exists() {
 
-		$state = Pinterest_For_Woocommerce()::get_data( 'feed_job' ) ?? array();
+		$local_feed = ProductFeedStatus::get_local_feed();
 
-		return isset( $state['feed_file'] ) && file_exists( $state['feed_file'] );
+		return isset( $local_feed['feed_file'] ) && file_exists( $local_feed['feed_file'] );
 	}
 
 
@@ -155,20 +167,22 @@ class ProductSync {
 	 */
 	public static function feed_reschedule( $force = false ) {
 
-		$feed_job = Pinterest_For_Woocommerce()::get_data( 'feed_job' ) ?? array();
+		$state = ProductFeedStatus::get();
 
 		if ( ! $force && isset( $feed_job['status'] ) && in_array( $feed_job['status'], array( 'in_progress', 'starting' ), true ) ) {
+		// if scheduled_for_generation, we are rescheduling here.
+
+		if ( ! $force && isset( $state['status'] ) && in_array( $state['status'], array( 'in_progress', 'starting' ), true ) ) {
 			return;
 		}
 
-		$feed_job['status'] = 'scheduled_for_generation';
-		if ( isset( $feed_job['finished'] ) ) {
-			unset( $feed_job['finished'] );
-		}
+		ProductFeedStatus::set(
+			array(
+				'status' => 'scheduled_for_generation',
+			)
+		);
 
-		Pinterest_For_Woocommerce()::save_data( 'feed_job', $feed_job );
 		self::trigger_async_feed_generation( $force );
-
 		self::log( 'Feed generation (re)scheduled.' );
 	}
 
@@ -225,16 +239,16 @@ class ProductSync {
 	 */
 	public static function handle_feed_registration() {
 
-		$state = self::feed_job_status( 'check_registration' );
-
 		if ( ! self::feed_file_exists() ) {
 			self::log( 'Feed didn\'t fully generate yet. Retrying later.', 'debug' );
 			// Feed is not generated yet, lets wait a bit longer.
 			return true;
 		}
 
+		$local_feed = ProductFeedStatus::get_local_feed();
+
 		$feed_args = array(
-			'feed_location'             => $state['feed_url'],
+			'feed_location'             => $local_feed['feed_url'],
 			'feed_format'               => 'XML',
 			'feed_default_currency'     => get_woocommerce_currency(),
 			'default_availability_type' => 'IN_STOCK',
@@ -296,7 +310,7 @@ class ProductSync {
 	 */
 	public static function handle_feed_generation() {
 
-		$state = self::feed_job_status();
+		$state = ProductFeedStatus::get();
 		$start = microtime( true );
 
 		if ( $state && 'generated' === $state['status'] || ! self::is_product_sync_enabled() ) {
@@ -312,22 +326,24 @@ class ProductSync {
 				return; // No need to perform any action.
 			}
 
-			$state = self::feed_job_status(
-				'starting',
+			ProductFeedStatus::set(
 				array(
-					'dataset'       => $product_ids,
+					'status'        => 'starting',
 					'current_index' => 0,
+					'product_count' => count( $product_ids ),
 				)
 			);
 
+			ProductFeedStatus::store_dataset( $product_ids );
 			self::$current_index = 0;
 		}
 
 		try {
 
 			if ( 'in_progress' === $state['status'] ) {
-				$product_ids         = get_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $state['job_id'] );
-				self::$current_index = get_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_current_index_' . $state['job_id'] );
+
+				$product_ids         = ProductFeedStatus::retrieve_dataset();
+				self::$current_index = $state['current_index'];
 				self::$current_index = false === self::$current_index ? self::$current_index : ( (int) self::$current_index ) + 1; // Start on the next item.
 			}
 
@@ -335,7 +351,8 @@ class ProductSync {
 				throw new \Exception( esc_html__( 'Something went wrong while attempting to generate the feed.', 'pinterest-for-woocommerce' ), 400 );
 			}
 
-			$target_file = $state['tmp_file'];
+			$local_feed  = ProductFeedStatus::get_local_feed();
+			$target_file = $local_feed['tmp_file'];
 			$xml_file    = fopen( $target_file, ( 'in_progress' === $state['status'] ? 'a' : 'w' ) );
 
 			if ( ! $xml_file ) {
@@ -364,7 +381,7 @@ class ProductSync {
 				self::$iteration_buffer_size++;
 
 				if ( self::$iteration_buffer_size >= self::$products_per_write || self::$current_index >= $products_count ) {
-					self::write_iteration_buffer( $xml_file, $state );
+					self::write_iteration_buffer( $xml_file, $local_feed );
 				}
 
 				$step_index++;
@@ -383,16 +400,15 @@ class ProductSync {
 				fwrite( $xml_file, ProductsXmlFeed::get_xml_footer() );
 				fclose( $xml_file );
 
-				self::feed_job_status( 'generated' );
-
-				if ( ! rename( $state['tmp_file'], $state['feed_file'] ) ) {
+				if ( ! rename( $local_feed['tmp_file'], $local_feed['feed_file'] ) ) {
 					/* Translators: the path of the file */
-					throw new \Exception( sprintf( esc_html__( 'Could not write feed to file: %s.', 'pinterest-for-woocommerce' ), $state['feed_file'] ), 400 );
+					throw new \Exception( sprintf( esc_html__( 'Could not write feed to file: %s.', 'pinterest-for-woocommerce' ), $local_feed['feed_file'] ), 400 );
 				}
 
-				$target_file = $state['feed_file'];
+				$target_file = $local_feed['feed_file'];
 
-				do_action( 'pinterest_for_woocommerce_feed_generated', $state );
+				ProductFeedStatus::set( array( 'status' => 'generated' ) );
+
 			} else {
 				// We got more products left. Schedule next iteration.
 				fclose( $xml_file );
@@ -413,7 +429,13 @@ class ProductSync {
 				return;
 			}
 
-			self::feed_job_status( 'error', array( 'progress' => $th->getMessage() ) );
+			ProductFeedStatus::set(
+				array(
+					'status'        => 'error',
+					'error_message' => $th->getMessage(),
+				)
+			);
+
 			self::log( $th->getMessage(), 'error' );
 		}
 	}
@@ -422,37 +444,29 @@ class ProductSync {
 	/**
 	 * Writes the iteration_buffer to the given file.
 	 *
-	 * @param resource $xml_file The file handle.
-	 * @param array    $state    The array holding the feed_state values.
+	 * @param resource $xml_file   The file handle.
+	 * @param array    $local_feed The array holding the feed attributes.
 	 *
 	 * @return void
 	 *
 	 * @throws \Exception PHP Exception.
 	 */
-	private static function write_iteration_buffer( $xml_file, $state ) {
+	private static function write_iteration_buffer( $xml_file, $local_feed ) {
 
 		if ( false !== fwrite( $xml_file, self::$iteration_buffer ) ) {
 			self::$iteration_buffer      = '';
 			self::$iteration_buffer_size = 0;
 
-			self::feed_job_status(
-				'in_progress',
+			ProductFeedStatus::set(
 				array(
+					'status'        => 'in_progress',
 					'current_index' => self::$current_index,
-					'progress'      => sprintf(
-						/* Translators: %1$s number of products written, %2$s total number of products, %3$s hyperlink open tag, %4$s hyperlink close tag */
-						esc_html__( 'Wrote %1$s out of %2$s products to %3$sfeed file%4$s.', 'pinterest-for-woocommerce' ),
-						self::$current_index,
-						$state['products_count'],
-						'<a href="' . $state['feed_url'] . '" target="_blank">',
-						'</a>'
-					),
 				)
 			);
 
 		} else {
 			/* Translators: the path of the file */
-			throw new \Exception( sprintf( esc_html__( 'Could not write to file: %s.', 'pinterest-for-woocommerce' ), $state['tmp_file'] ), 400 );
+			throw new \Exception( sprintf( esc_html__( 'Could not write to file: %s.', 'pinterest-for-woocommerce' ), $local_feed['tmp_file'] ), 400 );
 		}
 	}
 
@@ -640,108 +654,6 @@ class ProductSync {
 
 
 	/**
-	 * Saves or returns the Current state of the Feed generation job.
-	 * Status can be one of the following:
-	 *
-	 * - starting                 The feed job is being initialized. A new JobID will be assigned if none exists.
-	 * - check_registration       If a JobID already exists, it is returned, otherwise a new one will be assigned.
-	 * - in_progress              Signifies that we are between iterations and generating the feed.
-	 * - generated                The feed is generated, no further action will be taken.
-	 * - scheduled_for_generation The feed needs to be (re)generated. If this status is set, the next run of __CLASS__::handle_feed_generation() will start the generation process.
-	 * - pending_config           The feed was reset or was never configured.
-	 * - error                    The generation process returned an error.
-	 *
-	 * @param string $status The status of the feed's generation process. See above.
-	 * @param array  $args   The arguments that go along with the given status.
-	 *
-	 * @return array
-	 */
-	public static function feed_job_status( $status = null, $args = null ) {
-
-		$state_data = Pinterest_For_Woocommerce()::get_data( 'feed_job' );
-
-		if ( ! is_null( $state_data ) ) {
-			$expired = ( 'generated' === $state_data['status'] && $state_data['finished'] < ( time() - DAY_IN_SECONDS ) );
-
-			if ( $expired ) {
-				$state_data['status'] = 'scheduled_for_generation';
-				if ( isset( $state_data['finished'] ) ) {
-					unset( $state_data['finished'] );
-				}
-				Pinterest_For_Woocommerce()::save_data( 'feed_job', $state_data );
-			}
-		}
-
-		if ( is_null( $status ) || ( ! is_null( $status ) && 'check_registration' === $status && ! empty( $state_data['job_id'] ) ) ) {
-			return $state_data;
-		}
-
-		if ( ! isset( $state_data['status'] ) ) {
-			$state_data['status'] = 'pending_config';
-		}
-
-		$state_data     = empty( $state_data ) ? array() : $state_data;
-		$initial_status = $state_data['status'];
-
-		if ( 'starting' === $status || 'check_registration' === $status ) {
-
-			if ( 'check_registration' !== $status ) {
-				$state_data['status']  = $status;
-				$state_data['started'] = time();
-			}
-
-			if ( empty( $state_data['job_id'] ) ) {
-				$state_data['job_id'] = wp_generate_password( 6, false, false );
-			}
-
-			$upload_dir = wp_get_upload_dir();
-
-			$state_data['feed_file'] = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $state_data['job_id'] . '.xml';
-			$state_data['tmp_file']  = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $state_data['job_id'] . '-tmp.xml';
-			$state_data['feed_url']  = trailingslashit( $upload_dir['baseurl'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-' . $state_data['job_id'] . '.xml';
-
-			if ( isset( $args, $args['dataset'] ) ) {
-				set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $state_data['job_id'], $args['dataset'], WEEK_IN_SECONDS );
-			}
-		} elseif ( 'in_progress' === $status ) {
-			$state_data['status']        = 'in_progress';
-			$state_data['finished']      = 0;
-			$state_data['last_activity'] = time();
-			$state_data['progress']      = $args['progress'];
-
-			if ( isset( $args, $args['current_index'] ) ) {
-				set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_current_index_' . $state_data['job_id'], $args['current_index'], WEEK_IN_SECONDS );
-			}
-		} elseif ( 'generated' === $status ) {
-			$state_data['status']   = 'generated';
-			$state_data['finished'] = time();
-
-			// Cleanup.
-			delete_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $state_data['job_id'] );
-			delete_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_current_index_' . $state_data['job_id'] );
-
-		} elseif ( 'error' === $status ) {
-			$state_data['status']        = 'error';
-			$state_data['last_activity'] = time();
-			$state_data['progress']      = $args['progress'];
-
-			// Cleanup.
-			delete_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_dataset_' . $state_data['job_id'] );
-			delete_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_current_index_' . $state_data['job_id'] );
-		}
-
-		Pinterest_For_Woocommerce()::save_data( 'feed_job', $state_data );
-
-		if ( $initial_status !== $state_data['status'] ) {
-			self::log( 'Feed status set to: ' . $state_data['status'] );
-		}
-
-		return $state_data;
-
-	}
-
-
-	/**
 	 * Check if Given ID is of a product and if yes, mark feed as dirty.
 	 *
 	 * @param integer $product_id The product ID.
@@ -771,6 +683,23 @@ class ProductSync {
 		}
 	}
 
+
+	/**
+	 * Check if feed is expired, and reschedule feed generation.
+	 *
+	 * @return void
+	 */
+	public static function reschedule_if_expired() {
+
+		$state = ProductFeedStatus::get();
+
+		$expired = ( 'generated' === $state['status'] && $state['last_activity'] < ( time() - DAY_IN_SECONDS ) );
+
+		if ( $expired ) {
+			self::log( 'Feed is expired.' );
+			self::feed_reschedule();
+		}
+	}
 
 	/**
 	 * Cancels the scheduled product sync jobs.

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -118,8 +118,8 @@ class ProductSync {
 			// If feed is dirty on completion of feed generation, reschedule it.
 			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'reschedule_if_dirty' ) );
 
-			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'feed_data_cleanup' ) );
-			add_action( 'pinterest_for_woocommerce_feed_error', array( __CLASS__, 'feed_data_cleanup' ) );
+			add_action( 'pinterest_for_woocommerce_feed_generated', array( __NAMESPACE__ . '\ProductFeedStatus', 'feed_data_cleanup' ) );
+			add_action( 'pinterest_for_woocommerce_feed_error', array( __NAMESPACE__ . '\ProductFeedStatus', 'feed_data_cleanup' ) );
 
 			// If feed is generated, but not yet registered, register it as soon as possible using an async task.
 			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'trigger_async_feed_registration_asap' ) );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #178 
Closes #166 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
Small-ish refactor of the `ProductSync` methods related to handling the status of product feed.
More specifically;

- Improves logic of how we set & retrieve the status of the product feed by refactoring `ProductSync::feed_job_status()` onto smaller get/set methods. 
- Simplifies/reduces stored data for feed's current status.
- Uses transients for saving the related data.
- Avoids storing progress as string in the database.  
- Moves deregistration methods to concurrent request
- Avoid unnecessary calls to reschedule.
- Re-implements cleaner `reschedule_if_expired()`
- Implements `reschedule_if_errored()` to restart job after a delay.
- Remove scheduled actions on plugin deactivation. 

#### Screenshots
<!--- Optional --->
No visible changes to user flows / interactions. 

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Start with a clean plugin installation and a new Pinterest account.
2. Start the onboarding process and Connect to Pinterest.
3. Complete onboarding process
4. Verify that the product feed is being generated properly by visiting the Catalog tab of the plugin.
5. Verify that the product feed is being registered with Pinterest properly using Pinterest's dashboard.
5. Verify that the product feed is being regenerated after it expires (24h)
6. Verify that progress is not stored as translated strings as stated in #178
6. Verify that when Product Sync is disabled, the feed file is being deleted, the related transients are being removed and the scheduled actions are being removed. 
7. Verify that when the plugin is deactivated, scheduled tasks are removed. 

<!-- Please add details of other areas that might be impacted by the change. -->
