### PR TITLE
Add tooltips for the Publish Pins and Rich Pins options on the settings page

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@woocommerce/components';
 import {
-	Button,
+	Tooltip,
 	Card,
 	CardBody,
 	CheckboxControl,
@@ -21,6 +21,14 @@ import {
 	useSettingsDispatch,
 	useCreateNotice,
 } from '../helpers/effects';
+
+function HelpTooltip( { text } ) {
+	return (
+		<Tooltip position="top center" text={ text }>
+			<Icon icon="editor-help" />
+		</Tooltip>
+	);
+}
 
 const SetupPins = ( {} ) => {
 	const appSettings = useSettingsSelect();
@@ -78,6 +86,14 @@ const SetupPins = ( {} ) => {
 											'Track conversions',
 											'pinterest-for-woocommerce'
 										) }
+										help={
+											<HelpTooltip
+												text={ __(
+													'Gather analytics for Pins you publish and Pins users create from your site.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
+										}
 										checked={
 											appSettings.track_conversions
 										}
@@ -94,18 +110,12 @@ const SetupPins = ( {} ) => {
 											'pinterest-for-woocommerce'
 										) }
 										help={
-											<Button
-												isLink
-												href={
-													wcSettings
-														.pinterest_for_woocommerce
-														.pinterestLinks
-														.enhancedMatch
-												}
-												target="_blank"
-											>
-												<Icon icon="editor-help" />
-											</Button>
+											<HelpTooltip
+												text={ __(
+													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
 										}
 										checked={
 											appSettings.enhanced_match_support
@@ -131,6 +141,14 @@ const SetupPins = ( {} ) => {
 											'Add Rich Pins for Products',
 											'pinterest-for-woocommerce'
 										) }
+										help={
+											<HelpTooltip
+												text={ __(
+													'Automatically create and update rich pins on Pinterest for all synced products.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
+										}
 										checked={
 											appSettings.rich_pins_on_products
 										}
@@ -146,6 +164,14 @@ const SetupPins = ( {} ) => {
 											'Add Rich Pins for Posts',
 											'pinterest-for-woocommerce'
 										) }
+										help={
+											<HelpTooltip
+												text={ __(
+													'Automatically create and update rich pins on Pinterest for posts.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
+										}
 										checked={
 											appSettings.rich_pins_on_posts
 										}
@@ -170,6 +196,14 @@ const SetupPins = ( {} ) => {
 											'Save to Pinterest',
 											'pinterest-for-woocommerce'
 										) }
+										help={
+											<HelpTooltip
+												text={ __(
+													'Adds a ‘Save’ button on images allowing customers to save things straight from your website to Pinterest.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
+										}
 										checked={
 											appSettings.save_to_pinterest
 										}

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -270,6 +270,18 @@ $root: ".woocommerce-setup-guide";
 				}
 			}
 
+			&__setup-pins {
+
+				.components-popover__content {
+					width: 180px;
+					white-space: normal;
+					text-align: left;
+					// `font-family` is overwritten when using dashicon as the hovering anchor.
+					font-family: $default-font;
+				}
+
+			}
+
 			&__setup-account {
 
 				.connection-info {

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -394,7 +394,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'newAccount'             => 'https://business.pinterest.com/',
 					'claimWebsite'           => 'https://help.pinterest.com/en/business/article/claim-your-website',
 					'richPins'               => 'https://help.pinterest.com/en/business/article/rich-pins',
-					'enhancedMatch'          => 'https://help.pinterest.com/en/business/article/enhanced-match',
 					'createAdvertiser'       => 'https://help.pinterest.com/en/business/article/create-an-advertiser-account',
 					'adGuidelines'           => 'https://policy.pinterest.com/en/advertising-guidelines',
 					'adDataTerms'            => 'https://policy.pinterest.com/en/ad-data-terms',


### PR DESCRIPTION
Closes #205 

### Changes proposed in this pull request

- Add tooltips for the settings page
- Remove unused Pinterest link of "Enhanced Match"

#### Screenshots

![image](https://user-images.githubusercontent.com/17420811/141413757-59d73334-829e-439a-be10-ab7aa2622c3c.png)

### Detailed test instructions

1. Go to the Settings page
2. Hover on each question icons, and it should show up respective description within tooltip UI

### Changelog entry

> Add - Add tooltips for the Publish Pins and Rich Pins options on the settings page.
