### PR TITLE
Add documentation link props ~hook~ helper.

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -19,15 +19,15 @@ Clicking on "Connect" Pinterest account button.
 #### Emitters
 - [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L60)
 
-### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L31)
+### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L32)
 Clicking on "… convert your personal account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 
-### [`wcadmin_pfw_account_create_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L26)
+### [`wcadmin_pfw_account_create_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L27)
 Clicking on "… create a new Pinterest account" button.
 #### Emitters
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
 Clicking on "Disconnect" Pinterest account button during account setup.
@@ -44,7 +44,7 @@ Clicking on "Create business account" button.
 #### Emitters
 - [`BusinessAccountSelection`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L40)
 
-### [`wcadmin_pfw_documentation_link_click`](assets/source/setup-guide/index.js#L122)
+### [`wcadmin_pfw_documentation_link_click`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L6)
 Clicking on an external documentation link.
 #### Properties
 |   |   |   |
@@ -53,8 +53,9 @@ Clicking on an external documentation link.
 `context` | `string` | What action was initiated.
 `href` | `string` | Href to which the user was navigated to.
 #### Emitters
+- [`documentationLinkProps`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L37) on click, with given `linkId` and `context`.
 - [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L57) with `{ link_id: 'claim-website', context: 'claim-website' }`
-- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L53)
+- [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 	- with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
 	- with `{ link_id: 'merchant-guidelines', context: 'setup-account' }`
 - [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L50)
@@ -62,9 +63,9 @@ Clicking on an external documentation link.
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
-- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L34) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L35) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 
-### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L213)
+### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L207)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 |   |   |   |
@@ -72,7 +73,7 @@ Clicking on getting started page faq item to collapse or expand it.
 `action` | `string` | `'expand' \| 'collapse'` What action was initiated.
 `question_id` | `string` | Identifier of the clicked question.
 #### Emitters
-- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L232) whenever the FAQ is toggled.
+- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L226) whenever the FAQ is toggled.
 
 <!---
 End of `woo-tracking-jsdoc`-generated content.

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -17,7 +17,9 @@ import { recordEvent } from '@woocommerce/tracks';
  * Creates properties for an external documentation link.
  * May take any other props to be extended and forwarded to a link element (`<a>`, `<Button isLink>`).
  *
- * Sets `target="_blank" rel="noopener"` and onClick handler that fires track event.
+ * Sets `target="_blank" rel="noopener"` and `onClick` handler that fires track event.
+ *
+ * Please be careful not to overwrite the `onClick` handler coincidently.
  *
  * @fires wcadmin_pfw_documentation_link_click on click, with given `linkId` and `context`.
  *
@@ -27,8 +29,10 @@ import { recordEvent } from '@woocommerce/tracks';
  * @param {string} props.context Forwarded to {@link wcadmin_pfw_documentation_link_click}
  * @param {string} [props.target='_blank']
  * @param {string} [props.rel='noopener']
- * @param {Function} [props.onClick]
+ * @param {Function} [props.onClick] onClick event handler to be decorated with firing Track event.
  * @param {...import('react').AnchorHTMLAttributes} props.props
