### PR TITLE
Handle WC5.9 deprecation 

### DIFF
--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -9,10 +9,10 @@
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Pinterest\Compat;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -251,7 +251,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				return;
 			}
 
-			if ( Onboarding::should_show_tasks() ) {
+			if ( Compat::should_show_tasks() ) {
 
 				$build_path = '/assets/setup-task';
 
@@ -339,7 +339,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 			if (
 				! class_exists( Loader::class ) ||
 				! Loader::is_admin_page() ||
-				! Onboarding::should_show_tasks()
+				! Compat::should_show_tasks()
 			) {
 				return $registered_tasks_list_items;
 			}

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Deprecated methods compatibility layer.
+ *
+ * @package Pinterest/Compat
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+
+/**
+ * Helper class with functions that handle WordPress and WooCommerce deprecations.
+ * Using helper class with static methods to help with autoloading.
+ */
+class Compat {
+	/**
+	 * Helper function to check if UI should show tasks.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public static function should_show_tasks(): bool {
+		if ( version_compare( WC_VERSION, '5.9', '<' ) ) {
+			return Onboarding::should_show_tasks();
+		}
+
+		$setup_list    = TaskLists::get_list( 'setup' );
+		$extended_list = TaskLists::get_list( 'extended' );
+
+		return ( $setup_list && ! $setup_list->is_hidden() ) || ( $extended_list && ! $extended_list->is_hidden() );
+	}
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Closes #259 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->

Fixes WC59 deprecation logs for Onboarding::should_show_tasks().

Deprecation handling is performed through a simple static method of a Compat class. A class method was used instead of a plain file with a function to leverage PSR4 autoloading and namespaces.

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Follow steps in #259 and confirm that the deprecation log is gone.

<!-- Please add details of other areas that might be impacted by the change. -->

### Changelog entry

> Fix - Use Task List API to detect if we should show Pinterest onboarding tasks.
