### PR TITLE
Bugfix/xml additional images size

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'woocommerce_single' )[0];
 			}
 		}
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #248 .

Changes from the default image size (thumbnail) to woocommerce_single to match output for additional images to the [main image](https://github.com/woocommerce/pinterest-for-woocommerce/blob/c4054c80aa782240f44bbf0c6032be9e0e5378ba/src/ProductsXmlFeed.php#L201).


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Wait for the feed to be regenerated.
2. Verify that feed contains images on the `<additional_image_link>` tag, whose size is based on the woocommerce_single image size


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Image size for additional (gallery) images.