+ *
+ * @return {{herf: string, target: string, rel: string, onClick: Function, props}} Documentation link props.
  */
 export default function documentationLinkProps( {
 	href,

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -34,7 +34,7 @@ import { recordEvent } from '@woocommerce/tracks';
  *
  * @return {{herf: string, target: string, rel: string, onClick: Function, props}} Documentation link props.
  */
-export default function documentationLinkProps( {
+function documentationLinkProps( {
 	href,
 	linkId,
 	context,
@@ -62,3 +62,4 @@ export default function documentationLinkProps( {
 		},
 	};
 }
+export default documentationLinkProps;

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -27,7 +27,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * @param {string} props.context Forwarded to {@link wcadmin_pfw_documentation_link_click}
  * @param {string} [props.target='_blank']
  * @param {string} [props.rel='noreferrer']
- * @param {Function} props.onClick
+ * @param {Function} [props.onClick]
  * @param {...import('react').AnchorHTMLAttributes} props.props
  */
 export default function documentationLinkProps( {

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -19,7 +19,7 @@ import { recordEvent } from '@woocommerce/tracks';
  *
  * Sets `target="_blank" rel="noreferrer"` and onClick handler that fires track event.
  *
- * @fires pfw_documentation_link_click on click, with given `linkId` and `context`.
+ * @fires wcadmin_pfw_documentation_link_click on click, with given `linkId` and `context`.
  *
  * @param {Object} props React props.
  * @param {string} props.href Href to used by link and in track event.

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Clicking on an external documentation link.
+ *
+ * @event wcadmin_pfw_documentation_link_click
+ *
+ * @property {string} link_id Identifier of the link.
+ * @property {string} context What action was initiated.
+ * @property {string} href Href to which the user was navigated to.
+ */
+
+/**
+ * Creates properties for an external documentation link.
+ * May take any other props to be extended and forwarded to a link element (`<a>`, `<Button isLink>`).
+ *
+ * Sets `target="_blank" rel="noreferrer"` and onClick handler that fires track event.
+ *
+ * @fires pfw_documentation_link_click on click, with given `linkId` and `context`.
+ *
+ * @param {Object} props React props.
+ * @param {string} props.href Href to used by link and in track event.
+ * @param {string} props.linkId Forwarded to {@link wcadmin_pfw_documentation_link_click}
+ * @param {string} props.context Forwarded to {@link wcadmin_pfw_documentation_link_click}
+ * @param {string} [props.target='_blank']
+ * @param {string} [props.rel='noreferrer']
+ * @param {Function} props.onClick
+ * @param {...import('react').AnchorHTMLAttributes} props.props
+ */
+export default function documentationLinkProps( {
+	href,
+	linkId,
+	context,
+	target = '_blank',
+	rel = 'noreferrer',
+	onClick,
+	...props
+} ) {
+	return {
+		href,
+		target,
+		rel,
+		...props,
+		onClick: ( event ) => {
+			if ( onClick ) {
+				onClick( event );
+			}
+			if ( ! event.defaultPrevented ) {
+				recordEvent( 'pfw_documentation_link_click', {
+					link_id: linkId,
+					context,
+					href,
+				} );
+			}
+		},
+	};
+}

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -17,7 +17,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Creates properties for an external documentation link.
  * May take any other props to be extended and forwarded to a link element (`<a>`, `<Button isLink>`).
  *
- * Sets `target="_blank" rel="noreferrer"` and onClick handler that fires track event.
+ * Sets `target="_blank" rel="noopener"` and onClick handler that fires track event.
  *
  * @fires wcadmin_pfw_documentation_link_click on click, with given `linkId` and `context`.
  *
@@ -26,7 +26,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * @param {string} props.linkId Forwarded to {@link wcadmin_pfw_documentation_link_click}
  * @param {string} props.context Forwarded to {@link wcadmin_pfw_documentation_link_click}
  * @param {string} [props.target='_blank']
- * @param {string} [props.rel='noreferrer']
+ * @param {string} [props.rel='noopener']
  * @param {Function} [props.onClick]
  * @param {...import('react').AnchorHTMLAttributes} props.props
  */
@@ -35,7 +35,7 @@ export default function documentationLinkProps( {
 	linkId,
 	context,
 	target = '_blank',
-	rel = 'noreferrer',
+	rel = 'noopener',
 	onClick,
 	...props
 } ) {

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
-import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -24,6 +23,7 @@ import {
 	useSettingsDispatch,
 	useCreateNotice,
 } from '../helpers/effects';
+import documentationLinkProps from '../helpers/documentation-link-props';
 
 const StaticError = ( { reqError } ) => {
 	if ( reqError?.data?.pinterest_code === undefined ) {
@@ -147,19 +147,14 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 						description={ __(
 							'Claim your website to get access to analytics for the Pins you publish from your site, the analytics on Pins that other people create from your site and let people know where they can find more of your content.'
 						) }
-						readMore={ {
+						readMore={ documentationLinkProps( {
 							href:
 								wcSettings.pinterest_for_woocommerce
 									.pinterestLinks.claimWebsite,
-							onClick: () =>
-								recordEvent( 'pfw_documentation_link_click', {
-									link_id: 'claim-website',
-									context: 'claim-website',
-									href:
-										wcSettings.pinterest_for_woocommerce
-											.pinterestLinks.claimWebsite,
-								} ),
-						} }
+							linkId: 'claim-website',
+							context: 'claim-website',
+							rel: false,
+						} ) }
 					/>
 				</div>
 				<div className="woocommerce-setup-guide__step-column">

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -153,7 +153,6 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 									.pinterestLinks.claimWebsite,
 							linkId: 'claim-website',
 							context: 'claim-website',
-							rel: 'noopener',
 						} ) }
 					/>
 				</div>

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -153,7 +153,7 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 									.pinterestLinks.claimWebsite,
 							linkId: 'claim-website',
 							context: 'claim-website',
-							rel: false,
+							rel: 'noopener',
 						} ) }
 					/>
 				</div>

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -142,6 +142,7 @@ const SetupAccount = ( {
 													.adGuidelines,
 											linkId: 'ad-guidelines',
 											context: 'setup-account',
+											rel: 'noreferrer',
 										} ) }
 									/>
 								),
@@ -157,6 +158,7 @@ const SetupAccount = ( {
 													.merchantGuidelines,
 											linkId: 'merchant-guidelines',
 											context: 'setup-account',
+											rel: 'noreferrer',
 										} ) }
 									/>
 								),

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -22,6 +22,7 @@ import StepOverview from '../components/StepOverview';
 import AccountConnection from '../components/Account/Connection';
 import BusinessAccountSelection from '../components/Account/BusinessAccountSelection';
 import { useSettingsSelect, useCreateNotice } from '../helpers/effects';
