### PR TITLE
Add merchant guidelines link in the setup page

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -97,17 +97,30 @@ const SetupAccount = ( {
 						}
 						description={ createInterpolateElement(
 							__(
-								'Set up a free Pinterest business account to get access to analytics on your Pins and the ability to run ads. This requires agreeing to the <a>Pinterest advertising guidelines</a>.',
+								'Set up a free Pinterest business account to get access to analytics on your Pins and the ability to run ads. This requires agreeing to our <adGuidelinesLink>advertising guidelines</adGuidelinesLink> and following our <merchantGuidelinesLink>merchant guidelines</merchantGuidelinesLink>.',
 								'pinterest-for-woocommerce'
 							),
 							{
-								a: (
+								adGuidelinesLink: (
 									// Disabling no-content rule - content is interpolated from above string.
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
 										href={
 											wcSettings.pinterest_for_woocommerce
 												.pinterestLinks.adGuidelines
+										}
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+								merchantGuidelinesLink: (
+									// Disabling no-content rule - content is interpolated from above string.
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a
+										href={
+											wcSettings.pinterest_for_woocommerce
+												.pinterestLinks
+												.merchantGuidelines
 										}
 										target="_blank"
 										rel="noreferrer"

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -398,6 +398,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'createAdvertiser'       => 'https://help.pinterest.com/en/business/article/create-an-advertiser-account',
 					'adGuidelines'           => 'https://policy.pinterest.com/en/advertising-guidelines',
 					'adDataTerms'            => 'https://policy.pinterest.com/en/ad-data-terms',
+					'merchantGuidelines'     => 'https://policy.pinterest.com/en/merchant-guidelines',
 					'convertToBusinessAcct'  => 'https://help.pinterest.com/en/business/article/get-a-business-account#section-15096',
 					'appealDeclinedMerchant' => 'https://www.pinterest.com/product-catalogs/data-source/?showModal=true',
 				),


### PR DESCRIPTION
Closes #210.

### Changes proposed in this pull request

- Add the [Pinterest Merchant Guidelines][pinterest-merchant-guidelines] link in the step one of the setup page.

#### Screenshots

<img width="641" alt="Screenshot 2021-11-15 at 10 40 01" src="https://user-images.githubusercontent.com/914406/141713748-36414c51-3494-4eea-8d44-af230fef4db5.png">

### Detailed test instructions

1. Install Pinterest for WooCommerce.
2. Go to `Marketing` -> `Pinterest`, then Click `Get started`.
3. In the first step of the setup page, there is the new description with the merchant guidelines link on it.

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog note
<!-- Changelog notes highlight what's fixed or added in a release. -->

> New: Add the merchant guidelines link in the setup page

[pinterest-merchant-guidelines]: https://policy.pinterest.com/en/merchant-guidelines