### PR TITLE
Show a notice on the landing page if this extension does not support their store country

### DIFF
--- a/assets/source/setup-guide/app/components/UnsupportedCountryNotice/index.js
+++ b/assets/source/setup-guide/app/components/UnsupportedCountryNotice/index.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { Notice, ExternalLink } from '@wordpress/components';
+import { Link } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+// See https://github.com/woocommerce/woocommerce-admin/issues/7781,
+// https://github.com/woocommerce/woocommerce-admin/issues/7810
+// Please note, that this is NOT https://www.npmjs.com/package/@woocommerce/settings,
+// or https://github.com/woocommerce/woocommerce-admin/tree/main/packages/wc-admin-settings
+// but https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/settings/shared/index.ts
+// (at an unknown version).
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Renders an unsupported country <Notice> with warning appearance.
+ *
+ * @param {Object} props React props.
+ * @param {string} props.countryCode The alpha-2 country code to map the country name.
+ */
+export default function UnsupportedCountryNotice( { countryCode } ) {
+	const countryName = getSetting( 'countries', {} )[ countryCode ];
+
+	if ( ! countryName ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="pins-for-woo-unsupported-country-notice"
+			status="warning"
+			isDismissible={ false }
+		>
+			{ createInterpolateElement(
+				__(
+					'Your store’s country is <country />. This country is currently not supported by Pinterest for WooCommerce. However, you can still choose to list your products in supported countries, if you are able to sell your products to customers there. <settingsLink>Change your store’s country here</settingsLink>. <supportedCountriesLink>Read more about supported countries</supportedCountriesLink>',
+					'pinterest-for-woocommerce'
+				),
+				{
+					country: <strong>{ countryName }</strong>,
+					settingsLink: (
+						<Link
+							className="pins-for-woo-unsupported-country-notice__link"
+							type="wp-admin"
+							href="/wp-admin/admin.php?page=wc-settings"
+						/>
+					),
+					supportedCountriesLink: (
+						<ExternalLink
+							className="pins-for-woo-unsupported-country-notice__link"
+							href="https://help.pinterest.com/en/business/availability/ads-availability"
+						/>
+					),
+				}
+			) }
+		</Notice>
+	);
+}

--- a/assets/source/setup-guide/app/components/UnsupportedCountryNotice/style.scss
+++ b/assets/source/setup-guide/app/components/UnsupportedCountryNotice/style.scss
@@ -1,0 +1,19 @@
+@import "~@wordpress/base-styles/variables";
+@import "~@wordpress/base-styles/colors";
+
+.pins-for-woo-unsupported-country-notice {
+	margin: 0 0 $grid-unit-50;
+	color: $black;
+
+	&.is-warning {
+		background-color: #ffeec1;
+	}
+
+	.components-notice__content {
+		margin-left: $grid-unit-20;
+	}
+
+	&__link {
+		color: currentColor;
+	}
+}

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -19,6 +19,7 @@ import {
  * Internal dependencies
  */
 import PrelaunchNotice from '../../../components/prelaunch-notice';
+import UnsupportedCountryNotice from '../components/UnsupportedCountryNotice';
 
 const WelcomeSection = () => {
 	return (
@@ -196,7 +197,11 @@ const FaqQuestion = ( { question, answer } ) => {
 };
 
 const LandingPageApp = () => {
-	const { pluginVersion } = wcSettings.pinterest_for_woocommerce;
+	const {
+		pluginVersion,
+		isAdsSupportedCountry,
+		storeCountry,
+	} = wcSettings.pinterest_for_woocommerce;
 
 	// Only show the pre-launch beta notice if the plugin version is a beta.
 	const prelaunchNotice = pluginVersion.includes( 'beta' ) ? (
@@ -207,6 +212,9 @@ const LandingPageApp = () => {
 		<>
 			{ prelaunchNotice }
 			<div className="pinterest-for-woocommerce-landing-page">
+				{ ! isAdsSupportedCountry && (
+					<UnsupportedCountryNotice countryCode={ storeCountry } />
+				) }
 				<WelcomeSection />
 				<FeaturesSection />
 				<FaqSection />

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -376,6 +376,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		 * @return array
 		 */
 		private function get_component_settings() {
+			$store_country = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
 
 			return array(
 				'pluginVersion'            => PINTEREST_FOR_WOOCOMMERCE_VERSION,
@@ -384,6 +385,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'createBusinessAccountUrl' => $this->get_create_business_account_url(),
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
 				'domainToVerify'           => wp_parse_url( home_url(), PHP_URL_HOST ),
+				'storeCountry'             => $store_country,
+				'isAdsSupportedCountry'    => in_array( $store_country, $this->get_ads_supported_countries(), true ),
 				'isConnected'              => ! empty( Pinterest_For_Woocommerce()::is_connected() ),
 				'isBusinessConnected'      => ! empty( Pinterest_For_Woocommerce()::is_business_connected() ),
 				'businessAccounts'         => Pinterest_For_Woocommerce()::get_linked_businesses(),
@@ -520,6 +523,48 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 			$allowed_hosts[] = wp_parse_url( $service_domain, PHP_URL_HOST );
 
 			return $allowed_hosts;
+		}
+
+
+		/**
+		 * Get the alpha-2 country codes where Pinterest advertises.
+		 *
+		 * @see https://help.pinterest.com/en/business/availability/ads-availability
+		 *
+		 * @return string[]
+		 */
+		private function get_ads_supported_countries() {
+			return array(
+				'AU', // Australia.
+				'AT', // Austria.
+				'BE', // Belgium.
+				'BR', // Brazil.
+				'CA', // Canada.
+				'CY', // Cyprus.
+				'CZ', // Czech Republic.
+				'DK', // Denmark.
+				'FI', // Finland.
+				'FR', // France.
+				'DE', // Germany.
+				'GR', // Greece.
+				'HU', // Hungary.
+				'IE', // Ireland.
+				'IT', // Italy.
+				'LU', // Luxembourg.
+				'MT', // Malta.
+				'NL', // Netherlands.
+				'NZ', // New Zealand.
+				'NO', // Norway.
+				'PL', // Poland.
+				'PT', // Portugal.
+				'RO', // Romania.
+				'SK', // Slovakia.
+				'ES', // Spain.
+				'SE', // Sweden.
+				'CH', // Switzerland.
+				'GB', // United Kingdom (UK).
+				'US', // United States (US).
+			);
 		}
 	}
 


### PR DESCRIPTION
Closes #251 

### Changes proposed in this pull request

- Expose store country and whether it's supported by Pinterest Ads to client-side via inline JavaScript.
- Implement an unsupported country warning with `<Notice>` component and show it on the landing page when store country is not supported.

### Additional notes

:warning: Currently the extension is based on “store location” based on WP Admin > WooCommerce > Settings > General location information.
- [x] 💡 Before merging we'll confirm if the notice content is approved cc @shivanarrthine 

### Screenshots

![image](https://user-images.githubusercontent.com/17420811/141714821-aa9cb19e-0d31-4bf2-80b8-c92f56d36332.png)


### Detailed test instructions

1. Go to the General tab of WC Settings. Change the "**Country / State**" option to one of the unsupported countries.
2. Go to the landing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`
3. It should show an unsupported notice at the page top.
    - Click on the "Change your store’s country here", it should bring you to WC Settings.
    - Click on the "Read more about supported countries", it should open a new tab to Pinterest's help page.

### Changelog entry

> Add - Show a notice on the landing page if this extension does not support their store country.
