### PR TITLE
Adding Woo Tracker for Usage Tracking

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -176,6 +176,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			define( 'PINTEREST_FOR_WOOCOMMERCE_API_VERSION', '1' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_API_AUTH_ENDPOINT', 'oauth/callback' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_AUTH', PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_auth_key' );
+			define( 'PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX', 'pfw' );
 		}
 
 
@@ -232,6 +233,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'wp', array( Pinterest\SaveToPinterest::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\Tracking::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
+			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
+
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Include Pinterest data in the WC Tracker snapshot.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Pinterest_For_Woocommerce;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class handling Woo Tracker
+ */
+class TrackerSnapshot {
+
+
+	/**
+	 * Not needed if allow_tracking is disabled.
+	 *
+	 * @return bool Whether the object is needed.
+	 */
+	public static function is_needed(): bool {
+		return 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
+	}
+
+	/**
+	 * Hook extension tracker data into the WC tracker data.
+	 */
+	public static function maybe_init(): void {
+
+		if ( ! self::is_needed() ) {
+			return;
+		}
+
+		add_filter(
+			'woocommerce_tracker_data',
+			function ( $data ) {
+				return self::include_snapshot_data( $data );
+			}
+		);
+	}
+
+	/**
+	 * Add extension data to the WC Tracker snapshot.
+	 *
+	 * @param array $data The existing array of tracker data.
+	 *
+	 * @return array The updated array of tracker data.
+	 */
+	protected static function include_snapshot_data( array $data = array() ): array {
+		if ( ! isset( $data['extensions'] ) ) {
+			$data['extensions'] = array();
+		}
+
+		$data['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] = array(
+			'settings' => self::parse_settings(),
+		);
+
+		return $data;
+	}
+
+	/**
+	 * Parse general extension and settings data in the required format.
+	 *
+	 * @return array
+	 */
+	protected static function parse_settings(): array {
+
+		$settings = Pinterest_For_Woocommerce::get_settings( true );
+
+		/**
+		 * Lambda function to parse booleans into strings
+		 *
+		 * @param $key
+		 * @return string
+		 */
+		$fn_boolean_setting_to_string = function ( $key ) use ( $settings ): string {
+			return $settings[ $key ] ? 'yes' : 'no';
+		};
+
+		// options to be formatted as "yes" or "no".
+		$boolean_options = array(
+			'track_conversions',
+			'enhanced_match_support',
+			'save_to_pinterest',
+			'rich_pins_on_posts',
+			'rich_pins_on_products',
+			'product_sync_enabled',
+			'enable_debug_logging',
+			'erase_plugin_data',
+		);
+
+		return array_merge(
+			array( 'version' => PINTEREST_FOR_WOOCOMMERCE_VERSION ),
+			array_combine( $boolean_options, array_map( $fn_boolean_setting_to_string, $boolean_options ) )
+		);
+	}
+}

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest;
+
+class TrackerSnapshotTest extends \WP_UnitTestCase {
+
+
+	public static $default_settings = array(
+		'version'                => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+		'track_conversions'      => true,
+		'enhanced_match_support' => true,
+		'save_to_pinterest'      => true,
+		'rich_pins_on_posts'     => true,
+		'rich_pins_on_products'  => true,
+		'product_sync_enabled'   => true,
+		'enable_debug_logging'   => false,
+		'erase_plugin_data'      => false,
+	);
+
+	function setUp() {
+		parent::setUp();
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+	}
+
+
+	function test_settings_are_tracked_by_woo_tracker_if_opt_in() {
+
+		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+
+
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['track_conversions'], 'yes', "Boolean track value 'true' is tracked as 'yes'" );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['erase_plugin_data'], 'no', "Boolean track value 'false' is tracked as 'no'" );
+		$this->assertEquals( count( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings'] ), count(  self::$default_settings ), "All the values should be tracked" );
+	}
+
+	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {
+
+		update_option( 'woocommerce_allow_tracking', 'no' );
+
+		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+
+		$this->assertTrue( count($tracks) === 0, "Track data should be empty whe OPT-OUT" );
+
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #291 

Adds functionality regarding Usage Tracking when the user allows tracking

### Screenshots:

`wp wc tracker snapshot --format=yaml`

Output: 
```
[...]
 extensions:
    pfw:
      settings:
        version: 1.0.1
        track_conversions: 'no'
        enhanced_match_support: 'no'
        save_to_pinterest: 'no'
        rich_pins_on_posts: 'no'
        rich_pins_on_products: 'no'
        product_sync_enabled: 'no'
        enable_debug_logging: 'no'
        erase_plugin_data: 'no'
```

### Detailed test instructions:

Be sure you're OPT-IN in Woocommerce->Settings->Advanced->woocomerce.com
https://wp8.test/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
![Screenshot 2021-12-15 at 19 15 28](https://user-images.githubusercontent.com/5908855/146242558-fcaa9a2b-7283-4c53-ad70-4ba0278e0cc8.png)

1. Go to Pinterest Settings and set all the options as NO
2. run `wp wc tracker snapshot --format=yaml`
3.  You should see this in the output
```
[...]
 extensions:
    pfw:
      settings:
        version: 1.0.1
        track_conversions: 'no'
        enhanced_match_support: 'no'
        save_to_pinterest: 'no'
        rich_pins_on_posts: 'no'
        rich_pins_on_products: 'no'
        product_sync_enabled: 'no'
        enable_debug_logging: 'no'
        erase_plugin_data: 'no'
```
 4. Go to Pinterest Settings and set all the options as YES
 5. run `wp wc tracker snapshot --format=yaml` 
 6. You should see this in the output
 ```
[...]
 extensions:
    pfw:
      settings:
        version: 1.0.1
        track_conversions: 'yes'
        enhanced_match_support: 'yes'
        save_to_pinterest: 'yes'
        rich_pins_on_posts: 'yes'
        rich_pins_on_products: 'yes'
        product_sync_enabled: 'yes'
        enable_debug_logging: 'yes'
        erase_plugin_data: 'yes'
```
  7 . OPT-OUT in Woocommerce->Settings->Advanced->woocomerce.com
  8.  run `wp wc tracker snapshot --format=yaml`
  9. You cannot see anymore  `pfw` data in the output
  10.  PHP Unit test pass and helps to prevent future errors
  11.  Visual verification of the code looks good for you

### Changelog entry

>  Tweak - Add Usage Tracking 
