### PR TITLE
Add missing link in Setup Tracking section

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -40,7 +40,7 @@ import documentationLinkProps from '../helpers/documentation-link-props';
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
  *
  *
  * @param {Object} props React props.
@@ -352,8 +352,8 @@ const SetupTracking = ( { view = 'settings' } ) => {
 						readMore={ documentationLinkProps( {
 							href:
 								wcSettings.pinterest_for_woocommerce
-									.pinterestLinks.SetupTracking,
-							linkId: 'setup-tracking',
+									.pinterestLinks.installTag,
+							linkId: 'install-tag',
 							context: view,
 						} ) }
 					/>

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -401,6 +401,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'merchantGuidelines'     => 'https://policy.pinterest.com/en/merchant-guidelines',
 					'convertToBusinessAcct'  => 'https://help.pinterest.com/en/business/article/get-a-business-account#section-15096',
 					'appealDeclinedMerchant' => 'https://www.pinterest.com/product-catalogs/data-source/?showModal=true',
+					'installTag'             => 'https://help.pinterest.com/en/business/article/install-the-pinterest-tag',
 				),
 				'isSetupComplete'          => Pinterest_For_Woocommerce()::is_setup_complete(),
 				'countryTos'               => Pinterest_For_Woocommerce()::get_applicable_tos(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #262 

* Added a [new link reference](https://help.pinterest.com/en/business/article/install-the-pinterest-tag) in `includes/admin/class-pinterest-for-woocommerce-admin.php` based on the issue indications. 
* Change the name from `setupTracking` to `installTags` following issue indications.  

### Detailed test instructions:

1. Go to Onboarding - Setup tracking  `admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-tracking`
2. Click on the Read More link
3. You should see Install Pinterest tag docs in a new tab.