### PR TITLE
Fire track event for modal

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -81,7 +81,7 @@ Closing a modal.
 |   |   |   |
 |---|---|---|
 `context` | `string` | Indicate which modal this is for.
-`action` | `string` | `confirm` - When the final "got it" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
+`action` | `string` | `confirm` - When the final "Yes, I'm sure" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
 #### Emitters
 - [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77) with `context: 'account-disconnection'`
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -17,7 +17,7 @@ Do not edit it manually!
 ### [`wcadmin_pfw_account_connect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L37)
 Clicking on "Connect" Pinterest account button.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L60)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77)
 
 ### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L32)
 Clicking on "… convert your personal account" button.
@@ -32,7 +32,7 @@ Clicking on "… create a new Pinterest account" button.
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
 Clicking on "Disconnect" Pinterest account button during account setup.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L60)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77)
 
 ### [`wcadmin_pfw_business_account_connect_button_click`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L24)
 Clicking on "Connect" business account button.
@@ -62,10 +62,10 @@ Clicking on an external documentation link.
 	- with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
-	- with `{ link_id: 'setup-tracking', context: 'wizard'|'settings' }`
-- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L35) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+	- with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L36) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 
-### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L207)
+### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L208)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 |   |   |   |
@@ -73,7 +73,26 @@ Clicking on getting started page faq item to collapse or expand it.
 `action` | `string` | `'expand' \| 'collapse'` What action was initiated.
 `question_id` | `string` | Identifier of the clicked question.
 #### Emitters
-- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L226) whenever the FAQ is toggled.
+- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L227) whenever the FAQ is toggled.
+
+### [`wcadmin_pfw_modal_closed`](assets/source/setup-guide/app/components/Account/Connection.js#L53)
+Closing a modal.
+#### Properties
+|   |   |   |
+|---|---|---|
+`context` | `string` | Indicate which modal this is for.
+`action` | `string` | `confirm` - When the final "got it" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
+#### Emitters
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77) with `context: 'account-disconnection'`
+
+### [`wcadmin_pfw_modal_open`](assets/source/setup-guide/app/components/Account/Connection.js#L47)
+Opening a modal.
+#### Properties
+|   |   |   |
+|---|---|---|
+`context` | `string` | Indicate which modal this is for.
+#### Emitters
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77) with `context: 'account-disconnection'`
 
 <!---
 End of `woo-tracking-jsdoc`-generated content.

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -17,7 +17,7 @@ Do not edit it manually!
 ### [`wcadmin_pfw_account_connect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L37)
 Clicking on "Connect" Pinterest account button.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79)
 
 ### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L32)
 Clicking on "… convert your personal account" button.
@@ -32,7 +32,7 @@ Clicking on "… create a new Pinterest account" button.
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
 Clicking on "Disconnect" Pinterest account button during account setup.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79)
 
 ### [`wcadmin_pfw_business_account_connect_button_click`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L24)
 Clicking on "Connect" business account button.
@@ -50,14 +50,14 @@ Clicking on an external documentation link.
 |   |   |   |
 |---|---|---|
 `link_id` | `string` | Identifier of the link.
-`context` | `string` | What action was initiated.
+`context` | `string` | `'settings' \| 'welcome-section' \| 'wizard'` In which context the link was placed?
 `href` | `string` | Href to which the user was navigated to.
 #### Emitters
 - [`documentationLinkProps`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L37) on click, with given `linkId` and `context`.
-- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L57) with `{ link_id: 'claim-website', context: 'claim-website' }`
+- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L57) with `{ link_id: 'claim-website', context: props.view }`
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
-	- with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
-	- with `{ link_id: 'merchant-guidelines', context: 'setup-account' }`
+	- with `{ link_id: 'ad-guidelines', context: props.view }`
+	- with `{ link_id: 'merchant-guidelines', context: props.view }`
 - [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L50)
 	- with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
@@ -75,24 +75,26 @@ Clicking on getting started page faq item to collapse or expand it.
 #### Emitters
 - [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L227) whenever the FAQ is toggled.
 
