### PR TITLE
Enable enhanced match support by default 

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		protected static $default_settings = array(
 			'track_conversions'      => true,
-			'enhanced_match_support' => false,
+			'enhanced_match_support' => true,
 			'save_to_pinterest'      => true,
 			'rich_pins_on_posts'     => true,
 			'rich_pins_on_products'  => true,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #191.

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

This PR changes the default value of `enhanced_match_support` to `true` in the default settings so the user who installs the plugin for the first time will see the option `enhanced_match_support` is checked.

#### Screenshots
<!--- Optional --->

<img width="1054" alt="Screenshot 2021-11-09 at 09 58 26" src="https://user-images.githubusercontent.com/914406/140847697-58c9d084-7227-42d1-a9f3-0ca40c47124e.png">

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Install the plugin on a brand new site (so that there isn't any previous old Pinterest plugin data).
2. Go through the setup onboarding flow.
3. Go to the settings page.

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog entry

> Fix - Enable enhanced match by default 
