### PR TITLE
Specify `lts/fermium` in `.nvmrc` to use Node.js version 14 and not 16

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/fermium


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes `.nvmrc` from `lts/*` to `lts/fermium`. [Fermium](https://nodejs.org/en/about/releases/) refers to Node.js version 14. 

Currently our code does not work with Node.js version 16. By having this change, it should help prevent accidentally using Node.js version 16.

This PR is similar to https://github.com/woocommerce/google-listings-and-ads/pull/1090.

### Detailed test instructions:

1. Checkout this branch. 
2. Run `nvm use` in your command line. It should be using Node.js 14.18.1.
3. Run `npm ci` or `npm install`. It should complete successfully.
4. Run `npm start`. It should start successfully.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
