### PR TITLE
Add Track Events to documentation links.

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -22,12 +22,12 @@ Clicking on "Connect" Pinterest account button.
 ### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L31)
 Clicking on "… convert your personal account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
 
 ### [`wcadmin_pfw_account_create_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L26)
 Clicking on "… create a new Pinterest account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
 
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
 Clicking on "Disconnect" Pinterest account button during account setup.
@@ -54,12 +54,14 @@ Clicking on an external documentation link.
 `href` | `string` | Href to which the user was navigated to.
 #### Emitters
 - [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L57) with `{ link_id: 'claim-website', context: 'claim-website' }`
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52) with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
+	- with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
+	- with `{ link_id: 'merchant-guidelines', context: 'setup-account' }`
 - [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L50)
 	- with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
+	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
-	- with `{ link_id: 'tos', context: 'wizard'|'settings' }`
 - [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L34) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 
 ### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L213)

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -22,12 +22,12 @@ Clicking on "Connect" Pinterest account button.
 ### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L31)
 Clicking on "… convert your personal account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L51)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52)
 
 ### [`wcadmin_pfw_account_create_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L26)
 Clicking on "… create a new Pinterest account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L51)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52)
 
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
 Clicking on "Disconnect" Pinterest account button during account setup.
@@ -44,7 +44,25 @@ Clicking on "Create business account" button.
 #### Emitters
 - [`BusinessAccountSelection`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L40)
 
-### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L193)
+### [`wcadmin_pfw_documentation_link_click`](assets/source/setup-guide/index.js#L122)
+Clicking on an external documentation link.
+#### Properties
+|   |   |   |
+|---|---|---|
+`link_id` | `string` | Identifier of the link.
+`context` | `string` | What action was initiated.
+`href` | `string` | Href to which the user was navigated to.
+#### Emitters
+- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L57) with `{ link_id: 'claim-website', context: 'claim-website' }`
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L52) with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
+- [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L50)
+	- with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
+	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
+	- with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
+	- with `{ link_id: 'tos', context: 'wizard'|'settings' }`
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L34) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+
+### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L213)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 |   |   |   |
@@ -52,7 +70,7 @@ Clicking on getting started page faq item to collapse or expand it.
 `action` | `string` | `'expand' \| 'collapse'` What action was initiated.
 `question_id` | `string` | Identifier of the clicked question.
 #### Emitters
-- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L212) whenever the FAQ is toggled.
+- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L232) whenever the FAQ is toggled.
 
 <!---
 End of `woo-tracking-jsdoc`-generated content.

--- a/assets/source/setup-guide/app/components/StepOverview.js
+++ b/assets/source/setup-guide/app/components/StepOverview.js
@@ -4,7 +4,18 @@
 import { __ } from '@wordpress/i18n';
 import { Button, __experimentalText as Text } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 
