### PR TITLE
Rename `test-unit` task to `test:js`

### DIFF
--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -19,4 +19,4 @@ jobs:
         uses: ./.github/actions/prepare-node
 
       - name: Run JavaScript unit tests
-        run: npm run test-unit
+        run: npm run test:js

--- a/package.json
+++ b/package.json
@@ -98,23 +98,23 @@
     }
   },
   "scripts": {
-    "dev": "wp-scripts build && gulp build",
     "prebuild": "composer install --no-dev",
     "build": "wp-scripts build && gulp build && gulp package",
     "postbuild": "composer install",
-    "start": "wp-scripts start",
-    "lint:js": "wp-scripts lint-js ./assets/source",
-    "lint:js:fix": "wp-scripts lint-js ./assets/source --fix",
+    "build:zip": "npm run build",
+    "dev": "wp-scripts build && gulp build",
     "format:js": "wp-scripts format ./assets/source",
     "lint:css": "wp-scripts lint-style ./assets/source",
-    "lint:php": "composer run-script phpcs ./",
-    "test:php-prepare": "./bin/install-wp-tests.sh",
-    "test:php-run": "composer test-unit",
-    "test:php": "npm run test:php-prepare -- wordpress_test root root localhost && npm run test:php-run",
     "lint:css:fix": "wp-scripts lint-style ./assets/source --fix",
-    "build:zip": "npm run build",
+    "lint:js": "wp-scripts lint-js ./assets/source",
+    "lint:js:fix": "wp-scripts lint-js ./assets/source --fix",
+    "lint:php": "composer run-script phpcs ./",
+    "start": "wp-scripts start",
     "test:js": "wp-scripts test-unit-js --coverage",
-    "test:js:watch": "npm run test:js -- --watch"
+    "test:js:watch": "npm run test:js -- --watch",
+    "test:php": "npm run test:php-prepare -- wordpress_test root root localhost && npm run test:php-run",
+    "test:php-prepare": "./bin/install-wp-tests.sh",
+    "test:php-run": "composer test-unit"
   },
   "browserslist": [
     "last 5 versions",

--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
     "test:php": "npm run test:php-prepare -- wordpress_test root root localhost && npm run test:php-run",
     "lint:css:fix": "wp-scripts lint-style ./assets/source --fix",
     "build:zip": "npm run build",
-    "test-unit": "wp-scripts test-unit-js --coverage",
-    "test-unit:watch": "npm run test-unit -- --watch"
+    "test:js": "wp-scripts test-unit-js --coverage",
+    "test:js:watch": "npm run test:js -- --watch"
   },
   "browserslist": [
     "last 5 versions",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Rename test-unit task to test:js, 
	for consistency and to mismatch with `test:php` unit tests.
- Reorder npm scripts alphabetically + pre/post.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. `npm run test:js`
2. review the [package.json](https://github.com/woocommerce/pinterest-for-woocommerce/blob/update/npm-scripts/package.json#L101-L117) source


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
