### PR TITLE
Don't sync hidden or out of stock products.

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -204,14 +204,20 @@ class FeedGenerator extends AbstractChainedJob {
 
 			$types = array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types );
 
-			$products = wc_get_products(
-				array(
-					'type'    => $types,
-					'include' => $items,
-					'orderby' => 'none',
-					'limit'   => $this->get_batch_size(),
-				)
+			$products_query_args = array(
+				'type'       => $types,
+				'include'    => $items,
+				'visibility' => 'catalog',
+				'orderby'    => 'none',
+				'limit'      => $this->get_batch_size(),
 			);
+
+			// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set.
+			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+				$products_query_args['stock_status'] = 'instock';
+			}
+
+			$products = wc_get_products( $products_query_args );
 
 			$this->prepare_feed_buffers();
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -66,6 +66,17 @@ class ProductSync {
 			add_action( 'woocommerce_variation_set_stock_status', array( __CLASS__, 'mark_feed_dirty' ), 10, 1 );
 			add_action( 'woocommerce_product_set_stock_status', array( __CLASS__, 'mark_feed_dirty' ), 10, 1 );
 		}
+
+		/**
+		 * Mark feed as needing re-generation on changes to the woocommerce_hide_out_of_stock_items setting
+		 */
+		add_action(
+			'update_option_woocommerce_hide_out_of_stock_items',
+			function () {
+				Pinterest_For_Woocommerce()::save_data( 'feed_dirty', true );
+				self::log( 'Feed is dirty.' );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Hide hidden products from the feed file.
- Remove out-of-stock products when `Hide out of stock items from the catalog` is enabled.

Closes #206 .

### Detailed test instructions:

1. In testing site generate the feed file -> trigger `pinterest-for-woocommerce-start-feed-generation` AS action and wait until `pinterest/jobs/generate_feed/chain_end` finishes ( this second part may not be visible depending on the products count and AS cycle so don't worry ) 
2. Check the number of generated products. Check woocommerce -> marketing -> pinterest , `XML feed` row.
3. Enable `Hide out of stock items from the catalog` and mark one product as out of stock.
4. Generate the feed file again.
5. Check the number of generated products, it should be one less than in step 2
6. Mark one product as hiddent.
7. Generate the feed file again.
8. Check the number of generated products, it should be one less than in step 5

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
* Fix - Hide hidden products from the XML feed.
* Fix - Hide out of stock items from the XML feed when Hide out of stock option is selected.
>
