### PR TITLE
Add Pinterest ads manager CTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ assets/source/_maps
 
 # build products
 pinterest-for-woocommerce.zip
-
-# vim
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ assets/source/_maps
 
 # build products
 pinterest-for-woocommerce.zip
+
+# vim
+*.swp

--- a/assets/source/catalog-sync/sections/SyncState.js
+++ b/assets/source/catalog-sync/sections/SyncState.js
@@ -45,7 +45,6 @@ const SyncState = () => {
 						{
 							adsManagerLink: (
 								<ExternalLink
-									className="link"
 									href={
 										wcSettings.pinterest_for_woocommerce
 											.pinterestLinks.adsManager

--- a/assets/source/catalog-sync/sections/SyncState.js
+++ b/assets/source/catalog-sync/sections/SyncState.js
@@ -3,9 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { Icon, trendingUp as trendingUpIcon } from '@wordpress/icons';
 import {
 	Card,
 	CardHeader,
+	CardFooter,
+	ExternalLink,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 
@@ -30,6 +34,28 @@ const SyncState = () => {
 			</CardHeader>
 			<SyncStateSummary overview={ feedState?.overview } />
 			<SyncStateTable workflow={ feedState?.workflow } />
+			<CardFooter justify="flex-start">
+				<Icon icon={ trendingUpIcon } />
+				<Text>
+					{ createInterpolateElement(
+						__(
+							'Set up and manage ads to increase your reach with <adsManagerLink>Pinterest ads manager</adsManagerLink>',
+							'pinterest-for-woocommerce'
+						),
+						{
+							adsManagerLink: (
+								<ExternalLink
+									className="link"
+									href={
+										wcSettings.pinterest_for_woocommerce
+											.pinterestLinks.adsManager
+									}
+								/>
+							),
+						}
+					) }
+				</Text>
+			</CardFooter>
 		</Card>
 	);
 };

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -593,7 +593,7 @@ $root: ".woocommerce-setup-guide";
 		.components-card__footer {
 			flex-direction: row;
 
-			.link {
+			.components-external-link {
 				text-decoration: none;
 
 				&:hover {

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -590,6 +590,18 @@ $root: ".woocommerce-setup-guide";
 			display: none;
 		}
 
+		.components-card__footer {
+			flex-direction: row;
+
+			.link {
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+
 		th:first-child {
 			width: 1%;
 			min-width: 175px;

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -403,6 +403,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'merchantGuidelines'     => 'https://policy.pinterest.com/en/merchant-guidelines',
 					'convertToBusinessAcct'  => 'https://help.pinterest.com/en/business/article/get-a-business-account#section-15096',
 					'appealDeclinedMerchant' => 'https://www.pinterest.com/product-catalogs/data-source/?showModal=true',
+					'adsManager'             => 'https://ads.pinterest.com/',
 				),
 				'isSetupComplete'          => Pinterest_For_Woocommerce()::is_setup_complete(),
 				'countryTos'               => Pinterest_For_Woocommerce()::get_applicable_tos(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -3254,6 +3254,16 @@
                 }
               }
             },
+            "@wordpress/icons": {
+              "version": "2.10.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+              "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/element": "^2.20.3",
+                "@wordpress/primitives": "^1.12.3"
+              }
+            },
             "@wordpress/keycodes": {
               "version": "2.19.3",
               "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.19.3.tgz",
@@ -3660,6 +3670,18 @@
             "rememo": "^3.0.0",
             "tinycolor2": "^1.4.1",
             "uuid": "^7.0.2"
+          },
+          "dependencies": {
+            "@wordpress/icons": {
+              "version": "2.10.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+              "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/element": "^2.20.3",
+                "@wordpress/primitives": "^1.12.3"
+              }
+            }
           }
         },
         "@wordpress/date": {
@@ -3954,6 +3976,16 @@
           "requires": {
             "@babel/runtime": "^7.13.10",
             "lodash": "^4.17.19"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+          "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^2.20.3",
+            "@wordpress/primitives": "^1.12.3"
           }
         },
         "@wordpress/is-shallow-equal": {
@@ -4407,13 +4439,105 @@
       }
     },
     "@wordpress/icons": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
-      "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.2.tgz",
+      "integrity": "sha512-ckogzI/j9c+gqTA9T2zCtUiA7gjZHVWvC6USMCBHzPIVK7njQ9MD5R55vSEueA/qjhhcbcTZgz0yWrXnuE9PZw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/element": "^2.20.3",
-        "@wordpress/primitives": "^1.12.3"
+        "@wordpress/element": "^4.0.1",
+        "@wordpress/primitives": "^3.0.1"
+      },
+      "dependencies": {
+        "@wordpress/element": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.4.tgz",
+          "integrity": "sha512-GbYVSZrHitOmupQCjb7cSlewVigXHorpZUBpvWnkU3rhyh1tF/N9qve3fgg7Q3s2szjtTP+eEutB+4mmkwHQOA==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^2.2.3",
+            "lodash": "^4.17.21",
+            "react": "^17.0.1",
+            "react-dom": "^17.0.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.16.3",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+              "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.2.3.tgz",
+          "integrity": "sha512-nYIwT8WzHfAzjjwHLiwDQWrzn4/gUNr5zud465XQszM2cAItN2wnC26/ovSpPomDGkvjcG0YltgnSqc1T62olA==",
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.16.3",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+              "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "@wordpress/primitives": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.4.tgz",
+          "integrity": "sha512-yu3BEpr09vpPM0QOYGm5Kmwo/tfo7u7Ez4hN5+AL2dT53VNr3QOmDo0Ym7sewI7+GgU18H4VkAi1QOydrc4vDw==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/element": "^4.0.4",
+            "classnames": "^2.3.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.16.3",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+              "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "@wordpress/is-shallow-equal": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@wordpress/hooks": "^2.12.0",
     "@wordpress/html-entities": "^2.7.0",
     "@wordpress/i18n": "^3.11.0",
-    "@wordpress/icons": "^2.10.3",
+    "@wordpress/icons": ">=5.0.0 <6.0.0",
     "@wordpress/notices": "^2.12.7",
     "@wordpress/url": "^3.1.1",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #252.

This PR adds a Pinterest ads manager CTA under catalog overview as described in #252.

### Screenshots:

#### When there are warnings

<img width="1278" alt="Screenshot 2021-11-23 at 17 54 57" src="https://user-images.githubusercontent.com/914406/143003725-a3819b37-1896-48ab-af4b-7c3ff1e9f49e.png">

#### When there are no warnings

<img width="1280" alt="Screenshot 2021-11-23 at 17 48 49" src="https://user-images.githubusercontent.com/914406/143003763-ea111381-105a-4f55-b381-c7f602f2d41b.png">

### Detailed test instructions:

1. Install Pinterest for WooCommerce and go through the onboarding wizard.
2. Go to `Marketing` -> `Pinterest`, then Click `Catalog`.
3. At the bottom of the `Overview` table, there is a Pinterest ads manager CTA

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Pinterest ads manager CTA
