### PR TITLE
Add unit tests for ads manager CTA in catalog overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 config.codekit
 node_modules
 .vscode
+coverage
 
 # Ignore assets except source files
 assets/*    

--- a/assets/source/catalog-sync/sections/SyncState.test.js
+++ b/assets/source/catalog-sync/sections/SyncState.test.js
@@ -11,14 +11,9 @@ import SyncState from './SyncState';
 
 describe( 'SyncState component', () => {
 	test( 'should render header and footer correctly', () => {
-		const { getByText, getByRole } = render( <SyncState /> );
+		const { getByRole } = render( <SyncState /> );
 
 		expect( getByRole( 'heading' ) ).toHaveTextContent( 'Overview' );
-
-		expect(
-			getByText( 'Set up and manage ads to increase your reach with' )
-		).toBeTruthy();
-
 		expect( getByRole( 'link' ) ).toHaveTextContent(
 			'Pinterest ads manager'
 		);

--- a/assets/source/catalog-sync/sections/SyncState.test.js
+++ b/assets/source/catalog-sync/sections/SyncState.test.js
@@ -15,7 +15,7 @@ describe( 'SyncState component', () => {
 
 		expect( getByRole( 'heading' ) ).toHaveTextContent( 'Overview' );
 		expect( getByRole( 'link' ) ).toHaveTextContent(
-			'Pinterest ads manager'
+			'Pinterest ads manager(opens in a new tab)'
 		);
 	} );
 } );

--- a/assets/source/catalog-sync/sections/SyncState.test.js
+++ b/assets/source/catalog-sync/sections/SyncState.test.js
@@ -18,4 +18,16 @@ describe( 'SyncState component', () => {
 			'Pinterest ads manager(opens in a new tab)'
 		);
 	} );
+
+	test( 'should render SyncStateSummary', () => {
+		const { getAllByTestId } = render( <SyncState /> );
+
+		expect( getAllByTestId( 'summary-placeholder' ) ).toBeTruthy();
+	} );
+
+	test( 'should render SyncStateTable', () => {
+		const { getByText } = render( <SyncState /> );
+
+		expect( getByText( 'Property' ) ).toBeTruthy();
+	} );
 } );

--- a/assets/source/catalog-sync/sections/SyncState.test.js
+++ b/assets/source/catalog-sync/sections/SyncState.test.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Internal dependencies
+ */
+import SyncState from './SyncState';
+
+describe( 'SyncState component', () => {
+	test( 'should render header and footer correctly', () => {
+		const { getByText, getByRole } = render( <SyncState /> );
+
+		expect( getByRole( 'heading' ) ).toHaveTextContent( 'Overview' );
+
+		expect(
+			getByText( 'Set up and manage ads to increase your reach with' )
+		).toBeTruthy();
+
+		expect( getByRole( 'link' ) ).toHaveTextContent(
+			'Pinterest ads manager'
+		);
+	} );
+} );

--- a/assets/source/catalog-sync/sections/SyncStateTable.js
+++ b/assets/source/catalog-sync/sections/SyncStateTable.js
@@ -77,7 +77,7 @@ const SyncStateTable = ( { workflow } ) => {
 			showMenu={ false }
 		/>
 	) : (
-		<TablePlaceholder headers={ headers } numberOfRows={ 3 } />
+		<TablePlaceholder headers={ headers } numberOfRows={ 3 } caption="" />
 	);
 };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,11 @@ module.exports = {
 	testPathIgnorePatterns: [ '/node_modules/' ],
 	globals: {
 		wcSettings: {
-			pinterest_for_woocommerce: {},
+			pinterest_for_woocommerce: {
+				pinterestLinks: {
+					adsManager: 'https://example.com',
+				},
+			},
 		},
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3777,6 +3777,101 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.15.1.tgz",
+      "integrity": "sha512-kmj8opVDRE1E4GXyLlESsQthCXK7An28dFWxhiMwD7ZUI7ZxA6sjdJRxLerD9Jd8cHX4BDc1jzXaaZKqzlUkvg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
@@ -4187,6 +4282,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
+      "integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -9811,6 +9915,12 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
     "@types/jest": "^27.0.3",
     "@woocommerce/dependency-extraction-webpack-plugin": "^1.7.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #280.

This PR adds a unit test for Pinterest ads manager CTA under catalog overview.


### Screenshots:

N/A.


### Detailed test instructions:

1. Checkout this branch `feature/280-add-unit-tests-ads-manager-cta`.
2. Run `npm run test-unit`.
3. `assets/source/catalog-sync/sections/SyncState.test.js` is covered in the test.