+import documentationLinkProps from '../helpers/documentation-link-props';
 
 /**
  * Clicking on "… create a new Pinterest account" button.
@@ -133,54 +134,30 @@ const SetupAccount = ( {
 									// Disabling no-content rule - content is interpolated from above string.
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
-										href={
-											wcSettings.pinterest_for_woocommerce
-												.pinterestLinks.adGuidelines
-										}
-										target="_blank"
-										rel="noreferrer"
-										onClick={ () =>
-											recordEvent(
-												'pfw_documentation_link_click',
-												{
-													link_id: 'ad-guidelines',
-													context: 'setup-account',
-													href:
-														wcSettings
-															.pinterest_for_woocommerce
-															.pinterestLinks
-															.adGuidelines,
-												}
-											)
-										}
+										{ ...documentationLinkProps( {
+											href:
+												wcSettings
+													.pinterest_for_woocommerce
+													.pinterestLinks
+													.adGuidelines,
+											linkId: 'ad-guidelines',
+											context: 'setup-account',
+										} ) }
 									/>
 								),
 								merchantGuidelinesLink: (
 									// Disabling no-content rule - content is interpolated from above string.
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
-										href={
-											wcSettings.pinterest_for_woocommerce
-												.pinterestLinks
-												.merchantGuidelines
-										}
-										target="_blank"
-										rel="noreferrer"
-										onClick={ () =>
-											recordEvent(
-												'pfw_documentation_link_click',
-												{
-													link_id:
-														'merchant-guidelines',
-													context: 'setup-account',
-													href:
-														wcSettings
-															.pinterest_for_woocommerce
-															.pinterestLinks
-															.merchantGuidelines,
-												}
-											)
-										}
+										{ ...documentationLinkProps( {
+											href:
+												wcSettings
+													.pinterest_for_woocommerce
+													.pinterestLinks
+													.merchantGuidelines,
+											linkId: 'merchant-guidelines',
+											context: 'setup-account',
+										} ) }
 									/>
 								),
 							}

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -324,7 +324,7 @@ const SetupTracking = ( { view = 'settings' } ) => {
 												.pinterestLinks.adGuidelines,
 										linkId: 'ad-guidelines',
 										context: view,
-										rel: false,
+										rel: 'noopener',
 									} ) }
 								>
 									{ __(
@@ -341,7 +341,7 @@ const SetupTracking = ( { view = 'settings' } ) => {
 												.pinterestLinks.adDataTerms,
 										linkId: 'ad-data-terms',
 										context: view,
-										rel: false,
+										rel: 'noopener',
 									} ) }
 								>
 									{ __(
@@ -357,7 +357,7 @@ const SetupTracking = ( { view = 'settings' } ) => {
 									.pinterestLinks.SetupTracking,
 							linkId: 'setup-tracking',
 							context: view,
-							rel: false,
+							rel: 'noopener',
 						} ) }
 					/>
 				</div>
@@ -479,7 +479,8 @@ const SetupTracking = ( { view = 'settings' } ) => {
 																	linkId:
 																		'ad-terms-of-service',
 																	context: view,
-																	rel: false,
+																	rel:
+																		'noopener',
 																}
 															) }
 														></Button>

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -324,7 +324,6 @@ const SetupTracking = ( { view = 'settings' } ) => {
 												.pinterestLinks.adGuidelines,
 										linkId: 'ad-guidelines',
 										context: view,
-										rel: 'noopener',
 									} ) }
 								>
 									{ __(
@@ -341,7 +340,6 @@ const SetupTracking = ( { view = 'settings' } ) => {
 												.pinterestLinks.adDataTerms,
 										linkId: 'ad-data-terms',
 										context: view,
-										rel: 'noopener',
 									} ) }
 								>
 									{ __(
@@ -357,7 +355,6 @@ const SetupTracking = ( { view = 'settings' } ) => {
 									.pinterestLinks.SetupTracking,
 							linkId: 'setup-tracking',
 							context: view,
-							rel: 'noopener',
 						} ) }
 					/>
 				</div>
@@ -479,8 +476,6 @@ const SetupTracking = ( { view = 'settings' } ) => {
 																	linkId:
 																		'ad-terms-of-service',
 																	context: view,
-																	rel:
-																		'noopener',
 																}
 															) }
 														></Button>

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -11,7 +11,6 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
-import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -31,6 +30,7 @@ import {
 	useSettingsDispatch,
 	useCreateNotice,
 } from '../helpers/effects';
+import documentationLinkProps from '../helpers/documentation-link-props';
 
 /**
  * Tracking setup component.
@@ -318,25 +318,14 @@ const SetupTracking = ( { view = 'settings' } ) => {
 								) }{ ' ' }
 								<Button
 									isLink
-									href={
-										wcSettings.pinterest_for_woocommerce
-											.pinterestLinks.adGuidelines
-									}
-									target="_blank"
-									onClick={ () =>
-										recordEvent(
-											'pfw_documentation_link_click',
-											{
-												link_id: 'ad-guidelines',
-												context: view,
-												href:
-													wcSettings
-														.pinterest_for_woocommerce
-														.pinterestLinks
-														.adGuidelines,
-											}
-										)
-									}
+									{ ...documentationLinkProps( {
+										href:
+											wcSettings.pinterest_for_woocommerce
+												.pinterestLinks.adGuidelines,
+										linkId: 'ad-guidelines',
+										context: view,
+										rel: false,
+									} ) }
 								>
 									{ __(
 										'Ad Guidelines',
@@ -346,25 +335,14 @@ const SetupTracking = ( { view = 'settings' } ) => {
 								{ __( 'and', 'pinterest-for-woocommerce' ) }{ ' ' }
 								<Button
 									isLink
-									href={
-										wcSettings.pinterest_for_woocommerce
-											.pinterestLinks.adDataTerms
-									}
-									target="_blank"
-									onClick={ () =>
-										recordEvent(
-											'pfw_documentation_link_click',
-											{
-												link_id: 'ad-data-terms',
-												context: view,
-												href:
-													wcSettings
-														.pinterest_for_woocommerce
-														.pinterestLinks
-														.adDataTerms,
-											}
-										)
-									}
+									{ ...documentationLinkProps( {
+										href:
+											wcSettings.pinterest_for_woocommerce
+												.pinterestLinks.adDataTerms,
+										linkId: 'ad-data-terms',
+										context: view,
+										rel: false,
+									} ) }
 								>
 									{ __(
 										'Ad Data Terms',
@@ -373,19 +351,14 @@ const SetupTracking = ( { view = 'settings' } ) => {
 								</Button>
 							</>
 						}
-						readMore={ {
+						readMore={ documentationLinkProps( {
 							href:
 								wcSettings.pinterest_for_woocommerce
 									.pinterestLinks.SetupTracking,
-							onClick: () =>
-								recordEvent( 'pfw_documentation_link_click', {
-									link_id: 'setup-tracking',
-									context: view,
-									href:
-										wcSettings.pinterest_for_woocommerce
-											.pinterestLinks.SetupTracking,
-								} ),
-						} }
+							linkId: 'setup-tracking',
+							context: view,
+							rel: false,
+						} ) }
 					/>
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
@@ -496,28 +469,19 @@ const SetupTracking = ( { view = 'settings' } ) => {
 													link: (
 														<Button
 															isLink
-															href={
-																wcSettings
-																	.pinterest_for_woocommerce
-																	.countryTos
-																	.terms_url
-															}
-															target="_blank"
-															onClick={ () =>
-																recordEvent(
-																	'pfw_documentation_link_click',
-																	{
-																		link_id:
-																			'ad-terms-of-service',
-																		context: view,
-																		href:
-																			wcSettings
-																				.pinterest_for_woocommerce
-																				.countryTos
-																				.terms_url,
-																	}
-																)
-															}
+															{ ...documentationLinkProps(
+																{
+																	href:
+																		wcSettings
+																			.pinterest_for_woocommerce
+																			.countryTos
+																			.terms_url,
+																	linkId:
+																		'ad-terms-of-service',
+																	context: view,
+																	rel: false,
+																}
+															) }
 														></Button>
 													),
 												}

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -20,6 +20,7 @@ import {
  * Internal dependencies
  */
 import PrelaunchNotice from '../../../components/prelaunch-notice';