-const StepOverview = ( { title, description, link } ) => {
+/**
+ * Step overview.
+ *
+ * Used to provide a description aside of a card in setup step.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.title] Step's title.
+ * @param {string} [props.description] Detailed description.
+ * @param {Object} [props.readMore] Properties of the "Read more" {@link Button}, if it's to be displayed. Leave `undefined` or falsy, to do not render any button.
+ * @return {JSX.Element} Rendered element.
+ */
+const StepOverview = ( { title, description, readMore } ) => {
 	return (
 		<div className="woocommerce-setup-guide__step-overview">
 			{ title && (
@@ -19,9 +30,9 @@ const StepOverview = ( { title, description, link } ) => {
 				</div>
 			) }
 
-			{ link && (
+			{ readMore && (
 				<div className="woocommerce-setup-guide__step-overview__link">
-					<Button isLink href={ link } target="_blank">
+					<Button isLink target="_blank" { ...readMore }>
 						{ __( 'Read more' ) }
 					</Button>
 				</div>

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -42,6 +43,17 @@ const StaticError = ( { reqError } ) => {
 	);
 };
 
+/**
+ * Claim Website step component.
+ *
+ * To be used in onboarding setup stepper.
+ *
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'claim-website', context: 'claim-website' }`
+ * @param {Object} props React props.
+ * @param {Function} props.goToNextStep
+ * @param {string} props.view
+ * @return {JSX.Element} Rendered component.
+ */
 const ClaimWebsite = ( { goToNextStep, view } ) => {
 	const [ status, setStatus ] = useState( 'idle' );
 	const [ reqError, setReqError ] = useState();
@@ -135,10 +147,19 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 						description={ __(
 							'Claim your website to get access to analytics for the Pins you publish from your site, the analytics on Pins that other people create from your site and let people know where they can find more of your content.'
 						) }
-						link={
-							wcSettings.pinterest_for_woocommerce.pinterestLinks
-								.claimWebsite
-						}
+						readMore={ {
+							href:
+								wcSettings.pinterest_for_woocommerce
+									.pinterestLinks.claimWebsite,
+							onClick: () =>
+								recordEvent( 'pfw_documentation_link_click', {
+									link_id: 'claim-website',
+									context: 'claim-website',
+									href:
+										wcSettings.pinterest_for_woocommerce
+											.pinterestLinks.claimWebsite,
+								} ),
+						} }
 					/>
 				</div>
 				<div className="woocommerce-setup-guide__step-column">

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -40,6 +40,7 @@ import { useSettingsSelect, useCreateNotice } from '../helpers/effects';
  * @fires wcadmin_pfw_account_create_button_click
  * @fires wcadmin_pfw_account_convert_button_click
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: 'setup-account' }`
  *
  * @param {Object} props React props
  * @param {Function} props.goToNextStep
@@ -165,6 +166,21 @@ const SetupAccount = ( {
 										}
 										target="_blank"
 										rel="noreferrer"
+										onClick={ () =>
+											recordEvent(
+												'pfw_documentation_link_click',
+												{
+													link_id:
+														'merchant-guidelines',
+													context: 'setup-account',
+													href:
+														wcSettings
+															.pinterest_for_woocommerce
+															.pinterestLinks
+															.merchantGuidelines,
+												}
+											)
+										}
 									/>
 								),
 							}

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -39,6 +39,7 @@ import { useSettingsSelect, useCreateNotice } from '../helpers/effects';
  *
  * @fires wcadmin_pfw_account_create_button_click
  * @fires wcadmin_pfw_account_convert_button_click
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
  *
  * @param {Object} props React props
  * @param {Function} props.goToNextStep
@@ -137,6 +138,20 @@ const SetupAccount = ( {
 										}
 										target="_blank"
 										rel="noreferrer"
+										onClick={ () =>
+											recordEvent(
+												'pfw_documentation_link_click',
+												{
+													link_id: 'ad-guidelines',
+													context: 'setup-account',
+													href:
+														wcSettings
+															.pinterest_for_woocommerce
+															.pinterestLinks
+															.adGuidelines,
+												}
+											)
+										}
 									/>
 								),
 							}

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -11,6 +11,7 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -31,7 +32,22 @@ import {
 	useCreateNotice,
 } from '../helpers/effects';
 
-const SetupTracking = ( { view } ) => {
+/**
+ * Tracking setup component.
+ *
+ * To be used in onboarding stepper.
+ *
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
+ *
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.view='settings'] `'wizard'|'settings'` Kind of view to render.
+ * @return {JSX.Element} rendered component
+ */
+const SetupTracking = ( { view = 'settings' } ) => {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isFetching, setIsFetching ] = useState( false );
 	const [ status, setStatus ] = useState( 'idle' );
@@ -307,6 +323,20 @@ const SetupTracking = ( { view } ) => {
 											.pinterestLinks.adGuidelines
 									}
 									target="_blank"
+									onClick={ () =>
+										recordEvent(
+											'pfw_documentation_link_click',
+											{
+												link_id: 'ad-guidelines',
+												context: view,
+												href:
+													wcSettings
+														.pinterest_for_woocommerce
+														.pinterestLinks
+														.adGuidelines,
+											}
+										)
+									}
 								>
 									{ __(
 										'Ad Guidelines',
@@ -321,6 +351,20 @@ const SetupTracking = ( { view } ) => {
 											.pinterestLinks.adDataTerms
 									}
 									target="_blank"
+									onClick={ () =>
+										recordEvent(
+											'pfw_documentation_link_click',
+											{
+												link_id: 'ad-data-terms',
+												context: view,
+												href:
+													wcSettings
+														.pinterest_for_woocommerce
+														.pinterestLinks
+														.adDataTerms,
+											}
+										)
+									}
 								>
 									{ __(
 										'Ad Data Terms',
@@ -329,10 +373,19 @@ const SetupTracking = ( { view } ) => {
 								</Button>
 							</>
 						}
-						link={
-							wcSettings.pinterest_for_woocommerce.pinterestLinks
-								.SetupTracking
-						}
+						readMore={ {
+							href:
+								wcSettings.pinterest_for_woocommerce
+									.pinterestLinks.SetupTracking,
+							onClick: () =>
+								recordEvent( 'pfw_documentation_link_click', {
+									link_id: 'setup-tracking',
+									context: view,
+									href:
+										wcSettings.pinterest_for_woocommerce
+											.pinterestLinks.SetupTracking,
+								} ),
+						} }
 					/>
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
@@ -450,6 +503,21 @@ const SetupTracking = ( { view } ) => {
 																	.terms_url
 															}
 															target="_blank"
+															onClick={ () =>
+																recordEvent(
+																	'pfw_documentation_link_click',
+																	{
+																		link_id:
+																			'ad-terms-of-service',
+																		context: view,
+																		href:
+																			wcSettings
+																				.pinterest_for_woocommerce
+																				.countryTos
+																				.terms_url,
+																	}
+																)
+															}
 														></Button>
 													),
 												}

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -21,6 +21,16 @@ import {
  */
 import PrelaunchNotice from '../../../components/prelaunch-notice';
 
+const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
+
+/**
+ * Welcome Section Card.
+ * To be used in getting started page.
+ *
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+ *
+ * @return {JSX.Element} Rendered element.
+ */
 const WelcomeSection = () => {
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__welcome-section">
@@ -70,9 +80,19 @@ const WelcomeSection = () => {
 									// Disabling no-content rule - content is interpolated from above string.
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
-										href="https://business.pinterest.com/business-terms-of-service/"
+										href={ tosHref }
 										target="_blank"
 										rel="noreferrer"
+										onClick={ () =>
+											recordEvent(
+												'pfw_documentation_link_click',
+												{
+													link_id: 'terms-of-service',
+													context: 'welcome-section',
+													href: tosHref,
+												}
+											)
+										}
 									/>
 								),
 							}

--- a/assets/source/setup-guide/index.js
+++ b/assets/source/setup-guide/index.js
@@ -116,3 +116,15 @@ addFilter(
 		return pages;
 	}
 );
+
+// List of typedefs and events used across the plugin.
+
+/**
+ * Clicking on an external documentation link.
+ *
+ * @event wcadmin_pfw_documentation_link_click
+ *
+ * @property {string} link_id Identifier of the link.
+ * @property {string} context What action was initiated.
+ * @property {string} href Href to which the user was navigated to.
+ */


### PR DESCRIPTION
:warning:  This PR is based on https://github.com/woocommerce/pinterest-for-woocommerce/pull/254, for better documentation 
<!-- You can erase any parts of this template not applicable to your pull request. -->

<!-- Reference issue(s) that this PR fixes or addresses -->
Implements part of #232 

### Changes proposed in this pull request
<!-- Explain what this PR adds or changes, why, and how this will impact users. -->
Add Track Events to documentation links.

Change `StepOverview` to accept more props for read more `Button` link.

#### Screenshots
<!--- Optional --->

### Detailed test instructions
<!-- Add steps to confirm the fix or change. -->
1. Enable tracks logging, by `localStorage.setItem('debug', 'wc-admin*')`
2. Check the `wcadmin_pfw_documentation_link_click` events fired for the following links:
	- at [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding)
		-  "Terms of Service." - `{ link_id: 'terms-of-service', context: 'welcome-section' }`
	- at [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding)
		- "Pinterest advertising guidelines." - `{ link_id: 'ad-guidelines', context: 'setup-account' }`
		![image](https://user-images.githubusercontent.com/17435/141852692-c06974ec-596e-4ee2-9036-86d6d40e3202.png)



	- at [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=claim-website`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=claim-website)
		- "Read more" - `{ link_id: 'claim-website', context: 'claim-website' }` 
		![image](https://user-images.githubusercontent.com/17435/141852627-3e03cbc6-6720-4cc9-bd95-50903fca61c9.png)
	- at [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-tracking`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-tracking)
		-  "Ad Guidelines" - `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
		-  "Ad Data Terms" - `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
		-  "Read more" - `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
		- "Pinterest Advertising Agreement" - `{ link_id: 'tos', context: 'wizard'|'settings' }`
	![image](https://user-images.githubusercontent.com/17435/141852368-bd797107-39cf-49ba-9b97-87eb4bfeaba3.png)



<!-- Please add details of other areas that might be impacted by the change. -->

(no changelog, as we will add a single entry for a feature branch)

### Changelog note