-### [`wcadmin_pfw_modal_closed`](assets/source/setup-guide/app/components/Account/Connection.js#L53)
+### [`wcadmin_pfw_modal_closed`](assets/source/setup-guide/app/components/Account/Connection.js#L54)
 Closing a modal.
 #### Properties
 |   |   |   |
 |---|---|---|
-`context` | `string` | Indicate which modal this is for.
+`name` | `string` | Which modal is it?
+`context` | `string` | `'settings' \| 'wizard'` In which context it was used?
 `action` | `string` | `confirm` - When the final "Yes, I'm sure" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77) with `context: 'account-disconnection'`
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79) with `{ name: 'account-disconnection', … }`
 
 ### [`wcadmin_pfw_modal_open`](assets/source/setup-guide/app/components/Account/Connection.js#L47)
 Opening a modal.
 #### Properties
 |   |   |   |
 |---|---|---|
-`context` | `string` | Indicate which modal this is for.
+`name` | `string` | Which modal is it?
+`context` | `string` | `'settings' \| 'wizard'` In which context it was used?
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L77) with `context: 'account-disconnection'`
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79) with `{ name: 'account-disconnection', … }`
 
 <!---
 End of `woo-tracking-jsdoc`-generated content.

--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -56,7 +56,7 @@ const PinterestLogo = () => {
  * @event wcadmin_pfw_modal_closed
  * @property {string} context Indicate which modal this is for.
  * @property {string} action
- * 				`confirm` - When the final "got it" button is clicked.
+ * 				`confirm` - When the final "Yes, I'm sure" button is clicked.
  * 				`dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
  */
 

--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -48,13 +48,15 @@ const PinterestLogo = () => {
  * Opening a modal.
  *
  * @event wcadmin_pfw_modal_open
- * @property {string} context Indicate which modal this is for.
+ * @property {string} name Which modal is it?
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
  */
 /**
  * Closing a modal.
  *
  * @event wcadmin_pfw_modal_closed
- * @property {string} context Indicate which modal this is for.
+ * @property {string} name Which modal is it?
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
  * @property {string} action
  * 				`confirm` - When the final "Yes, I'm sure" button is clicked.
  * 				`dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
@@ -65,18 +67,23 @@ const PinterestLogo = () => {
  *
  * @fires wcadmin_pfw_account_connect_button_click
  * @fires wcadmin_pfw_account_disconnect_button_click
- * @fires wcadmin_pfw_modal_open with `context: 'account-disconnection'`
- * @fires wcadmin_pfw_modal_closed with `context: 'account-disconnection'`
- *
+ * @fires wcadmin_pfw_modal_open with `{ name: 'account-disconnection', … }`
+ * @fires wcadmin_pfw_modal_closed with `{ name: 'account-disconnection', … }`
  * @param {Object} props React props.
  * @param {boolean} props.isConnected
  * @param {Function} props.setIsConnected
  * @param {Object} props.accountData
+ * @param {string} props.context Context in which the component is used, to be forwarded to fired Track Events.
  * @return {JSX.Element} Rendered element.
  */
-const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
+const AccountConnection = ( {
+	isConnected,
+	setIsConnected,
+	accountData,
+	context,
+} ) => {
 	const createNotice = useCreateNotice();
-	const modalContext = 'account-disconnection';
+	const modalName = 'account-disconnection';
 
 	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
 		false
@@ -85,15 +92,16 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 	const openConfirmationModal = () => {
 		recordEvent( 'pfw_account_disconnect_button_click' );
 		setIsConfirmationModalOpen( true );
-		recordEvent( 'pfw_modal_open', { context: modalContext } );
+		recordEvent( 'pfw_modal_open', { context, name: modalName } );
 	};
 
 	const closeConfirmationModal = ( event, isConfirmed ) => {
 		setIsConfirmationModalOpen( false );
 
 		recordEvent( 'pfw_modal_closed', {
-			context: modalContext,
 			action: isConfirmed ? 'confirm' : 'dismiss',
+			context,
+			name: modalName,
 		} );
 	};
 

--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -44,12 +44,29 @@ const PinterestLogo = () => {
  *
  * @event wcadmin_pfw_account_disconnect_button_click
  */
+/**
+ * Opening a modal.
+ *
+ * @event wcadmin_pfw_modal_open
+ * @property {string} context Indicate which modal this is for.
+ */
+/**
+ * Closing a modal.
+ *
+ * @event wcadmin_pfw_modal_closed
+ * @property {string} context Indicate which modal this is for.
+ * @property {string} action
+ * 				`confirm` - When the final "got it" button is clicked.
+ * 				`dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
+ */
 
 /**
  * Pinterest account connection component.
  *
  * @fires wcadmin_pfw_account_connect_button_click
  * @fires wcadmin_pfw_account_disconnect_button_click
+ * @fires wcadmin_pfw_modal_open with `context: 'account-disconnection'`
+ * @fires wcadmin_pfw_modal_closed with `context: 'account-disconnection'`
  *
  * @param {Object} props React props.
  * @param {boolean} props.isConnected
@@ -59,18 +76,25 @@ const PinterestLogo = () => {
  */
 const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 	const createNotice = useCreateNotice();
+	const modalContext = 'account-disconnection';
 
 	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
 		false
 	);
 
 	const openConfirmationModal = () => {
-		setIsConfirmationModalOpen( true );
 		recordEvent( 'pfw_account_disconnect_button_click' );
+		setIsConfirmationModalOpen( true );
+		recordEvent( 'pfw_modal_open', { context: modalContext } );
 	};
 
-	const closeConfirmationModal = () => {
+	const closeConfirmationModal = ( event, isConfirmed ) => {
 		setIsConfirmationModalOpen( false );
+
+		recordEvent( 'pfw_modal_closed', {
+			context: modalContext,
+			action: isConfirmed ? 'confirm' : 'dismiss',
+		} );
 	};
 
 	const renderConfirmationModal = () => {
@@ -110,7 +134,7 @@ const AccountConnection = ( { isConnected, setIsConnected, accountData } ) => {
 	};
 
 	const handleDisconnectAccount = async () => {
-		closeConfirmationModal();
+		closeConfirmationModal( undefined, true );
 
 		try {
 			await apiFetch( {

--- a/assets/source/setup-guide/app/components/Account/Connection.test.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.test.js
@@ -1,0 +1,41 @@
+jest.mock( '../../helpers/effects' );
+jest.mock( '@woocommerce/tracks' );
+
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AccountConnection from './Connection';
+
+recordEvent.mockName( 'recordEvent' );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'AccountConnection component', () => {
+	it( 'Should call `pfw_modal_open { name: \'account-disconnection\', context}` track event once "Disconnect" button is clicked', () => {
+		// Render connected component.
+		const { getByRole } = render(
+			<AccountConnection
+				isConnected={ true }
+				accountData={ { id: 123 } }
+				context="foo"
+			/>
+		);
+		// Find & click the Disconnect button.
+		const disconnectButton = getByRole( 'button', { name: 'Disconnect' } );
+		fireEvent.click( disconnectButton );
+
+		// Assert fired event.
+		expect( recordEvent ).toHaveBeenCalledWith( 'pfw_modal_open', {
+			context: 'foo',
+			name: 'account-disconnection',
+		} );
+	} );
+} );

--- a/assets/source/setup-guide/app/components/Account/Connection.test.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.test.js
@@ -6,6 +6,7 @@ jest.mock( '@woocommerce/tracks' );
  */
 import { recordEvent } from '@woocommerce/tracks';
 import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -19,23 +20,85 @@ afterEach( () => {
 } );
 
 describe( 'AccountConnection component', () => {
-	it( 'Should call `pfw_modal_open { name: \'account-disconnection\', context}` track event once "Disconnect" button is clicked', () => {
-		// Render connected component.
-		const { getByRole } = render(
-			<AccountConnection
-				isConnected={ true }
-				accountData={ { id: 123 } }
-				context="foo"
-			/>
-		);
-		// Find & click the Disconnect button.
-		const disconnectButton = getByRole( 'button', { name: 'Disconnect' } );
-		fireEvent.click( disconnectButton );
+	describe( 'when rendered with account data', () => {
+		let getByRole;
+		beforeEach( () => {
+			// Render connected component.
+			getByRole = render(
+				<AccountConnection
+					isConnected={ true }
+					accountData={ { id: 123 } }
+					context="foo"
+				/>
+			).getByRole;
+		} );
+		describe( 'once "Disconnect" button is clicked', () => {
+			beforeEach( () => {
+				// Find & click the Disconnect button.
+				const disconnectButton = getByRole( 'button', {
+					name: 'Disconnect',
+				} );
+				fireEvent.click( disconnectButton );
+			} );
 
-		// Assert fired event.
-		expect( recordEvent ).toHaveBeenCalledWith( 'pfw_modal_open', {
-			context: 'foo',
-			name: 'account-disconnection',
+			it( "Should call `pfw_modal_open { name: 'account-disconnection', context}` track event", () => {
+				// Assert fired event.
+				expect( recordEvent ).toHaveBeenCalledWith( 'pfw_modal_open', {
+					context: 'foo',
+					name: 'account-disconnection',
+				} );
+			} );
+
+			it( "then \"Cancel\" button is clicked, should call `pfw_modal_closed { name: 'account-disconnection', action: 'dismiss', context}` track event", () => {
+				// Find & click the Cancel button.
+				const cancelButton = getByRole( 'button', {
+					name: 'Cancel',
+				} );
+				fireEvent.click( cancelButton );
+
+				// Assert fired event.
+				expect( recordEvent ).toHaveBeenCalledWith(
+					'pfw_modal_closed',
+					{
+						action: 'dismiss',
+						context: 'foo',
+						name: 'account-disconnection',
+					}
+				);
+			} );
+
+			it( "then \"X\" button is clicked, should call `pfw_modal_closed { name: 'account-disconnection', action: 'dismiss', context}` track event", () => {
+				// Find & click the Cancel button.
+				const cancelButton = getByRole( 'button', {
+					name: 'Close dialog',
+				} );
+				fireEvent.click( cancelButton );
+
+				// Assert fired event.
+				expect( recordEvent ).toHaveBeenCalledWith(
+					'pfw_modal_closed',
+					{
+						action: 'dismiss',
+						context: 'foo',
+						name: 'account-disconnection',
+					}
+				);
+			} );
+
+			it( "then \"Esc\" key is pressed, should call `pfw_modal_closed { name: 'account-disconnection', action: 'dismiss', context}` track event", () => {
+				// Press Esc.
+				userEvent.keyboard( '{esc}' );
+
+				// Assert fired event.
+				expect( recordEvent ).toHaveBeenCalledWith(
+					'pfw_modal_closed',
+					{
+						action: 'dismiss',
+						context: 'foo',
+						name: 'account-disconnection',
+					}
+				);
+			} );
 		} );
 	} );
 } );

--- a/assets/source/setup-guide/app/helpers/documentation-link-props.js
+++ b/assets/source/setup-guide/app/helpers/documentation-link-props.js
@@ -9,7 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * @event wcadmin_pfw_documentation_link_click
  *
  * @property {string} link_id Identifier of the link.
- * @property {string} context What action was initiated.
+ * @property {string} context `'settings' | 'welcome-section' | 'wizard'` In which context the link was placed?
  * @property {string} href Href to which the user was navigated to.
  */
 

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -48,7 +48,7 @@ const StaticError = ( { reqError } ) => {
  *
  * To be used in onboarding setup stepper.
  *
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'claim-website', context: 'claim-website' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'claim-website', context: props.view }`
  * @param {Object} props React props.
  * @param {Function} props.goToNextStep
  * @param {string} props.view
@@ -152,7 +152,7 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 								wcSettings.pinterest_for_woocommerce
 									.pinterestLinks.claimWebsite,
 							linkId: 'claim-website',
-							context: 'claim-website',
+							context: view,
 						} ) }
 					/>
 				</div>

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -40,8 +40,8 @@ import documentationLinkProps from '../helpers/documentation-link-props';
  *
  * @fires wcadmin_pfw_account_create_button_click
  * @fires wcadmin_pfw_account_convert_button_click
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: 'setup-account' }`
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: 'setup-account' }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: props.view }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: props.view }`
  *
  * @param {Object} props React props
  * @param {Function} props.goToNextStep
@@ -58,6 +58,7 @@ const SetupAccount = ( {
 	setIsConnected,
 	isBusinessConnected,
 } ) => {
+	const context = view;
 	const createNotice = useCreateNotice();
 	const appSettings = useSettingsSelect();
 	const [ businessAccounts, setBusinessAccounts ] = useState(
@@ -141,7 +142,7 @@ const SetupAccount = ( {
 													.pinterestLinks
 													.adGuidelines,
 											linkId: 'ad-guidelines',
-											context: 'setup-account',
+											context,
 											rel: 'noreferrer',
 										} ) }
 									/>
@@ -157,7 +158,7 @@ const SetupAccount = ( {
 													.pinterestLinks
 													.merchantGuidelines,
 											linkId: 'merchant-guidelines',
-											context: 'setup-account',
+											context,
 											rel: 'noreferrer',
 										} ) }
 									/>
@@ -169,6 +170,7 @@ const SetupAccount = ( {
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>
 						<AccountConnection
+							context={ context }
 							isConnected={ isConnected }
 							setIsConnected={ setIsConnected }
 							accountData={ appSettings.account_data }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3882,6 +3882,15 @@
         "@testing-library/dom": "^8.0.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.0.3",
     "@woocommerce/dependency-extraction-webpack-plugin": "^1.7.0",
     "@woocommerce/eslint-plugin": "^1.2.0",

--- a/woo-tracking-jsdoc/publish.js
+++ b/woo-tracking-jsdoc/publish.js
@@ -80,7 +80,12 @@ exports.publish = function ( data ) {
 						/\|/g,
 						'\\|'
 					);
-					mdResult += `\`${ property.name }\` | \`${ type }\` | ${ description }\n`;
+					mdResult += `\`${
+						property.name
+					}\` | \`${ type }\` | ${ description.replace(
+						/\s*\n\s*/,
+						' <br> '
+					) }\n`;
 				} );
 			}
 

--- a/woo-tracking-jsdoc/publish.js
+++ b/woo-tracking-jsdoc/publish.js
@@ -83,7 +83,7 @@ exports.publish = function ( data ) {
 					mdResult += `\`${
 						property.name
 					}\` | \`${ type }\` | ${ description.replace(
-						/\s*\n\s*/,
+						/\s*\n\s*/g,
 						' <br> '
 					) }\n`;
 				} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Support multiline Track Event properties' description.
- Fire track event for modal

implements part of #232.




### Screenshots:



![modal open](https://user-images.githubusercontent.com/17435/144649805-c83f9f19-6db5-43a7-9bee-7ad81b92330a.gif)
![modal event](https://user-images.githubusercontent.com/17435/144649808-4476c373-1fcc-44ca-90eb-b59344835689.gif)

### Detailed test instructions:

0. Enable tracks logging, by `localStorage.setItem('debug', 'wc-admin*')`
1. Go to [`/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding`](https://wp581wc580.test/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding) 
2. (Connect account)
3. Click on "disconnect"
	- you should get `wcadmin_pfw_modal_open: { context: 'account-disconnection' }`
4. Click on overlay | "x" | "cancel" | press <kbd>Esc</kbd>
	- you should get `wcadmin_pfw_modal_closed: { context: 'account-disconnection', action: 'dismiss' }`
5. Reopen, click "Yes, I'm sure"
	- you should get `wcadmin_pfw_modal_closed: { context: 'account-disconnection', action: 'confirm' }`

(no changelog entry, we will add a single one for all tracks)
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