+import documentationLinkProps from '../helpers/documentation-link-props';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
 
@@ -80,19 +81,11 @@ const WelcomeSection = () => {
 									// Disabling no-content rule - content is interpolated from above string.
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
-										href={ tosHref }
-										target="_blank"
-										rel="noreferrer"
-										onClick={ () =>
-											recordEvent(
-												'pfw_documentation_link_click',
-												{
-													link_id: 'terms-of-service',
-													context: 'welcome-section',
-													href: tosHref,
-												}
-											)
-										}
+										{ ...documentationLinkProps( {
+											href: tosHref,
+											linkId: 'terms-of-service',
+											context: 'welcome-section',
+										} ) }
 									/>
 								),
 							}

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -85,6 +85,7 @@ const WelcomeSection = () => {
 											href: tosHref,
 											linkId: 'terms-of-service',
 											context: 'welcome-section',
+											rel: 'noreferrer',
 										} ) }
 									/>
 								),

--- a/assets/source/setup-guide/index.js
+++ b/assets/source/setup-guide/index.js
@@ -116,15 +116,3 @@ addFilter(
 		return pages;
 	}
 );
-
-// List of typedefs and events used across the plugin.
-
-/**
- * Clicking on an external documentation link.
- *
- * @event wcadmin_pfw_documentation_link_click
- *
- * @property {string} link_id Identifier of the link.
- * @property {string} context What action was initiated.
- * @property {string} href Href to which the user was navigated to.
- */


### PR DESCRIPTION
This PR aims to improve https://github.com/woocommerce/pinterest-for-woocommerce/pull/261

### Changes proposed in this Pull Request:

- Separate Documentation Link props creation to a helper. 
	Make the code more DRY, and assert consistency for all links.
- Set `rel:'noopener'` for external link Buttons. 
	To secure them in IE.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->



_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

Double-check that, the changes introduced in https://github.com/woocommerce/pinterest-for-woocommerce/pull/261 works as before.

### Additional notes:
1. This PR exercises Component hooks described in p7H4VZ-2IH-p2. However, I created a helper, not a hook, as I don't really get why it would need to be a hook. I'd appreciate a comment from somebody more experienced in React.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->

(no changelog, as we will add a single entry for a feature branch)
### Changelog entry