### PR TITLE
Adjust image size for additional images

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -615,6 +615,20 @@ class ProductSync {
 			return array();
 		}
 
+		// Do not sync products with hidden visibility
+		$visible_product_ids = array();
+		foreach ( $product_ids as $index => $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( 'hidden' !== $product->get_catalog_visibility() ) {
+				$visible_product_ids[] = $product_id;
+			}
+		}
+		$product_ids = $visible_product_ids;
+
+		if ( empty( $product_ids ) ) {
+			return array();
+		}
+
 		$products_count = count( $product_ids );
 
 		// Get Variations of the current product and inject them into our array.

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -602,14 +602,19 @@ class ProductSync {
 			)
 		);
 
-		$product_ids = wc_get_products(
-			array(
-				'limit'  => -1,
-				'return' => 'ids',
-				'status' => 'publish',
-				'type'   => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
-			)
+		$products_query_args = array(
+			'limit'        => -1,
+			'return'       => 'ids',
+			'status'       => 'publish',
+			'type'         => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
 		);
+
+		// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items') ) {
+			$products_query_args['stock_status'] = 'instock';
+		}
+
+		$product_ids = wc_get_products( $products_query_args );
 
 		if ( empty( $product_ids ) ) {
 			return array();

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'woocommerce_single' )[0];
 			}
 		}
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #248 .

Changes from the default image size (thumbnail) to woocommerce_single to match output for additional images to the [main image](https://github.com/woocommerce/pinterest-for-woocommerce/blob/c4054c80aa782240f44bbf0c6032be9e0e5378ba/src/ProductsXmlFeed.php#L201).


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Wait for the feed to be regenerated.
2. Verify that feed contains images on the `<additional_image_link>` tag, whose size is based on the woocommerce_single image size


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Image size for additional (gallery) images.
