### PR TITLE
Fix error message for merchants with declined status

### DIFF
--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -226,7 +226,7 @@ const HealthCheck = () => {
 
 	const notice = notices[ healthStatus.status ] || notices.error;
 
-	if ( notice.status === 'error' ) {
+	if ( notice.status === 'error' && ! notice.message ) {
 		notice.message =
 			healthStatus.message ||
 			__(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #230

Fixes the expected error message for merchants with declined status:
From: "Could not fetch account status" to "Your merchant account is disapproved."


### Screenshots:

<!--- Optional --->
![image](https://user-images.githubusercontent.com/40774170/142287547-c6df0224-0ca9-4f66-9ce8-5674425e0077.png)

### Detailed test instructions:

1. Start onboarding and connect to a new account.
2. Wait till it gets the "Declined" status from Pinterest
2. Verify the correct error message is shown in the plugin's settings.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Wrong error message on declined Pinterest account.

