### PR TITLE
Fix: Error on WC Session when accessing REST API endpoint "/wc/v1" publicly #244

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -188,7 +188,7 @@ class Tracking {
 		}
 
 		if ( empty( $user_email ) ) {
-			$session_customer = function_exists( 'WC' ) ? WC()->session->get( 'customer' ) : false;
+			$session_customer = function_exists( 'WC' ) && isset( WC()->session ) ? WC()->session->get( 'customer' ) : false;
 			$user_email       = $session_customer ? $session_customer['email'] : false;
 		}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #244 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
It fixes the PHP fatal error (500) when accessing the REST API endpoint "/wp-json/wc/v1" when not logged-in.

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1.  Create a WooCommerce store
2. Install Pinterest by WooCommerce plugin
3. Now try accessing "/wp-json/wc/v1" endpoint without login. For example, yoursite.com/wp-json/wc/v1

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog entry

> Fix - Fix error with WC Session when accessing REST API endpoints publicly
