### PR TITLE
Add product attributes

### DIFF
--- a/assets/source/product-attributes/index.js
+++ b/assets/source/product-attributes/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './index.scss';

--- a/assets/source/product-attributes/index.scss
+++ b/assets/source/product-attributes/index.scss
@@ -1,5 +1,7 @@
 .wc-metaboxes-wrapper {
+
 	.wc-metabox.woocommerce_variation {
+
 		.pinterest-metabox.wc-metabox {
 			overflow: hidden;
 			clear: both;
@@ -13,6 +15,7 @@
 			}
 
 			h3 {
+
 				.handlediv {
 					margin-top: 0;
 					visibility: visible;
@@ -20,6 +23,7 @@
 			}
 
 			.pinterest-input {
+
 				.options {
 					border: none;
 

--- a/assets/source/product-attributes/index.scss
+++ b/assets/source/product-attributes/index.scss
@@ -1,0 +1,43 @@
+.wc-metaboxes-wrapper {
+	.wc-metabox.woocommerce_variation {
+		.pinterest-metabox.wc-metabox {
+			overflow: hidden;
+			clear: both;
+			border: 1px solid #ddd;
+			// using !important to override the WooCommerce style for meta boxes
+			margin: 16px 0 !important;
+
+			.wc-metabox-content {
+				overflow: hidden;
+				padding: 0 1em;
+			}
+
+			h3 {
+				.handlediv {
+					margin-top: 0;
+					visibility: visible;
+				}
+			}
+
+			.pinterest-input {
+				.options {
+					border: none;
+
+					input[type="checkbox"] {
+						margin-top: 5px !important;
+					}
+				}
+			}
+		}
+
+		.pinterest-metabox.wc-metabox:last-of-type {
+			border-bottom: 1px solid #ddd;
+		}
+	}
+}
+
+.gla-channel-visibility-box .form-row > select {
+	display: block;
+	margin: 8px 0;
+	max-width: 100%;
+}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -267,6 +267,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$attributes_tab       = new Pinterest\Admin\Product\Attributes\AttributesTab( $admin );
 			$variation_attributes = new Pinterest\Admin\Product\Attributes\VariationsAttributes( $admin );
 
+			$admin->register();
 			$attributes_tab->register();
 			$variation_attributes->register();
 		}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -264,9 +264,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public function admin_init() {
 			$view_factory         = new Pinterest\View\PHPViewFactory();
 			$admin                = new Pinterest\Admin\Admin( $view_factory );
-			$attributes_manager   = new Pinterest\Product\Attributes\AttributeManager();
-			$attributes_tab       = new Pinterest\Admin\Product\Attributes\AttributesTab( $admin, $attributes_manager );
-			$variation_attributes = new Pinterest\Admin\Product\Attributes\VariationsAttributes( $admin, $attributes_manager );
+			$attributes_tab       = new Pinterest\Admin\Product\Attributes\AttributesTab( $admin );
+			$variation_attributes = new Pinterest\Admin\Product\Attributes\VariationsAttributes( $admin );
 
 			$attributes_tab->register();
 			$variation_attributes->register();

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -226,6 +226,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$this->includes();
 
 			add_action( 'init', array( $this, 'init' ), 0 );
+			add_action( 'admin_init', array( $this, 'admin_init' ), 0 );
 			add_action( 'rest_api_init', array( $this, 'init_api_endpoints' ) );
 			add_action( 'wp_head', array( $this, 'maybe_inject_verification_code' ) );
 			add_action( 'wp_head', array( Pinterest\RichPins::class, 'maybe_inject_rich_pins_opengraph_tags' ) );
@@ -257,6 +258,19 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			do_action( 'pinterest_for_woocommerce_init' );
 		}
 
+		/**
+		 * Init classes for admin interface.
+		 */
+		public function admin_init() {
+			$view_factory         = new Pinterest\View\PHPViewFactory();
+			$admin                = new Pinterest\Admin\Admin( $view_factory );
+			$attributes_manager   = new Pinterest\Product\Attributes\AttributeManager();
+			$attributes_tab       = new Pinterest\Admin\Product\Attributes\AttributesTab( $admin, $attributes_manager );
+			$variation_attributes = new Pinterest\Admin\Product\Attributes\VariationsAttributes( $admin, $attributes_manager );
+
+			$attributes_tab->register();
+			$variation_attributes->register();
+		}
 
 		/**
 		 * Checks all plugin requirements. If run in admin context also adds a notice.

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class Admin
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin;
+
+use Automattic\WooCommerce\Pinterest\View\ViewException;
+use Automattic\WooCommerce\Pinterest\View\ViewFactory;
+
+/**
+ * Class Admin
+ */
+class Admin {
+
+	/**
+	 * View factory.
+	 *
+	 * @var ViewFactory
+	 */
+	protected $view_factory;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @param ViewFactory $view_factory View factory.
+	 */
+	public function __construct( ViewFactory $view_factory ) {
+		$this->view_factory = $view_factory;
+	}
+
+	/**
+	 * Get the admin view.
+	 *
+	 * @param string $view              Name of the view.
+	 * @param array  $context_variables Array of variables to pass to the view.
+	 *
+	 * @return string The rendered view
+	 *
+	 * @throws ViewException If the view doesn't exist or can't be loaded.
+	 */
+	public function get_view( string $view, array $context_variables = array() ): string {
+		return $this->view_factory->create( $view )
+							->render( $context_variables );
+	}
+
+}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -34,6 +34,34 @@ class Admin {
 	}
 
 	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'admin_enqueue_scripts',
+			function() {
+				$this->enqueue_assets();
+			}
+		);
+	}
+
+	/**
+	 * Enqueues any assets.
+	 */
+	protected function enqueue_assets() {
+		$screen = get_current_screen();
+
+		if ( $screen && 'product' === $screen->id ) {
+			wp_enqueue_style(
+				'pinterest-product-attributes-css',
+				Pinterest_For_Woocommerce()->plugin_url() . '/assets/product-attributes/index.css',
+				array(),
+				PINTEREST_FOR_WOOCOMMERCE_VERSION
+			);
+		}
+	}
+
+	/**
 	 * Get the admin view.
 	 *
 	 * @param string $view              Name of the view.

--- a/src/Admin/Input/Form.php
+++ b/src/Admin/Input/Form.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Class Form
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+use Automattic\WooCommerce\Pinterest\Exception\ValidateInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Form
+ */
+class Form implements FormInterface {
+
+	use ValidateInterface;
+
+	/**
+	 * Form name.
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
+	 * Form data.
+	 *
+	 * @var mixed
+	 */
+	protected $data;
+
+	/**
+	 * Children.
+	 *
+	 * @var FormInterface[]
+	 */
+	protected $children = array();
+
+	/**
+	 * Parent form.
+	 *
+	 * @var FormInterface
+	 */
+	protected $parent;
+
+	/**
+	 * Is form submitted.
+	 *
+	 * @var bool
+	 */
+	protected $is_submitted = false;
+
+	/**
+	 * Form constructor.
+	 *
+	 * @param mixed $data Form data.
+	 */
+	public function __construct( $data = null ) {
+		$this->set_data( $data );
+	}
+
+	/**
+	 * Get form name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Set form name.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return FormInterface
+	 */
+	public function set_name( string $name ): FormInterface {
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Get form children.
+	 *
+	 * @return FormInterface[]
+	 */
+	public function get_children(): array {
+		return $this->children;
+	}
+
+	/**
+	 * Add a child form.
+	 *
+	 * @param FormInterface $form Form.
+	 *
+	 * @return FormInterface
+	 *
+	 * @throws FormException If form is already submitted.
+	 */
+	public function add( FormInterface $form ): FormInterface {
+		if ( $this->is_submitted ) {
+			throw FormException::cannot_modify_submitted();
+		}
+
+		$this->children[ $form->get_name() ] = $form;
+		$form->set_parent( $this );
+
+		return $this;
+	}
+
+	/**
+	 * Remove a child with the given name from the form's children.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return FormInterface
+	 *
+	 * @throws FormException If form is already submitted.
+	 */
+	public function remove( string $name ): FormInterface {
+		if ( $this->is_submitted ) {
+			throw FormException::cannot_modify_submitted();
+		}
+
+		if ( isset( $this->children[ $name ] ) ) {
+			$this->children[ $name ]->set_parent( null );
+			unset( $this->children[ $name ] );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Whether the form contains a child with the given name.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return bool
+	 */
+	public function has( string $name ): bool {
+		return isset( $this->children[ $name ] );
+	}
+
+	/**
+	 * Set parent form.
+	 *
+	 * @param FormInterface|null $form Form.
+	 *
+	 * @return void
+	 */
+	public function set_parent( ?FormInterface $form ): void {
+		$this->parent = $form;
+	}
+
+	/**
+	 * Get parent form.
+	 *
+	 * @return FormInterface|null
+	 */
+	public function get_parent(): ?FormInterface {
+		return $this->parent;
+	}
+
+	/**
+	 * Return the form's data.
+	 *
+	 * @return mixed
+	 */
+	public function get_data() {
+		return $this->data;
+	}
+
+	/**
+	 * Set the form's data.
+	 *
+	 * @param mixed $data Form data.
+	 *
+	 * @return void
+	 */
+	public function set_data( $data ): void {
+		if ( is_array( $data ) && ! empty( $this->children ) ) {
+			$this->data = $this->map_children_data( $data );
+		} else {
+			if ( is_string( $data ) ) {
+				$data = trim( $data );
+			}
+			$this->data = $data;
+		}
+	}
+
+	/**
+	 * Maps the data to each child and returns the mapped data.
+	 *
+	 * @param array $data Form data.
+	 *
+	 * @return array
+	 */
+	protected function map_children_data( array $data ): array {
+		$children_data = array();
+		foreach ( $data as $key => $datum ) {
+			if ( isset( $this->children[ $key ] ) ) {
+				$this->children[ $key ]->set_data( $datum );
+				$children_data[ $key ] = $this->children[ $key ]->get_data();
+			}
+		}
+
+		return $children_data;
+	}
+
+	/**
+	 * Submit the form.
+	 *
+	 * @param array $submitted_data Submitted form data.
+	 */
+	public function submit( array $submitted_data = array() ): void {
+		if ( ! $this->is_submitted ) {
+			$this->is_submitted = true;
+			$this->set_data( $submitted_data );
+		}
+	}
+
+	/**
+	 * Return the data used for the form's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array {
+		$view_data = array(
+			'name'     => $this->get_view_name(),
+			'is_root'  => $this->is_root(),
+			'children' => array(),
+		);
+
+		foreach ( $this->get_children() as $index => $form ) {
+			$view_data['children'][ $index ] = $form->get_view_data();
+		}
+
+		return $view_data;
+	}
+
+	/**
+	 * Return the name used for the form's view.
+	 *
+	 * @return string
+	 */
+	public function get_view_name(): string {
+		return $this->is_root() ? sprintf( 'pinterest_%s', $this->get_name() ) : sprintf( '%s[%s]', $this->get_parent()->get_view_name(), $this->get_name() );
+	}
+
+	/**
+	 * Whether this is the root form (i.e. has no parents).
+	 *
+	 * @return bool
+	 */
+	public function is_root(): bool {
+		return null === $this->parent;
+	}
+
+	/**
+	 * Whether the form has been already submitted.
+	 *
+	 * @return bool
+	 */
+	public function is_submitted(): bool {
+		return $this->is_submitted;
+	}
+}

--- a/src/Admin/Input/Form.php
+++ b/src/Admin/Input/Form.php
@@ -129,7 +129,7 @@ class Form implements FormInterface {
 			throw FormException::cannot_modify_submitted();
 		}
 
-		if ( isset( $this->children[ $name ] ) ) {
+		if ( $this->has( $name ) ) {
 			$this->children[ $name ]->set_parent( null );
 			unset( $this->children[ $name ] );
 		}

--- a/src/Admin/Input/FormException.php
+++ b/src/Admin/Input/FormException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class FormException
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+use Automattic\WooCommerce\Pinterest\Exception\PinterestException;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class FormException
+ */
+class FormException extends Exception implements PinterestException {
+	/**
+	 * Return a new instance of the exception when a submitted form is being modified.
+	 *
+	 * @return static
+	 */
+	public static function cannot_modify_submitted(): FormException {
+		return new static( 'You cannot modify a submitted form.' );
+	}
+}

--- a/src/Admin/Input/FormInterface.php
+++ b/src/Admin/Input/FormInterface.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Interface FormInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface FormInterface
+ */
+interface FormInterface {
+
+	/**
+	 * Return the form's data.
+	 *
+	 * @return mixed
+	 */
+	public function get_data();
+
+	/**
+	 * Set the form's data.
+	 *
+	 * @param mixed $data Form data.
+	 *
+	 * @return void
+	 */
+	public function set_data( $data ): void;
+
+	/**
+	 * Return the form name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string;
+
+	/**
+	 * Set the form's name.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return FormInterface
+	 */
+	public function set_name( string $name ): FormInterface;
+
+	/**
+	 * Submit the form.
+	 *
+	 * @param array $submitted_data Submitted form data.
+	 *
+	 * @return void
+	 */
+	public function submit( array $submitted_data = array() ): void;
+
+	/**
+	 * Return the data used for the form's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array;
+
+	/**
+	 * Return the name used for the form's view.
+	 *
+	 * @return string
+	 */
+	public function get_view_name(): string;
+
+	/**
+	 * Get form children.
+	 *
+	 * @return FormInterface[]
+	 */
+	public function get_children(): array;
+
+	/**
+	 * Add a child form.
+	 *
+	 * @param FormInterface $form Form.
+	 *
+	 * @return FormInterface
+	 */
+	public function add( FormInterface $form ): FormInterface;
+
+	/**
+	 * Remove a child with the given name from the form's children.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return FormInterface
+	 */
+	public function remove( string $name ): FormInterface;
+
+	/**
+	 * Whether the form contains a child with the given name.
+	 *
+	 * @param string $name Form name.
+	 *
+	 * @return bool
+	 */
+	public function has( string $name ): bool;
+
+	/**
+	 * Set parent.
+	 *
+	 * @param FormInterface|null $form Form.
+	 *
+	 * @return void
+	 */
+	public function set_parent( ?FormInterface $form ): void;
+
+	/**
+	 * Get parent.
+	 *
+	 * @return FormInterface|null
+	 */
+	public function get_parent(): ?FormInterface;
+
+	/**
+	 * If this is the root form (i.e. has no parents)
+	 *
+	 * @return bool
+	 */
+	public function is_root(): bool;
+
+	/**
+	 * Whether the form has been already submitted.
+	 *
+	 * @return bool
+	 */
+	public function is_submitted(): bool;
+}

--- a/src/Admin/Input/Input.php
+++ b/src/Admin/Input/Input.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Class Input
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Input
+ */
+class Input extends Form implements InputInterface {
+
+	/**
+	 * Input ID.
+	 *
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * Input type.
+	 *
+	 * @var string
+	 */
+	protected $type;
+
+	/**
+	 * Input label.
+	 *
+	 * @var string
+	 */
+	protected $label;
+
+	/**
+	 * Input description.
+	 *
+	 * @var string
+	 */
+	protected $description;
+
+	/**
+	 * Input value.
+	 *
+	 * @var mixed
+	 */
+	protected $value;
+
+	/**
+	 * Input constructor.
+	 *
+	 * @param string $type Input type.
+	 */
+	public function __construct( string $type ) {
+		$this->type = $type;
+		parent::__construct();
+	}
+
+	/**
+	 * Get ID.
+	 *
+	 * @return string|null
+	 */
+	public function get_id(): ?string {
+		return $this->id;
+	}
+
+	/**
+	 * Get type.
+	 *
+	 * @return string
+	 */
+	public function get_type(): string {
+		return $this->type;
+	}
+
+	/**
+	 * Get label.
+	 *
+	 * @return string|null
+	 */
+	public function get_label(): ?string {
+		return $this->label;
+	}
+
+	/**
+	 * Get description.
+	 *
+	 * @return string|null
+	 */
+	public function get_description(): ?string {
+		return $this->description;
+	}
+
+	/**
+	 * Get value.
+	 *
+	 * @return mixed
+	 */
+	public function get_value() {
+		return $this->get_data();
+	}
+
+	/**
+	 * Set ID.
+	 *
+	 * @param string|null $id Input ID.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_id( ?string $id ): InputInterface {
+		$this->id = $id;
+
+		return $this;
+	}
+
+	/**
+	 * Set label.
+	 *
+	 * @param string|null $label Input label.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_label( ?string $label ): InputInterface {
+		$this->label = $label;
+
+		return $this;
+	}
+
+	/**
+	 * Set description.
+	 *
+	 * @param string|null $description Input description.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_description( ?string $description ): InputInterface {
+		$this->description = $description;
+
+		return $this;
+	}
+
+	/**
+	 * Set value.
+	 *
+	 * @param mixed $value Input value.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_value( $value ): InputInterface {
+		$this->set_data( $value );
+
+		return $this;
+	}
+
+	/**
+	 * Return the data used for the input's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array {
+		$view_data = array(
+			'id'          => $this->get_view_id(),
+			'type'        => $this->get_type(),
+			'label'       => $this->get_label(),
+			'value'       => $this->get_value(),
+			'description' => $this->get_description(),
+			'desc_tip'    => true,
+		);
+
+		return array_merge( parent::get_view_data(), $view_data );
+	}
+
+	/**
+	 * Return the id used for the input's view.
+	 *
+	 * @return string
+	 */
+	public function get_view_id(): string {
+		$parent = $this->get_parent();
+		if ( $parent instanceof InputInterface ) {
+			return sprintf( '%s_%s', $parent->get_view_id(), $this->get_id() );
+		} elseif ( $parent instanceof FormInterface ) {
+			return sprintf( '%s_%s', $parent->get_view_name(), $this->get_id() );
+		}
+
+		return sprintf( 'pinterest_%s', $this->get_name() );
+	}
+}

--- a/src/Admin/Input/InputInterface.php
+++ b/src/Admin/Input/InputInterface.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Interface InputInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface InputInterface
+ */
+interface InputInterface extends FormInterface {
+
+	/**
+	 * Get input ID.
+	 *
+	 * @return string|null
+	 */
+	public function get_id(): ?string;
+
+	/**
+	 * Set input ID.
+	 *
+	 * @param string|null $id Input ID.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_id( ?string $id ): InputInterface;
+
+	/**
+	 * Get type.
+	 *
+	 * @return string
+	 */
+	public function get_type(): string;
+
+	/**
+	 * Get label.
+	 *
+	 * @return string|null
+	 */
+	public function get_label(): ?string;
+
+	/**
+	 * Set label.
+	 *
+	 * @param string|null $label Input label.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_label( ?string $label ): InputInterface;
+
+	/**
+	 * Get description.
+	 *
+	 * @return string|null
+	 */
+	public function get_description(): ?string;
+
+	/**
+	 * Set description.
+	 *
+	 * @param string|null $description Input description.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_description( ?string $description ): InputInterface;
+
+	/**
+	 * Get value.
+	 *
+	 * @return mixed
+	 */
+	public function get_value();
+
+	/**
+	 * Set value.
+	 *
+	 * @param mixed $value Input value.
+	 *
+	 * @return InputInterface
+	 */
+	public function set_value( $value ): InputInterface;
+
+	/**
+	 * Return the id used for the input's view.
+	 *
+	 * @return string
+	 */
+	public function get_view_id(): string;
+}

--- a/src/Admin/Input/Select.php
+++ b/src/Admin/Input/Select.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Class Select
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Select
+ */
+class Select extends Input {
+	/**
+	 * Input options.
+	 *
+	 * @var array
+	 */
+	protected $options = array();
+
+	/**
+	 * Select constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'select' );
+	}
+
+	/**
+	 * Get options.
+	 *
+	 * @return array
+	 */
+	public function get_options(): array {
+		return $this->options;
+	}
+
+	/**
+	 * Set options.
+	 *
+	 * @param array $options List of options.
+	 *
+	 * @return $this
+	 */
+	public function set_options( array $options ): Select {
+		$this->options = $options;
+
+		return $this;
+	}
+
+	/**
+	 * Return the data used for the input's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array {
+		$view_data            = parent::get_view_data();
+		$view_data['options'] = $this->get_options();
+
+		// Add custom class.
+		$view_data['class'] = 'select short';
+
+		return $view_data;
+	}
+}

--- a/src/Admin/Product/Attributes/AttributesForm.php
+++ b/src/Admin/Product/Attributes/AttributesForm.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Class AttributesForm
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Admin\Input\Form;
+use Automattic\WooCommerce\Pinterest\Admin\Input\FormException;
+use Automattic\WooCommerce\Pinterest\Admin\Input\InputInterface;
+use Automattic\WooCommerce\Pinterest\Admin\Input\Select;
+use Automattic\WooCommerce\Pinterest\Admin\Input\SelectWithTextInput;
+use Automattic\WooCommerce\Pinterest\Exception\InvalidValue;
+use Automattic\WooCommerce\Pinterest\Exception\ValidateInterface;
+use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeInterface;
+use Automattic\WooCommerce\Pinterest\Product\Attributes\WithValueOptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AttributesForm
+ */
+class AttributesForm extends Form {
+
+	use ValidateInterface;
+
+	/**
+	 * Attribute types.
+	 *
+	 * @var string[]
+	 */
+	protected $attribute_types = array();
+
+	/**
+	 * AttributesForm constructor.
+	 *
+	 * @param string[] $attribute_types Attribute Types.
+	 * @param array    $data            Attribute data.
+	 */
+	public function __construct( array $attribute_types, array $data = array() ) {
+		foreach ( $attribute_types as $attribute_type ) {
+			$this->add_attribute( $attribute_type );
+		}
+
+		parent::__construct( $data );
+	}
+
+	/**
+	 * Return the data used for the input's view.
+	 *
+	 * @return array
+	 */
+	public function get_view_data(): array {
+		$view_data = parent::get_view_data();
+
+		// Add classes to hide/display attributes based on product type.
+		foreach ( $view_data['children'] as $index => $input ) {
+			if ( ! isset( $this->attribute_types[ $index ] ) ) {
+				continue;
+			}
+
+			$attribute_id     = $index;
+			$attribute_type   = $this->attribute_types[ $index ];
+			$applicable_types = call_user_func( array( $attribute_type, 'get_applicable_product_types' ) );
+
+			/**
+			 * This filter is documented in AttributeManager::map_attribute_types
+			 *
+			 * @see AttributeManager::map_attribute_types
+			 */
+			$applicable_types = apply_filters( "wc_pinterest_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
+
+			/**
+			 * Filters the list of product types to hide the attribute for.
+			 */
+			$hidden_types = apply_filters( "wc_pinterest_attribute_hidden_product_types_{$attribute_id}", array() );
+
+			$visible_types = array_diff( $applicable_types, $hidden_types );
+
+			$input['pinterest_wrapper_class'] = $input['pinterest_wrapper_class'] ?? '';
+
+			if ( ! empty( $visible_types ) ) {
+				$input['pinterest_wrapper_class'] .= ' show_if_' . join( ' show_if_', $visible_types );
+			}
+
+			if ( ! empty( $hidden_types ) ) {
+				$input['pinterest_wrapper_class'] .= ' hide_if_' . join( ' hide_if_', $hidden_types );
+			}
+
+			$view_data['children'][ $index ] = $input;
+		}
+
+		return $view_data;
+	}
+
+	/**
+	 * Initialize input.
+	 *
+	 * @param InputInterface     $input     Input interface.
+	 * @param AttributeInterface $attribute Attribute interface.
+	 *
+	 * @return InputInterface
+	 */
+	protected function init_input( InputInterface $input, AttributeInterface $attribute ) {
+		$input->set_id( $attribute::get_id() )
+			->set_name( $attribute::get_id() );
+
+		$value_options = array();
+		if ( $attribute instanceof WithValueOptionsInterface ) {
+			$value_options = $attribute::get_value_options();
+		}
+		$value_options = apply_filters( "wc_pinterest_product_attribute_value_options_{$attribute::get_id()}", $value_options );
+
+		if ( ! empty( $value_options ) ) {
+			if ( ! $input instanceof Select && ! $input instanceof SelectWithTextInput ) {
+				$new_input = new SelectWithTextInput();
+				$new_input->set_label( $input->get_label() )
+					->set_description( $input->get_description() );
+
+				return $this->init_input( $new_input, $attribute );
+			}
+
+			// Add a 'default' value option.
+			$value_options = array( '' => __( 'Default', 'pinterest-for-woocommerce' ) ) + $value_options;
+
+			$input->set_options( $value_options );
+		}
+
+		return $input;
+	}
+
+	/**
+	 * Add an attribute to the form
+	 *
+	 * @param string      $attribute_type An attribute class extending AttributeInterface.
+	 * @param string|null $input_type     An input class extending InputInterface to use for attribute input.
+	 *
+	 * @return AttributesForm
+	 *
+	 * @throws InvalidValue  If the attribute type is invalid or an invalid input type is specified for the attribute.
+	 * @throws FormException If form is already submitted.
+	 */
+	public function add_attribute( string $attribute_type, ?string $input_type = null ): AttributesForm {
+		$this->validate_interface( $attribute_type, AttributeInterface::class );
+
+		// use the attribute's default input type if none provided.
+		if ( empty( $input_type ) ) {
+			$input_type = call_user_func( array( $attribute_type, 'get_input_type' ) );
+		}
+
+		$this->validate_interface( $input_type, InputInterface::class );
+
+		$attribute_input = $this->init_input( new $input_type(), new $attribute_type() );
+		$this->add( $attribute_input );
+
+		$attribute_id                           = call_user_func( array( $attribute_type, 'get_id' ) );
+		$this->attribute_types[ $attribute_id ] = $attribute_type;
+
+		return $this;
+	}
+
+	/**
+	 * Remove an attribute from the form
+	 *
+	 * @param string $attribute_type An attribute class extending AttributeInterface.
+	 *
+	 * @return AttributesForm
+	 *
+	 * @throws InvalidValue  If the attribute type is invalid or an invalid input type is specified for the attribute.
+	 * @throws FormException If form is already submitted.
+	 */
+	public function remove_attribute( string $attribute_type ): AttributesForm {
+		$this->validate_interface( $attribute_type, AttributeInterface::class );
+
+		$attribute_id = call_user_func( array( $attribute_type, 'get_id' ) );
+		unset( $this->attribute_types[ $attribute_id ] );
+		$this->remove( $attribute_id );
+
+		return $this;
+	}
+
+	/**
+	 * Sets the input type for the given attribute.
+	 *
+	 * @param string $attribute_type Attribute type.
+	 * @param string $input_type     Input type.
+	 *
+	 * @return $this
+	 *
+	 * @throws FormException If form is already submitted.
+	 */
+	public function set_attribute_input( string $attribute_type, string $input_type ): AttributesForm {
+		if ( $this->is_submitted ) {
+			throw FormException::cannot_modify_submitted();
+		}
+
+		$this->validate_interface( $attribute_type, AttributeInterface::class );
+		$this->validate_interface( $input_type, InputInterface::class );
+
+		$attribute_id = call_user_func( array( $attribute_type, 'get_id' ) );
+		if ( $this->has( $attribute_id ) ) {
+			$this->children[ $attribute_id ] = $this->init_input( new $input_type(), new $attribute_type() );
+		}
+
+		return $this;
+	}
+}

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Class AttributesTab
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Admin\Admin;
+use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AttributesTab
+ */
+class AttributesTab {
+
+	/**
+	 * Admin class.
+	 *
+	 * @var Admin
+	 */
+	protected $admin;
+
+	/**
+	 * Attribute manager.
+	 *
+	 * @var AttributeManager
+	 */
+	protected $attribute_manager;
+
+	/**
+	 * AttributesTab constructor.
+	 *
+	 * @param Admin            $admin             Admin class.
+	 * @param AttributeManager $attribute_manager Attribute manager.
+	 */
+	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+		$this->admin             = $admin;
+		$this->attribute_manager = $attribute_manager;
+	}
+
+	/**
+	 * Register hooks.
+	 */
+	public function register(): void {
+		add_action(
+			'woocommerce_new_product',
+			function ( int $product_id, WC_Product $product ) {
+				$this->handle_update_product( $product );
+			},
+			10,
+			2
+		);
+		add_action(
+			'woocommerce_update_product',
+			function ( int $product_id, WC_Product $product ) {
+				$this->handle_update_product( $product );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_product_data_tabs',
+			function ( array $tabs ) {
+				return $this->add_tab( $tabs );
+			}
+		);
+		add_action(
+			'woocommerce_product_data_panels',
+			function () {
+				$this->render_panel();
+			}
+		);
+	}
+
+	/**
+	 * Adds the Pinterest tab to the WooCommerce product data box.
+	 *
+	 * @param array $tabs The current product data tabs.
+	 *
+	 * @return array An array with product tabs with the Pinterest tab added.
+	 */
+	private function add_tab( array $tabs ): array {
+		$shown_types = array_map(
+			function ( string $product_type ) {
+				return "show_if_${product_type}";
+			},
+			$this->get_applicable_product_types()
+		);
+
+		$classes = array_merge( array( 'pinterest' ), $shown_types );
+
+		$tabs['pinterest_attributes'] = array(
+			'label'  => 'Pinterest',
+			'class'  => join( ' ', $classes ),
+			'target' => 'pinterest_attributes',
+		);
+
+		return $tabs;
+	}
+
+	/**
+	 * Render the product attributes tab.
+	 */
+	private function render_panel() {
+		$product = wc_get_product( get_the_ID() );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->admin->get_view(
+			'attributes/tab-panel',
+			array(
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				'form' => $this->get_form( $product )->get_view_data(),
+			)
+		);
+	}
+
+	/**
+	 * Handle form submission and update the product attributes.
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 */
+	private function handle_update_product( WC_Product $product ) {
+		/**
+		 * Array of `true` values for each product IDs already handled by this method. Used to prevent double submission.
+		 *
+		 * @var bool[] $already_updated
+		 */
+		static $already_updated = array();
+		if ( isset( $already_updated[ $product->get_id() ] ) ) {
+			return;
+		}
+
+		$form           = $this->get_form( $product );
+		$form_view_data = $form->get_view_data();
+
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( empty( $_POST[ $form_view_data['name'] ] ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$submitted_data = (array) wc_clean( wp_unslash( $_POST[ $form_view_data['name'] ] ) );
+		// phpcs:enable WordPress.Security.NonceVerification
+
+		$form->submit( $submitted_data );
+		$this->update_data( $product, $form->get_data() );
+
+		$already_updated[ $product->get_id() ] = true;
+	}
+
+	/**
+	 * Get the attributes form.
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 *
+	 * @return AttributesForm
+	 */
+	protected function get_form( WC_Product $product ): AttributesForm {
+		$attribute_types = $this->attribute_manager->get_attribute_types_for_product_types( $this->get_applicable_product_types() );
+
+		$form = new AttributesForm( $attribute_types, $this->attribute_manager->get_all_values( $product ) );
+		$form->set_name( 'attributes' );
+
+		return $form;
+	}
+
+	/**
+	 * Return an array of WooCommerce product types that the Pinterest tab can be displayed for.
+	 *
+	 * @return array of WooCommerce product types (e.g. 'simple', 'variable', etc.)
+	 */
+	protected function get_applicable_product_types(): array {
+		return apply_filters( 'wc_pinterest_attributes_tab_applicable_product_types', array( 'simple', 'variable' ) );
+	}
+
+	/**
+	 * Update data.
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 * @param array      $data    Data to update.
+	 *
+	 * @return void
+	 */
+	protected function update_data( WC_Product $product, array $data ): void {
+		foreach ( $this->attribute_manager->get_attribute_types_for_product( $product ) as $attribute_id => $attribute_type ) {
+			if ( isset( $data[ $attribute_id ] ) ) {
+				$this->attribute_manager->update( $product, new $attribute_type( $data[ $attribute_id ] ) );
+			}
+		}
+	}
+
+}

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -37,12 +37,11 @@ class AttributesTab {
 	/**
 	 * AttributesTab constructor.
 	 *
-	 * @param Admin            $admin             Admin class.
-	 * @param AttributeManager $attribute_manager Attribute manager.
+	 * @param Admin $admin Admin class.
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin ) {
 		$this->admin             = $admin;
-		$this->attribute_manager = $attribute_manager;
+		$this->attribute_manager = AttributeManager::instance();
 	}
 
 	/**

--- a/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
+++ b/src/Admin/Product/Attributes/Input/AttributeInputInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Class AttributeInputInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Product\Attributes\Input
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Product\Attributes\Input;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AttributeInputInterface
+ */
+interface AttributeInputInterface {
+
+	/**
+	 * Returns a name for the attribute input.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string;
+
+	/**
+	 * Returns a short description for the attribute input.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string;
+
+	/**
+	 * Returns the input class used for the attribute input.
+	 *
+	 * Must be an instance of `InputInterface`.
+	 *
+	 * @return string
+	 */
+	public static function get_input_type(): string;
+
+}

--- a/src/Admin/Product/Attributes/Input/ConditionInput.php
+++ b/src/Admin/Product/Attributes/Input/ConditionInput.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class Condition
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Product\Attributes\Input;
+
+use Automattic\WooCommerce\Pinterest\Admin\Input\Select;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Condition
+ */
+class ConditionInput extends Select {
+
+	/**
+	 * ConditionInput constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->set_label( __( 'Condition', 'pinterest-for-woocommerce' ) );
+		$this->set_description( __( 'Condition or state of the item.', 'pinterest-for-woocommerce' ) );
+	}
+
+}

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Class VariationsAttributes
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Admin\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Admin\Admin;
+use Automattic\WooCommerce\Pinterest\Admin\Input\Form;
+use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
+use WC_Product_Variation;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class VariationsAttributes
+ */
+class VariationsAttributes {
+
+	/**
+	 * Admin class.
+	 *
+	 * @var Admin
+	 */
+	protected $admin;
+
+	/**
+	 * Attibute Manager.
+	 *
+	 * @var AttributeManager
+	 */
+	protected $attribute_manager;
+
+	/**
+	 * VariationsAttributes constructor.
+	 *
+	 * @param Admin            $admin             Admin class.
+	 * @param AttributeManager $attribute_manager Attribute manager.
+	 */
+	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+		$this->admin             = $admin;
+		$this->attribute_manager = $attribute_manager;
+	}
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'woocommerce_product_after_variable_attributes',
+			function ( int $variation_index, array $variation_data, WP_Post $variation ) {
+				$this->render_attributes_form( $variation_index, $variation );
+			},
+			90,
+			3
+		);
+		add_action(
+			'woocommerce_save_product_variation',
+			function ( int $variation_id, int $variation_index ) {
+				$this->handle_save_variation( $variation_id, $variation_index );
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Render the attributes form for variations.
+	 *
+	 * @param int     $variation_index Position in the loop.
+	 * @param WP_Post $variation       Post data.
+	 */
+	private function render_attributes_form( int $variation_index, WP_Post $variation ) {
+		/**
+		 * Product variation.
+		 *
+		 * @var WC_Product_Variation $product
+		 */
+		$product = wc_get_product( $variation->ID );
+
+		$data = $this->get_form( $product, $variation_index )->get_view_data();
+
+		// Do not render the form if it doesn't contain any child attributes.
+		$attributes = reset( $data['children'] );
+		if ( empty( $data['children'] ) || empty( $attributes['children'] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->admin->get_view( 'attributes/variations-form', $data );
+	}
+
+	/**
+	 * Handle form submission and update the product attributes.
+	 *
+	 * @param int $variation_id    Variation ID.
+	 * @param int $variation_index Variation index.
+	 */
+	private function handle_save_variation( int $variation_id, int $variation_index ) {
+		/**
+		 * Product variation.
+		 *
+		 * @var WC_Product_Variation $variation
+		 */
+		$variation = wc_get_product( $variation_id );
+
+		$form           = $this->get_form( $variation, $variation_index );
+		$form_view_data = $form->get_view_data();
+
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( empty( $_POST[ $form_view_data['name'] ] ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$submitted_data = (array) wc_clean( wp_unslash( $_POST[ $form_view_data['name'] ] ) );
+		// phpcs:enable WordPress.Security.NonceVerification
+
+		$form->submit( $submitted_data );
+		$form_data = $form->get_data();
+
+		if ( ! empty( $form_data[ $variation_index ] ) ) {
+			$this->update_data( $variation, $form_data[ $variation_index ] );
+		}
+	}
+
+	/**
+	 * Get form.
+	 *
+	 * @param WC_Product_Variation $variation       Product variation.
+	 * @param int                  $variation_index Variation index.
+	 *
+	 * @return Form
+	 */
+	protected function get_form( WC_Product_Variation $variation, int $variation_index ): Form {
+		$attribute_types = $this->attribute_manager->get_attribute_types_for_product( $variation );
+		$attribute_form  = new AttributesForm( $attribute_types );
+		$attribute_form->set_name( (string) $variation_index );
+
+		$form = new Form();
+		$form->set_name( 'variation_attributes' )
+			->add( $attribute_form )
+			->set_data(
+				array(
+					(string) $variation_index => $this->attribute_manager->get_all_values( $variation ),
+				)
+			);
+
+		return $form;
+	}
+
+	/**
+	 * Update data.
+	 *
+	 * @param WC_Product_Variation $variation Product variation.
+	 * @param array                $data      Product data.
+	 *
+	 * @return void
+	 */
+	protected function update_data( WC_Product_Variation $variation, array $data ): void {
+		foreach ( $this->attribute_manager->get_attribute_types_for_product( $variation ) as $attribute_id => $attribute_type ) {
+			if ( isset( $data[ $attribute_id ] ) ) {
+				$this->attribute_manager->update( $variation, new $attribute_type( $data[ $attribute_id ] ) );
+			}
+		}
+	}
+
+}

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -49,6 +49,7 @@ class VariationsAttributes {
 	 * Register a service.
 	 */
 	public function register(): void {
+		// Priority 90 to render after regular variation attributes.
 		add_action(
 			'woocommerce_product_after_variable_attributes',
 			function ( int $variation_index, array $variation_data, WP_Post $variation ) {

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -39,12 +39,11 @@ class VariationsAttributes {
 	/**
 	 * VariationsAttributes constructor.
 	 *
-	 * @param Admin            $admin             Admin class.
-	 * @param AttributeManager $attribute_manager Attribute manager.
+	 * @param Admin $admin Admin class.
 	 */
-	public function __construct( Admin $admin, AttributeManager $attribute_manager ) {
+	public function __construct( Admin $admin ) {
 		$this->admin             = $admin;
-		$this->attribute_manager = $attribute_manager;
+		$this->attribute_manager = AttributeManager::instance();
 	}
 	/**
 	 * Register a service.

--- a/src/Exception/InvalidClass.php
+++ b/src/Exception/InvalidClass.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Class InvalidClass
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use LogicException;
+
+/**
+ * Class InvalidClass
+ */
+class InvalidClass extends LogicException implements PinterestException {
+
+	/**
+	 * Create a new instance of the exception when a class should implement an interface but does not.
+	 *
+	 * @param string $class     The class name.
+	 * @param string $interface The interface name.
+	 *
+	 * @return static
+	 */
+	public static function should_implement( string $class, string $interface ) {
+		return new static(
+			sprintf(
+				'The class "%s" must implement the "%s" interface.',
+				$class,
+				$interface
+			)
+		);
+	}
+
+	/**
+	 * Create a new instance of the exception when a class should NOT implement an interface but it does.
+	 *
+	 * @param string $class     The class name.
+	 * @param string $interface The interface name.
+	 *
+	 * @return static
+	 */
+	public static function should_not_implement( string $class, string $interface ): InvalidClass {
+		return new static(
+			sprintf(
+				'The class "%s" must NOT implement the "%s" interface.',
+				$class,
+				$interface
+			)
+		);
+	}
+
+	/**
+	 * Create a new instance of the exception when a class should override a method but does not.
+	 *
+	 * @param string $class  The class name.
+	 * @param string $method The method name.
+	 *
+	 * @return static
+	 */
+	public static function should_override( string $class, string $method ) {
+		return new static(
+			sprintf(
+				'The class "%s" must override the "%s()" method.',
+				$class,
+				$method
+			)
+		);
+	}
+}

--- a/src/Exception/InvalidValue.php
+++ b/src/Exception/InvalidValue.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Class InvalidValue
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use LogicException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class InvalidValue
+ */
+class InvalidValue extends LogicException implements PinterestException {
+
+	/**
+	 * Create a new instance of the exception when a value is not a positive integer.
+	 *
+	 * @param string $method The method that requires a positive integer.
+	 *
+	 * @return static
+	 */
+	public static function negative_integer( string $method ) {
+		return new static( sprintf( 'The method "%s" requires a positive integer value.', $method ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value is not a string.
+	 *
+	 * @param string $key The name of the value.
+	 *
+	 * @return static
+	 */
+	public static function not_string( string $key ) {
+		return new static( sprintf( 'The value of %s must be of type string.', $key ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value is not a string.
+	 *
+	 * @param string $key The name of the value.
+	 *
+	 * @return static
+	 */
+	public static function not_integer( string $key ): InvalidValue {
+		return new static( sprintf( 'The value of %s must be of type integer.', $key ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value is not an instance of a given class.
+	 *
+	 * @param string $class_name The name of the class that the value must be an instance of.
+	 * @param string $key        The name of the value.
+	 *
+	 * @return static
+	 */
+	public static function not_instance_of( string $class_name, string $key ) {
+		return new static( sprintf( 'The value of %s must be an instance of %s.', $key, $class_name ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value is empty.
+	 *
+	 * @param string $key The name of the value.
+	 *
+	 * @return static
+	 *
+	 * @since 1.2.0
+	 */
+	public static function is_empty( string $key ): InvalidValue {
+		return new static( sprintf( 'The value of %s can not be empty.', $key ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value is not from a predefined list of allowed values.
+	 *
+	 * @param mixed $key            The name of the value.
+	 * @param array $allowed_values The list of allowed values.
+	 *
+	 * @return static
+	 */
+	public static function not_in_allowed_list( $key, array $allowed_values ): InvalidValue {
+		return new static( sprintf( 'The value of %s must be either of [%s].', $key, implode( ', ', $allowed_values ) ) );
+	}
+
+	/**
+	 * Create a new instance of the exception when a value isn't a valid product ID.
+	 *
+	 * @param mixed $value The provided product ID that isn't valid.
+	 *
+	 * @return static
+	 */
+	public static function not_valid_product_id( $value ): InvalidValue {
+		return new static( sprintf( 'Invalid product ID: %s', $value ) );
+	}
+}

--- a/src/Exception/PinterestException.php
+++ b/src/Exception/PinterestException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * PinterestException interface.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use Throwable;
+
+/**
+ * This interface is used for all of our exceptions so that we can easily catch only our own exceptions.
+ */
+interface PinterestException extends Throwable {}

--- a/src/Exception/ValidateInterface.php
+++ b/src/Exception/ValidateInterface.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Trait ValidateInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+/**
+ * Trait ValidateInterface
+ */
+trait ValidateInterface {
+
+	/**
+	 * Validate that a class implements a given interface.
+	 *
+	 * @param string $class     The class name.
+	 * @param string $interface The interface name.
+	 *
+	 * @throws InvalidClass When the given class does not implement the interface.
+	 */
+	protected function validate_interface( string $class, string $interface ) {
+		$implements = class_implements( $class );
+		if ( ! array_key_exists( $interface, $implements ) ) {
+			throw InvalidClass::should_implement( $class, $interface );
+		}
+	}
+
+	/**
+	 * Validate that an object is an instance of an interface.
+	 *
+	 * @param object $object    The object to validate.
+	 * @param string $interface The interface name.
+	 *
+	 * @throws InvalidClass When the given object does not implement the interface.
+	 */
+	protected function validate_instanceof( $object, string $interface ) {
+		$class = '';
+		if ( is_object( $object ) ) {
+			$class = get_class( $object );
+		}
+
+		if ( ! $object instanceof $interface ) {
+			throw InvalidClass::should_implement( $class, $interface );
+		}
+	}
+
+	/**
+	 * Validate that an object is NOT an instance of an interface.
+	 *
+	 * @param object $object    The object to validate.
+	 * @param string $interface The interface name.
+	 *
+	 * @throws InvalidClass When the given object implements the interface.
+	 */
+	protected function validate_not_instanceof( $object, string $interface ) {
+		$class = '';
+		if ( is_object( $object ) ) {
+			$class = get_class( $object );
+		}
+
+		if ( $object instanceof $interface ) {
+			throw InvalidClass::should_not_implement( $class, $interface );
+		}
+	}
+}

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Helper functions that are useful throughout the plugin.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest;
+
+/**
+ * Trait PluginHelper
+ */
+trait PluginHelper {
+
+	/**
+	 * Get the plugin slug.
+	 *
+	 * @return string
+	 */
+	protected function get_slug(): string {
+		return 'pinterest';
+	}
+
+	/**
+	 * Get the prefix used for plugin's metadata keys in the database.
+	 *
+	 * @return string
+	 */
+	protected function get_meta_key_prefix(): string {
+		return "_wc_{$this->get_slug()}";
+	}
+
+	/**
+	 * Prefix a meta data key with the plugin prefix.
+	 *
+	 * @param string $key Meta key name.
+	 *
+	 * @return string
+	 */
+	protected function prefix_meta_key( string $key ): string {
+		$prefix = $this->get_meta_key_prefix();
+
+		return "{$prefix}_{$key}";
+	}
+
+	/**
+	 * Check whether debugging mode is enabled.
+	 *
+	 * @return bool Whether debugging mode is enabled.
+	 */
+	protected function is_debug_mode(): bool {
+		return defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+
+}

--- a/src/Product/Attributes/AbstractAttribute.php
+++ b/src/Product/Attributes/AbstractAttribute.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Class AbstractAttribute
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Product\Attributes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AbstractAttribute
+ */
+abstract class AbstractAttribute implements AttributeInterface {
+
+	/**
+	 * Attribute value.
+	 *
+	 * @var mixed
+	 */
+	protected $value = null;
+
+	/**
+	 * AbstractAttribute constructor.
+	 *
+	 * @param mixed $value Attribute value.
+	 */
+	public function __construct( $value = null ) {
+		$this->set_value( $value );
+	}
+
+	/**
+	 * Return the attribute type. Must be a valid PHP type.
+	 *
+	 * @return string
+	 *
+	 * @link https://www.php.net/manual/en/function.settype.php
+	 */
+	public static function get_value_type(): string {
+		return 'string';
+	}
+
+	/**
+	 * Returns the attribute value.
+	 *
+	 * @return mixed
+	 */
+	public function get_value() {
+		return $this->value;
+	}
+
+	/**
+	 * Set the attribute value.
+	 *
+	 * @param mixed $value Attribute value.
+	 *
+	 * @return $this
+	 */
+	public function set_value( $value ): AbstractAttribute {
+		$this->value = $this->cast_value( $value );
+
+		return $this;
+	}
+
+	/**
+	 * Casts the value to the attribute value type and returns the result.
+	 *
+	 * @param mixed $value Attribute value.
+	 *
+	 * @return mixed
+	 */
+	protected function cast_value( $value ) {
+		if ( is_string( $value ) ) {
+			$value = trim( $value );
+
+			if ( '' === $value ) {
+				return null;
+			}
+		}
+
+		$value_type = static::get_value_type();
+		if ( in_array( $value_type, array( 'bool', 'boolean' ), true ) ) {
+			$value = wc_string_to_bool( $value );
+		} else {
+			settype( $value, $value_type );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Return an array of WooCommerce product types that this attribute can be applied to.
+	 *
+	 * @return array
+	 */
+	public static function get_applicable_product_types(): array {
+		return array( 'simple', 'variable', 'variation' );
+	}
+
+	/**
+	 * Magic method to convert to string.
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return (string) $this->get_value();
+	}
+
+}

--- a/src/Product/Attributes/AttributeInterface.php
+++ b/src/Product/Attributes/AttributeInterface.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Interface AttributeInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Admin\Product\Attributes\Input\AttributeInputInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface AttributeInterface
+ */
+interface AttributeInterface {
+
+	/**
+	 * Returns the attribute ID.
+	 *
+	 * @return string
+	 */
+	public static function get_id(): string;
+
+	/**
+	 * Return the attribute's value type. Must be a valid PHP type.
+	 *
+	 * @return string
+	 *
+	 * @link https://www.php.net/manual/en/function.settype.php
+	 */
+	public static function get_value_type(): string;
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 */
+	public static function get_input_type(): string;
+
+	/**
+	 * Return an array of WooCommerce product types that this attribute can be applied to.
+	 *
+	 * @return array
+	 */
+	public static function get_applicable_product_types(): array;
+
+	/**
+	 * Returns the attribute value.
+	 *
+	 * @return mixed
+	 */
+	public function get_value();
+
+}

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Class AttributeManager
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Exception\InvalidClass;
+use Automattic\WooCommerce\Pinterest\Exception\InvalidValue;
+use Automattic\WooCommerce\Pinterest\Exception\ValidateInterface;
+use Automattic\WooCommerce\Pinterest\PluginHelper;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AttributeManager
+ */
+class AttributeManager {
+
+	use PluginHelper;
+	use ValidateInterface;
+
+	protected const ATTRIBUTES = array(
+		Condition::class,
+	);
+
+	/**
+	 * Attribute types mapped to product types.
+	 *
+	 * @var array
+	 */
+	protected $attribute_types_map;
+
+	/**
+	 * Update product attribute.
+	 *
+	 * @param WC_Product         $product   WooCommerce product.
+	 * @param AttributeInterface $attribute Attribute to update.
+	 *
+	 * @throws InvalidValue If the attribute is invalid for the given product.
+	 */
+	public function update( WC_Product $product, AttributeInterface $attribute ) {
+		$this->validate( $product, $attribute::get_id() );
+
+		if ( null === $attribute->get_value() || '' === $attribute->get_value() ) {
+			$this->delete( $product, $attribute::get_id() );
+			return;
+		}
+
+		$value = $attribute->get_value();
+		if ( in_array( $attribute::get_value_type(), array( 'bool', 'boolean' ), true ) ) {
+			$value = wc_bool_to_string( $value );
+		}
+
+		$product->update_meta_data( $this->prefix_meta_key( $attribute::get_id() ), $value );
+		$product->save_meta_data();
+	}
+
+	/**
+	 * Get a product attribute.
+	 *
+	 * @param WC_Product $product      WooCommerce product.
+	 * @param string     $attribute_id Attribute ID.
+	 *
+	 * @return AttributeInterface|null
+	 *
+	 * @throws InvalidValue If the attribute ID is invalid for the given product.
+	 */
+	public function get( WC_Product $product, string $attribute_id ): ?AttributeInterface {
+		$this->validate( $product, $attribute_id );
+
+		$value = null;
+		if ( $this->exists( $product, $attribute_id ) ) {
+			$value = $product->get_meta( $this->prefix_meta_key( $attribute_id ), true );
+		}
+
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+
+		$attribute_class = $this->get_attribute_types_for_product( $product )[ $attribute_id ];
+		return new $attribute_class( $value );
+	}
+
+	/**
+	 * Return attribute value.
+	 *
+	 * @param WC_Product $product      WooCommerce product.
+	 * @param string     $attribute_id Attribute ID.
+	 *
+	 * @return mixed|null
+	 */
+	public function get_value( WC_Product $product, string $attribute_id ) {
+		$attribute = $this->get( $product, $attribute_id );
+
+		return $attribute instanceof AttributeInterface ? $attribute->get_value() : null;
+	}
+
+	/**
+	 * Return all attributes for the given product
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 *
+	 * @return AttributeInterface[]
+	 */
+	public function get_all( WC_Product $product ): array {
+		$all_attributes = array();
+		foreach ( array_keys( $this->get_attribute_types_for_product( $product ) ) as $attribute_id ) {
+			$attribute = $this->get( $product, $attribute_id );
+			if ( null !== $attribute ) {
+				$all_attributes[ $attribute_id ] = $attribute;
+			}
+		}
+
+		return $all_attributes;
+	}
+
+	/**
+	 * Return all attribute values for the given product
+	 *
+	 * @param WC_Product $product WooCommerce Product.
+	 *
+	 * @return array of attribute values
+	 */
+	public function get_all_values( WC_Product $product ): array {
+		$all_attributes = array();
+		foreach ( array_keys( $this->get_attribute_types_for_product( $product ) ) as $attribute_id ) {
+			$attribute = $this->get_value( $product, $attribute_id );
+			if ( null !== $attribute ) {
+				$all_attributes[ $attribute_id ] = $attribute;
+			}
+		}
+
+		return $all_attributes;
+	}
+
+	/**
+	 * Delete attribute data for a product.
+	 *
+	 * @param WC_Product $product      WooCommerce Product.
+	 * @param string     $attribute_id Attribute ID.
+	 *
+	 * @throws InvalidValue If the attribute ID is invalid for the given product.
+	 */
+	public function delete( WC_Product $product, string $attribute_id ) {
+		$this->validate( $product, $attribute_id );
+
+		$product->delete_meta_data( $this->prefix_meta_key( $attribute_id ) );
+		$product->save_meta_data();
+	}
+
+	/**
+	 * Whether the attribute exists and has been set for the product.
+	 *
+	 * @param WC_Product $product      WooCommerce Product.
+	 * @param string     $attribute_id Attribute ID.
+	 *
+	 * @return bool
+	 */
+	public function exists( WC_Product $product, string $attribute_id ): bool {
+		return $product->meta_exists( $this->prefix_meta_key( $attribute_id ) );
+	}
+
+	/**
+	 * Returns an array of attribute types for the given product
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 *
+	 * @return string[] of attribute classes mapped to attribute IDs
+	 */
+	public function get_attribute_types_for_product( WC_Product $product ): array {
+		return $this->get_attribute_types_for_product_types( array( $product->get_type() ) );
+	}
+
+	/**
+	 * Returns an array of attribute types for the given product types
+	 *
+	 * @param string[] $product_types Array of WooCommerce product types.
+	 *
+	 * @return string[] of attribute classes mapped to attribute IDs
+	 */
+	public function get_attribute_types_for_product_types( array $product_types ): array {
+		// Flip the product types array to have them as array keys.
+		$product_types_keys = array_flip( $product_types );
+
+		// Intersect the product types with our stored attributes map to get arrays of attributes matching the given product types.
+		$match_attributes = array_intersect_key( $this->get_attribute_types_map(), $product_types_keys );
+
+		// Re-index the attributes map array to avoid string ($product_type) array keys.
+		$match_attributes = array_values( $match_attributes );
+
+		if ( empty( $match_attributes ) ) {
+			return array();
+		}
+
+		// Merge all of the attribute arrays from the map (there might be duplicates) and return the results.
+		return array_merge( ...$match_attributes );
+	}
+
+	/**
+	 * Returns all available attribute IDs.
+	 *
+	 * @return array
+	 *
+	 * @since 1.3.0
+	 */
+	public static function get_available_attribute_ids(): array {
+		$attributes = array();
+		foreach ( self::get_available_attribute_types() as $attribute_type ) {
+			if ( method_exists( $attribute_type, 'get_id' ) ) {
+				$attribute_id                = call_user_func( array( $attribute_type, 'get_id' ) );
+				$attributes[ $attribute_id ] = $attribute_id;
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Return an array of all available attribute class names.
+	 *
+	 * @return string[] Attribute class names
+	 */
+	public static function get_available_attribute_types(): array {
+		/**
+		 * Filters the list of available product attributes.
+		 *
+		 * @param string[] $attributes Array of attribute class names (FQN)
+		 */
+		return apply_filters( 'wc_pinterest_product_attribute_types', self::ATTRIBUTES );
+	}
+
+	/**
+	 * Returns an array of attribute types for all product types
+	 *
+	 * @return string[][] of attribute classes mapped to product types
+	 */
+	protected function get_attribute_types_map(): array {
+		if ( ! isset( $this->attribute_types_map ) ) {
+			$this->map_attribute_types();
+		}
+
+		return $this->attribute_types_map;
+	}
+
+	/**
+	 * Validate product attribute.
+	 *
+	 * @param WC_Product $product      WooCommerce product.
+	 * @param string     $attribute_id Attribute ID.
+	 *
+	 * @throws InvalidValue If the attribute type is invalid for the given product.
+	 */
+	protected function validate( WC_Product $product, string $attribute_id ) {
+		$attribute_types = $this->get_attribute_types_for_product( $product );
+		if ( ! isset( $attribute_types[ $attribute_id ] ) ) {
+			do_action(
+				'wc_pinterest_error',
+				sprintf( 'Attribute "%s" is not supported for a "%s" product (ID: %s).', $attribute_id, $product->get_type(), $product->get_id() ),
+				__METHOD__
+			);
+
+			throw InvalidValue::not_in_allowed_list( 'attribute_id', array_keys( $attribute_types ) );
+		}
+	}
+
+	/**
+	 * Map attribute types.
+	 *
+	 * @throws InvalidClass If any of the given attribute classes do not implement the AttributeInterface.
+	 */
+	protected function map_attribute_types(): void {
+		$this->attribute_types_map = array();
+		foreach ( self::get_available_attribute_types() as $attribute_type ) {
+			$this->validate_interface( $attribute_type, AttributeInterface::class );
+
+			$attribute_id     = call_user_func( array( $attribute_type, 'get_id' ) );
+			$applicable_types = call_user_func( array( $attribute_type, 'get_applicable_product_types' ) );
+
+			/**
+			 * Filters the list of applicable product types for each attribute.
+			 *
+			 * @param string[] $applicable_types Array of WooCommerce product types
+			 * @param string   $attribute_type   Attribute class name (FQN)
+			 */
+			$applicable_types = apply_filters( "wc_pinterest_attribute_applicable_product_types_{$attribute_id}", $applicable_types, $attribute_type );
+
+			foreach ( $applicable_types as $product_type ) {
+				$this->attribute_types_map[ $product_type ]                  = $this->attribute_types_map[ $product_type ] ?? array();
+				$this->attribute_types_map[ $product_type ][ $attribute_id ] = $attribute_type;
+			}
+		}
+	}
+}

--- a/src/Product/Attributes/AttributeManager.php
+++ b/src/Product/Attributes/AttributeManager.php
@@ -25,6 +25,13 @@ class AttributeManager {
 	use PluginHelper;
 	use ValidateInterface;
 
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var AttributeManager
+	 */
+	protected static $instance = null;
+
 	protected const ATTRIBUTES = array(
 		Condition::class,
 	);
@@ -35,6 +42,18 @@ class AttributeManager {
 	 * @var array
 	 */
 	protected $attribute_types_map;
+
+	/**
+	 * Load single instance of class.
+	 *
+	 * @return AttributeManager Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
 	/**
 	 * Update product attribute.

--- a/src/Product/Attributes/Condition.php
+++ b/src/Product/Attributes/Condition.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class Condition
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Product\Attributes;
+
+use Automattic\WooCommerce\Pinterest\Admin\Product\Attributes\Input\ConditionInput;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Condition
+ */
+class Condition extends AbstractAttribute implements WithValueOptionsInterface {
+
+	/**
+	 * Returns the attribute ID.
+	 *
+	 * @return string
+	 */
+	public static function get_id(): string {
+		return 'condition';
+	}
+
+	/**
+	 * Return an array of WooCommerce product types that this attribute can be applied to.
+	 *
+	 * @return array
+	 */
+	public static function get_applicable_product_types(): array {
+		return array( 'simple', 'variation' );
+	}
+
+	/**
+	 * Return an array of values available to choose for the attribute.
+	 *
+	 * Note: array key is used as the option key.
+	 *
+	 * @return array
+	 */
+	public static function get_value_options(): array {
+		return array(
+			'new'         => __( 'New', 'pinterest-for-woocommerce' ),
+			'refurbished' => __( 'Refurbished', 'pinterest-for-woocommerce' ),
+			'used'        => __( 'Used', 'pinterest-for-woocommerce' ),
+		);
+	}
+
+	/**
+	 * Return the attribute's input class. Must be an instance of `AttributeInputInterface`.
+	 *
+	 * @return string
+	 *
+	 * @see AttributeInputInterface
+	 */
+	public static function get_input_type(): string {
+		return ConditionInput::class;
+	}
+
+}

--- a/src/Product/Attributes/WithValueOptionsInterface.php
+++ b/src/Product/Attributes/WithValueOptionsInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Interface WithValueOptionsInterface
+ *
+ * @package Automattic\WooCommerce\Pinterest\Product\Attributes
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Product\Attributes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface WithValueOptionsInterface
+ */
+interface WithValueOptionsInterface {
+	/**
+	 * Return an array of values available to choose for the attribute.
+	 *
+	 * Note: array key is used as the option key.
+	 *
+	 * @return array
+	 */
+	public static function get_value_options(): array;
+}

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -90,6 +90,8 @@ class ProductsXmlFeed {
 
 	/**
 	 * Get the XML for all the product attributes.
+	 * Will only return the attributes which have been set
+	 * or are available for the product type.
 	 *
 	 * @param WC_Product $product WooCommerce product.
 	 * @param string     $indent  Line indentation string.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -100,8 +100,9 @@ class ProductsXmlFeed {
 		$attributes        = $attribute_manager->get_all_values( $product );
 		$xml               = '';
 
-		foreach ( $attributes as $property => $value ) {
-			$xml .= "{$indent}<{$property}>{$value}</{$property}>" . PHP_EOL;
+		foreach ( $attributes as $name => $value ) {
+			$property = "g:{$name}";
+			$xml     .= "{$indent}<{$property}>{$value}</{$property}>" . PHP_EOL;
 		}
 
 		return $xml;

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -79,11 +81,31 @@ class ProductsXmlFeed {
 			}
 		}
 
+		$xml .= self::get_attributes_xml( $product, "\t\t\t" );
+
 		$xml .= "\t\t</item>" . PHP_EOL;
 
 		return apply_filters( 'pinterest_for_woocommerce_feed_item_xml', $xml, $product );
 	}
 
+	/**
+	 * Get the XML for all the product attributes.
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 * @param string     $indent  Line indentation string.
+	 * @return string XML string.
+	 */
+	private static function get_attributes_xml( $product, $indent ) {
+		$attribute_manager = AttributeManager::instance();
+		$attributes        = $attribute_manager->get_all_values( $product );
+		$xml               = '';
+
+		foreach ( $attributes as $property => $value ) {
+			$xml .= "{$indent}<{$property}>{$value}</{$property}>" . PHP_EOL;
+		}
+
+		return $xml;
+	}
 
 	/**
 	 * Returns the Product ID.

--- a/src/View/PHPView.php
+++ b/src/View/PHPView.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Class PHPView
+ *
+ * @package Automattic\WooCommerce\Pinterest\View
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+use Automattic\WooCommerce\Pinterest\PluginHelper;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PHPView
+ */
+class PHPView implements View {
+
+	use PluginHelper;
+
+	/**
+	 * Extension to use for view files.
+	 */
+	protected const VIEW_EXTENSION = 'php';
+
+	/**
+	 * Path to the view file to render.
+	 *
+	 * @var string
+	 */
+	protected $path;
+
+	/**
+	 * Internal storage for passed-in context.
+	 *
+	 * @var array
+	 */
+	protected $context = array();
+
+	/**
+	 * View factory.
+	 *
+	 * @var ViewFactory
+	 */
+	protected $view_factory;
+
+	/**
+	 * PHPView constructor.
+	 *
+	 * @param string      $path         Path to the view file to render.
+	 * @param ViewFactory $view_factory View factory instance to use.
+	 *
+	 * @throws ViewException If an invalid path was passed into the View.
+	 */
+	public function __construct( string $path, ViewFactory $view_factory ) {
+		$this->path         = $this->validate( $path );
+		$this->view_factory = $view_factory;
+	}
+
+	/**
+	 * Render the current view with a given context.
+	 *
+	 * @param array $context Context in which to render.
+	 *
+	 * @return string Rendered HTML.
+	 *
+	 * @throws ViewException If the view could not be loaded.
+	 */
+	public function render( array $context = array() ): string {
+		// Add entire context as array to the current instance to pass onto
+		// partial views.
+		$this->context = $context;
+
+		// Save current buffering level so we can backtrack in case of an error.
+		// This is needed because the view itself might also add an unknown
+		// number of output buffering levels.
+		$buffer_level = ob_get_level();
+		ob_start();
+
+		try {
+			include $this->path;
+		} catch ( Exception $exception ) {
+			// Remove whatever levels were added up until now.
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
+
+			do_action( 'wc_pinterest_exception', $exception, __METHOD__ );
+
+			throw ViewException::invalid_view_exception(
+				$this->path,
+				$exception
+			);
+		}
+
+		return ob_get_clean() ?: '';
+	}
+
+	/**
+	 * Render a partial view.
+	 *
+	 * This can be used from within a currently rendered view, to include
+	 * nested partials.
+	 *
+	 * The passed-in context is optional, and will fall back to the parent's
+	 * context if omitted.
+	 *
+	 * @param string     $path    Path of the partial to render.
+	 * @param array|null $context Context in which to render the partial.
+	 *
+	 * @return string Rendered HTML.
+	 *
+	 * @throws ViewException If the view could not be loaded or the provided path was not valid.
+	 */
+	public function render_partial( string $path, array $context = null ): string {
+		return $this->view_factory->create( $path )->render( $context ?: $this->context );
+	}
+
+	/**
+	 * Return the raw value of a context property.
+	 *
+	 * By default, properties are automatically escaped when accessing them
+	 * within the view. This method allows direct access to the raw value
+	 * instead to bypass this automatic escaping.
+	 *
+	 * @param string $property Property for which to return the raw value.
+	 *
+	 * @return mixed Raw context property value.
+	 *
+	 * @throws ViewException If a requested property is not recognized (only in debugging mode).
+	 */
+	public function raw( string $property ) {
+		if ( array_key_exists( $property, $this->context ) ) {
+			return $this->context[ $property ];
+		}
+
+		do_action( 'wc_pinterest_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
+
+		/*
+		 * We only throw an exception here if we are in debugging mode, as we
+		 * don't want to take the server down when trying to render a missing
+		 * property.
+		 */
+		if ( $this->is_debug_mode() ) {
+			throw ViewException::invalid_context_property( $property );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Validate a path.
+	 *
+	 * @param string $path Path to validate.
+	 *
+	 * @return string Validated path.
+	 *
+	 * @throws ViewException If an invalid path was passed into the View.
+	 */
+	protected function validate( string $path ): string {
+		$path = $this->check_extension( $path, static::VIEW_EXTENSION );
+		$path = path_join( $this->get_views_base_path(), $path );
+
+		if ( ! is_readable( $path ) ) {
+			do_action( 'wc_pinterest_error', sprintf( 'View not found in path "%s".', $path ), __METHOD__ );
+
+			throw ViewException::invalid_path( $path );
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Check that the path has the correct extension.
+	 *
+	 * Optionally adds the extension if none was detected.
+	 *
+	 * @param string $path      Path to check the extension of.
+	 * @param string $extension Extension to use.
+	 *
+	 * @return string Path with correct extension.
+	 */
+	protected function check_extension( string $path, string $extension ): string {
+		$detected_extension = pathinfo( $path, PATHINFO_EXTENSION );
+
+		if ( $extension !== $detected_extension ) {
+			$path .= '.' . $extension;
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Use magic getter to provide automatic escaping by default.
+	 *
+	 * Use the raw() method to skip automatic escaping.
+	 *
+	 * @param string $property Property to get.
+	 *
+	 * @return mixed
+	 *
+	 * @throws ViewException If a requested property is not recognized (only in debugging mode).
+	 */
+	public function __get( string $property ) {
+		if ( array_key_exists( $property, $this->context ) ) {
+			return $this->sanitize_context_variable( $this->context[ $property ] );
+		}
+
+		do_action( 'wc_pinterest_error', sprintf( 'View property "%s" is missing or undefined.', $property ), __METHOD__ );
+
+		/*
+		 * We only throw an exception here if we are in debugging mode, as we
+		 * don't want to take the server down when trying to render a missing
+		 * property.
+		 */
+		if ( $this->is_debug_mode() ) {
+			throw ViewException::invalid_context_property( $property );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Sanitize context variable.
+	 *
+	 * @param mixed $var Variable to sanitize.
+	 */
+	protected function sanitize_context_variable( $var ) {
+		if ( is_array( $var ) ) {
+			return array_map( array( $this, 'sanitize_context_variable' ), $var );
+		} else {
+			return ! is_bool( $var ) && is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
+		}
+	}
+
+	/**
+	 * Get base path for the view.
+	 *
+	 * @return string
+	 */
+	protected function get_views_base_path(): string {
+		return path_join( dirname( __DIR__, 2 ), 'views' );
+	}
+}

--- a/src/View/PHPView.php
+++ b/src/View/PHPView.php
@@ -96,7 +96,12 @@ class PHPView implements View {
 			);
 		}
 
-		return ob_get_clean() ?: '';
+		$output = ob_get_clean();
+		if ( ! $output ) {
+			$output = '';
+		}
+
+		return $output;
 	}
 
 	/**
@@ -116,7 +121,11 @@ class PHPView implements View {
 	 * @throws ViewException If the view could not be loaded or the provided path was not valid.
 	 */
 	public function render_partial( string $path, array $context = null ): string {
-		return $this->view_factory->create( $path )->render( $context ?: $this->context );
+		if ( ! $context ) {
+			$context = $this->context;
+		}
+
+		return $this->view_factory->create( $path )->render( $context );
 	}
 
 	/**

--- a/src/View/PHPViewFactory.php
+++ b/src/View/PHPViewFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class PHPViewFactory
+ *
+ * @package Automattic\WooCommerce\Pinterest\View
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PHPViewFactory
+ */
+final class PHPViewFactory implements ViewFactory {
+
+	/**
+	 * Create a new view object.
+	 *
+	 * @param string $path Path to the view file to render.
+	 *
+	 * @return View Instantiated view object.
+	 *
+	 * @throws ViewException If an invalid path was passed into the View.
+	 */
+	public function create( string $path ): View {
+		return new PHPView( $path, $this );
+	}
+}

--- a/src/View/Renderable.php
+++ b/src/View/Renderable.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Interface Renderable
+ *
+ * @package Automattic\WooCommerce\Pinterest\Infrastructure
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Used to designate an object that can be rendered (e.g. views, blocks, shortcodes, etc.).
+ */
+interface Renderable {
+
+	/**
+	 * Render the renderable.
+	 *
+	 * @param array $context Optional. Contextual information to use while
+	 *                       rendering. Defaults to an empty array.
+	 *
+	 * @return string Rendered result.
+	 */
+	public function render( array $context = array() ): string;
+}

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Interface View
+ *
+ * @package Automattic\WooCommerce\Pinterest\View
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+use Automattic\WooCommerce\Pinterest\View\ViewException;
+
+defined( 'ABSPATH' ) || exit;
+
+interface View extends Renderable {
+	/**
+	 * Render the current view with a given context.
+	 *
+	 * @param array $context Context in which to render.
+	 *
+	 * @return string Rendered HTML.
+	 *
+	 * @throws ViewException If the view could not be loaded.
+	 */
+	public function render( array $context = array() ): string;
+
+	/**
+	 * Render a partial view.
+	 *
+	 * This can be used from within a currently rendered view, to include
+	 * nested partials.
+	 *
+	 * The passed-in context is optional, and will fall back to the parent's
+	 * context if omitted.
+	 *
+	 * @param string     $path    Path of the partial to render.
+	 * @param array|null $context Context in which to render the partial.
+	 *
+	 * @return string Rendered HTML.
+	 *
+	 * @throws ViewException If the view could not be loaded or provided path was not valid.
+	 */
+	public function render_partial( string $path, array $context = null ): string;
+
+	/**
+	 * Return the raw value of a context property.
+	 *
+	 * By default, properties are automatically escaped when accessing them
+	 * within the view. This method allows direct access to the raw value
+	 * instead to bypass this automatic escaping.
+	 *
+	 * @param string $property Property for which to return the raw value.
+	 *
+	 * @return mixed Raw context property value.
+	 */
+	public function raw( string $property );
+}

--- a/src/View/ViewException.php
+++ b/src/View/ViewException.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class ViewException
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+use Automattic\WooCommerce\Pinterest\Exception\PinterestException;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ViewException
+ */
+class ViewException extends Exception implements PinterestException {
+
+	/**
+	 * Create a new instance of the exception if the view file itself created
+	 * an exception.
+	 *
+	 * @param string    $uri       URI of the file that is not accessible or
+	 *                             not readable.
+	 * @param Exception $exception Exception that was thrown by the view file.
+	 *
+	 * @return static
+	 */
+	public static function invalid_view_exception( string $uri, Exception $exception ) {
+		$message = sprintf(
+			'Could not load the View URI "%1$s". Reason: "%2$s".',
+			$uri,
+			$exception->getMessage()
+		);
+
+		return new static( $message, (int) $exception->getCode(), $exception );
+	}
+
+	/**
+	 * Create a new instance of the exception for a file that is not accessible
+	 * or not readable.
+	 *
+	 * @param string $path Path of the file that is not accessible or not
+	 *                     readable.
+	 *
+	 * @return static
+	 */
+	public static function invalid_path( $path ) {
+		$message = sprintf(
+			'The view path "%s" is not accessible or readable.',
+			$path
+		);
+
+		return new static( $message );
+	}
+
+	/**
+	 * Create a new instance of the exception for a context property that is
+	 * not recognized.
+	 *
+	 * @param string $property Name of the context property that was not recognized.
+	 *
+	 * @return static
+	 */
+	public static function invalid_context_property( string $property ) {
+		$message = sprintf(
+			'The property "%s" could not be found within the context of the currently rendered view.',
+			$property
+		);
+
+		return new static( $message );
+	}
+}

--- a/src/View/ViewFactory.php
+++ b/src/View/ViewFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Interface ViewFactory
+ *
+ * @package Automattic\WooCommerce\Pinterest\View
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\View;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface ViewFactory
+ */
+interface ViewFactory {
+
+	/**
+	 * Create a new view object.
+	 *
+	 * @param string $path Path to the view file to render.
+	 *
+	 * @return View Instantiated view object.
+	 */
+	public function create( string $path ): View;
+}

--- a/views/attributes/tab-panel.php
+++ b/views/attributes/tab-panel.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tab panel view
+ *
+ * @package Automattic\WooCommerce\Pinterest\View\PHPView
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Pinterest\View\PHPView;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP view.
+ *
+ * @var PHPView $this
+ */
+
+/**
+ * Form
+ *
+ * @var array $form
+ */
+$form = $this->form
+
+?>
+
+<div id="pinterest_attributes" class="panel woocommerce_options_panel">
+	<h2><?php esc_html_e( 'Product attributes', 'pinterest-for-woocommerce' ); ?></h2>
+	<p class="show_if_variable"><?php esc_html_e( 'As this is a variable product, you can add additional product attributes by going to Variations > Select one variation > Pinterest.', 'pinterest-for-woocommerce' ); ?></p>
+	<?php
+	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo $this->render_partial( 'inputs/form', array( 'form' => $form ) );
+	?>
+</div>
+

--- a/views/attributes/variations-form.php
+++ b/views/attributes/variations-form.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Variation forms.
+ *
+ * @package Automattic\WooCommerce\Pinterest\View\PHPView
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Pinterest\Admin\Input\SelectWithTextInput;
+use Automattic\WooCommerce\Pinterest\View\PHPView;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP view.
+ *
+ * @var PHPView $this
+ */
+
+/**
+ * Form children.
+ *
+ * @var array $children
+ */
+$children = $this->children;
+?>
+
+<?php if ( $this->is_root ) : ?>
+<div class="pinterest-metabox wc-metabox closed">
+	<h3>
+		<strong><?php esc_html_e( 'Pinterest', 'pinterest-for-woocommerce' ); ?></strong>
+		<div class="handlediv" aria-label="Click to toggle"></div>
+	</h3>
+	<div class="wc-metabox-content" style="display: none;">
+	<?php endif; ?>
+	<?php
+	foreach ( $children as $form ) {
+		if ( ! empty( $form['type'] ) ) {
+			$form['wrapper_class'] =
+				sprintf( '%s %s', $form['wrapper_class'] ?? '', 'form-row form-row-full' );
+
+			if ( 'select-with-text-input' === $form['type'] && ! empty( $form['children'][ SelectWithTextInput::SELECT_INPUT_KEY ] ) && ! empty( $form['children'][ SelectWithTextInput::CUSTOM_INPUT_KEY ] ) ) {
+				$form['children'][ SelectWithTextInput::SELECT_INPUT_KEY ]['wrapper_class'] =
+					sprintf( '%s %s', $form['children'][ SelectWithTextInput::SELECT_INPUT_KEY ]['wrapper_class'] ?? '', 'form-row form-row-first' );
+
+				$form['children'][ SelectWithTextInput::CUSTOM_INPUT_KEY ]['wrapper_class'] =
+					sprintf( '%s %s', $form['children'][ SelectWithTextInput::CUSTOM_INPUT_KEY ]['wrapper_class'] ?? '', 'form-row form-row-last' );
+			}
+
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $this->render_partial( 'inputs/form', array( 'form' => $form ) );
+		} else {
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $this->render_partial( 'attributes/variations-form', $form );
+		}
+	}
+	?>
+	<?php if ( $this->is_root ) : ?>
+	</div>
+</div>
+<?php endif; ?>

--- a/views/inputs/form.php
+++ b/views/inputs/form.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Form
+ *
+ * @package Automattic\WooCommerce\Pinterest\View\PHPView
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP view.
+ *
+ * @var \Automattic\WooCommerce\Pinterest\View\PHPView $this
+ */
+
+/**
+ * Form.
+ *
+ * @var array $form
+ */
+$form = $this->form;
+?>
+
+<div class="pinterest-input <?php echo esc_attr( $form['pinterest_wrapper_class'] ?? '' ); ?>">
+	<?php
+	if ( ! empty( $form['type'] ) ) {
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->render_partial( path_join( 'inputs/', $form['type'] ), array( 'input' => $form ) );
+	}
+
+	if ( ! empty( $form['children'] ) ) {
+		foreach ( $form['children'] as $form ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $this->render_partial( 'inputs/form', array( 'form' => $form ) );
+		}
+	}
+	?>
+</div>
+
+

--- a/views/inputs/select.php
+++ b/views/inputs/select.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Input.
+ *
+ * @package Automattic\WooCommerce\Pinterest\View\PHPView
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PHP View.
+ *
+ * @var \Automattic\WooCommerce\Pinterest\View\PHPView $this
+ */
+
+/**
+ * Input.
+ *
+ * @var array $input
+ */
+$input = $this->input;
+
+woocommerce_wp_select( $input );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,4 +50,17 @@ const SetupTask = {
 	},
 };
 
-module.exports = [ SetupGuide, SetupTask ];
+// Webpack config for product-attributes.
+const ProductAttributes = {
+	...defaultConfig,
+	plugins: ourPlugins,
+	entry: {
+		index: './assets/source/product-attributes/index.js',
+	},
+	output: {
+		filename: '[name].js',
+		path: __dirname + '/assets/product-attributes',
+	},
+};
+
+module.exports = [ SetupGuide, SetupTask, ProductAttributes ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves part of #195 

This PR adds the product attribute functionality based on the Google Listings and Ads extension. This initial PR copies the basic framework for adding product attributes and includes the first attribute (condition).

Overview of changes:
- Add PHP view framework for displaying input elements in the backend
- Add Admin class for loading the backend resources
- Add product attributes and a manager to handle multiple attributes
- Add initial condition attribute
- Compile CSS and load it for product editing pages
- Add the attributes to the XML feed

### Detailed test instructions:

1. Update to this PR 
2. Set the condition in the Pinterest tab when editing several products
3. Set the conditions in the Pinterest tab when editing several variations
4. Regenerate the feed and monitor the list of the issues (Note: I haven't found a good way to speed up the regeneration of a feed besides waiting 24h)
5. Check the issues list and confirm that the condition warning is no longer shown for the products you edited.
![image](https://user-images.githubusercontent.com/11388669/146349469-9ebac170-f3ac-4e2b-b063-eb167dacc81c.png)
6. Check the XML feed and confirm we see the condition added as follows:
```
<g:condition>new</g:condition>
```

### Changelog entry

* Add - Product attribute for condition.

