### PR TITLE
Add `wcadmin_pfw_setup` tracking events.

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -58,14 +58,14 @@ Clicking on an external documentation link.
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 	- with `{ link_id: 'ad-guidelines', context: props.view }`
 	- with `{ link_id: 'merchant-guidelines', context: props.view }`
-- [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L50)
+- [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L53)
 	- with `{ link_id: 'ad-guidelines', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
-- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L36) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L47) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 
-### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L208)
+### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L222)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 |   |   |   |
@@ -73,7 +73,7 @@ Clicking on getting started page faq item to collapse or expand it.
 `action` | `string` | `'expand' \| 'collapse'` What action was initiated.
 `question_id` | `string` | Identifier of the clicked question.
 #### Emitters
-- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L227) whenever the FAQ is toggled.
+- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L241) whenever the FAQ is toggled.
 
 ### [`wcadmin_pfw_get_started_notice_link_click`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L16)
 Clicking on the link inside the notice.
@@ -124,6 +124,24 @@ Clicking on "… Save changes" button.
 `context` | `string` | The context in which the event is recorded
 #### Emitters
 - [`SaveSettingsButton`](assets/source/setup-guide/app/components/SaveSettingsButton.js#L41) with `{ context: view, … }`
+
+### [`wcadmin_pfw_setup`](assets/source/setup-guide/app/views/LandingPageApp.js#L28)
+Triggered on events during setup,
+like starting, ending, or navigating between steps.
+#### Properties
+|   |   |   |
+|---|---|---|
+`target` | `string` | Setup phase that the user navigates to.
+`trigger` | `string` | UI element that triggered the action, e.g. `wizard-stepper` or `get-started` button.
+#### Emitters
+- [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L53)
+	- with `{ target: 'complete', trigger: 'setup-tracking-complete' }` when "Complete setup" button is clicked.
+	- with `{ target: 'fetch-tags' | 'fetch-advertisers', trigger: 'setup-tracking-try-again' }` when "Try again" button is clicked.
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L47) with `{ target: 'onboarding', trigger: 'get-started' }` when "Get started" button is clicked for incomplete setup.
+- [`WizardApp`](assets/source/setup-guide/app/views/WizardApp.js#L38)
+	- with `{ target: 'setup-account' | 'claim-website' | 'setup-tracking', trigger: 'wizard-stepper' }` when wizard's header step is clicked.
+	- with `{ target: 'claim-website' , trigger: 'setup-account-continue' }` when continue button is clicked.
+	- with `{ target: 'setup-tracking', trigger: 'claim-website-continue' }` when continue button is clicked.
 
 <!---
 End of `woo-tracking-jsdoc`-generated content.

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -11,6 +11,7 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Card,
@@ -42,6 +43,8 @@ import documentationLinkProps from '../helpers/documentation-link-props';
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
  *
+ * @fires wcadmin_pfw_setup with `{ target: 'complete', trigger: 'setup-tracking-complete' }` when "Complete setup" button is clicked.
+ * @fires wcadmin_pfw_setup with `{ target: 'fetch-tags' | 'fetch-advertisers', trigger: 'setup-tracking-try-again' }` when "Try again" button is clicked.
  *
  * @param {Object} props React props.
  * @param {string} [props.view='settings'] `'wizard'|'settings'` Kind of view to render.
@@ -241,8 +244,16 @@ const SetupTracking = ( { view = 'settings' } ) => {
 		setStatus( 'idle' );
 
 		if ( appSettings.tracking_advertiser ) {
+			recordEvent( 'pfw_setup', {
+				target: 'fetch-tags',
+				trigger: 'setup-tracking-try-again',
+			} );
 			fetchTags( appSettings.tracking_advertiser );
 		} else {
+			recordEvent( 'pfw_setup', {
+				target: 'fetch-advertisers',
+				trigger: 'setup-tracking-try-again',
+			} );
 			fetchAdvertisers();
 		}
 	};
@@ -272,6 +283,10 @@ const SetupTracking = ( { view = 'settings' } ) => {
 	};
 
 	const handleCompleteSetup = async () => {
+		recordEvent( 'pfw_setup', {
+			target: 'complete',
+			trigger: 'setup-tracking-complete',
+		} );
 		// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
 		const path = getNewPath( {}, '/pinterest/settings', {} );
 

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -26,14 +26,41 @@ import UnsupportedCountryNotice from '../components/UnsupportedCountryNotice';
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
 
 /**
+ * Triggered on events during setup,
+ * like starting, ending, or navigating between steps.
+ *
+ * @event wcadmin_pfw_setup
+ *
+ * @property {string} target Setup phase that the user navigates to.
+ * @property {string} trigger UI element that triggered the action, e.g. `wizard-stepper` or `get-started` button.
+ */
+
+/**
  * Welcome Section Card.
  * To be used in getting started page.
  *
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+ * @fires wcadmin_pfw_setup with `{ target: 'onboarding', trigger: 'get-started' }` when "Get started" button is clicked for incomplete setup.
  *
  * @return {JSX.Element} Rendered element.
  */
 const WelcomeSection = () => {
+	const handleGetStarted = () => {
+		if ( ! wcSettings.pinterest_for_woocommerce.isSetupComplete ) {
+			recordEvent( 'pfw_setup', {
+				target: 'onboarding',
+				trigger: 'get-started',
+			} );
+		}
+		getHistory().push(
+			getNewPath(
+				{},
+				wcSettings.pinterest_for_woocommerce.isSetupComplete
+					? '/pinterest/catalog'
+					: '/pinterest/onboarding'
+			)
+		);
+	};
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__welcome-section">
 			<Flex>
@@ -53,20 +80,7 @@ const WelcomeSection = () => {
 					</Text>
 
 					<Text variant="body">
-						<Button
-							isPrimary
-							onClick={ () =>
-								getHistory().push(
-									getNewPath(
-										{},
-										wcSettings.pinterest_for_woocommerce
-											.isSetupComplete
-											? '/pinterest/catalog'
-											: '/pinterest/onboarding'
-									)
-								)
-							}
-						>
+						<Button isPrimary onClick={ handleGetStarted }>
 							{ __( 'Get started', 'pinterest-for-woocommerce' ) }
 						</Button>
 					</Text>

--- a/assets/source/setup-guide/app/views/LandingPageApp.test.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.test.js
@@ -1,0 +1,90 @@
+jest.mock( '@woocommerce/tracks' );
+
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import LandingPageApp from './LandingPageApp';
+import '../../../tests/custom-matchers';
+
+recordEvent.mockName( 'recordEvent' );
+jest.mock( '@woocommerce/settings', () => ( {
+	getSetting: jest
+		.fn()
+		.mockName( 'getSetting' )
+		.mockReturnValue( { es: 'Spain' } ),
+} ) );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'LandingPageApp component', () => {
+	describe( 'when rendered', () => {
+		let getByRole;
+		beforeEach( () => {
+			// Render connected component.
+			getByRole = render( <LandingPageApp /> ).getByRole;
+		} );
+		describe( 'while `wcSettings.pinterest_for_woocommerce.isSetupComplete = false`', () => {
+			beforeEach( () => {
+				wcSettings.pinterest_for_woocommerce.isSetupComplete = false;
+			} );
+			describe( 'once "Get started" button is clicked', () => {
+				beforeEach( () => {
+					// Find & click the button.
+					const getStartedButton = getByRole( 'button', {
+						name: 'Get started',
+					} );
+					fireEvent.click( getStartedButton );
+				} );
+
+				it( "should call `wcadmin_pfw_setup { target: 'onboarding', trigger: 'get-started' }` track event", () => {
+					expect( recordEvent ).toHaveBeenCalledWith( 'pfw_setup', {
+						target: 'onboarding',
+						trigger: 'get-started',
+					} );
+				} );
+
+				it( 'should navigate to `/pinterest/onboarding`', () => {
+					expect( window.location ).toContainURLSearchParam(
+						'path',
+						'/pinterest/onboarding'
+					);
+				} );
+			} );
+		} );
+		describe( 'while `wcSettings.pinterest_for_woocommerce.isSetupComplete = true`', () => {
+			beforeEach( () => {
+				wcSettings.pinterest_for_woocommerce.isSetupComplete = true;
+			} );
+			describe( 'once "Get started" button is clicked', () => {
+				beforeEach( () => {
+					// Find & click the button.
+					const getStartedButton = getByRole( 'button', {
+						name: 'Get started',
+					} );
+					fireEvent.click( getStartedButton );
+				} );
+
+				it( 'should not call `wcadmin_pfw_setup` track event', () => {
+					expect( recordEvent ).not.toHaveBeenCalledWith(
+						'pfw_setup'
+					);
+				} );
+
+				it( 'should navigate to `/pinterest/catalog`', () => {
+					expect( window.location ).toContainURLSearchParam(
+						'path',
+						'/pinterest/catalog'
+					);
+				} );
+			} );
+		} );
+	} );
+} );

--- a/assets/source/tests/custom-matchers.js
+++ b/assets/source/tests/custom-matchers.js
@@ -1,0 +1,49 @@
+expect.extend( {
+	/**
+	 * Custom matcher to check the presence and optionally the value of a search query param in the given location.
+	 *
+	 * @param {Location} receivedLocation Location to be checked, for example `window.location`.
+	 * @param {string} param Parameter to check the presence of.
+	 * @param {string} [value] Value of the parameter to be checked.
+	 * @return {{message: string, pass: boolean}} Jest compatible matcher output.
+	 */
+	toContainURLSearchParam( receivedLocation, param, value ) {
+		const hasValue = arguments.length === 3;
+		// Sanitize the query params.
+		const params = new URLSearchParams( receivedLocation.search );
+
+		let message = `Expected location ${ this.utils.printReceived(
+			receivedLocation.toString()
+		) }`;
+		let pass = true;
+		// Colorize the param name.
+		const expectedParam = this.utils.printExpected( param );
+		const receivedParam = this.utils.printReceived( param );
+		// Check the presence only.
+		if ( ! hasValue ) {
+			if ( params.has( param ) ) {
+				message += ` not to have param '${ receivedParam }'`;
+			} else {
+				message += ` to have param '${ expectedParam }'`;
+				pass = false;
+			}
+
+			return { message: () => message, pass };
+		}
+
+		// Check the value.
+		const actualValue = params.get( param );
+		// Colorize the values.
+		const expectedValue = this.utils.printExpected( value );
+		const receivedValue = this.utils.printReceived( actualValue );
+		// We check the strict equality directly,
+		// we may consider using module:expect/build/matchers.equals to support `extand.any()` & co.
+		if ( actualValue === value ) {
+			message += `not to have param '${ receivedParam }' of '${ receivedValue }'`;
+		} else {
+			message += `to have param '${ expectedParam }' of '${ expectedValue }', but got '${ receivedValue }'`;
+			pass = false;
+		}
+		return { message: () => message, pass };
+	},
+} );

--- a/assets/source/tests/dependencies/woocommerce/settings.js
+++ b/assets/source/tests/dependencies/woocommerce/settings.js
@@ -1,3 +1,3 @@
-export default function getSettings() {
+export function getSettings() {
 	return {};
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
 	globals: {
 		wcSettings: {
 			pinterest_for_woocommerce: {
+				pluginVersion: '1.2.3',
 				pinterestLinks: {
 					adsManager: 'https://example.com',
 					preLaunchNotice: 'https://example.com',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Implement `wcadmin_pfw_setup` tracking event. Part of #232.
- Add some test coverage for `LandingPageApp`.
- Add a custom matcher `toContainURLSearchParam` for easier WP-admin location assertions.

### Screenshots:
![Setup events](https://user-images.githubusercontent.com/17435/147163136-3ae0ec17-ba8b-4711-afff-8ed374cbf98b.gif)


### Detailed test instructions:

#### Happy path
0. Disconnect your account, to restart the onboarding.
	1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fconnection`
	2. Click "Disconnect", confirm
1. Enable track logging with `localStorage.setItem('debug', 'wc-admin*')` in dev tools
2. Go to landing page `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`
3. Click on "Get started"
	-  `wcadmin_pfw_setup { target: 'onboarding', trigger: 'get-started' }` should be fired
4. Connect the account (this will eventually take you to step 2)
5. Click "Set up your business account", to get back to step 1
	- `wcadmin_pfw_setup { target: 'setup-account', trigger: 'wizard-stepper' }` should be fired
	- other steps are not clickable due to https://github.com/woocommerce/pinterest-for-woocommerce/issues/307, but should fire the event once enabled.
6. Click "Continue"
	- `wcadmin_pfw_setup { target: 'claim-website' , trigger: 'setup-account-continue' }` should be fired
7. Click "Start verification"
8. Click "Continue"
	- `wcadmin_pfw_setup { target: 'setup-tracking', trigger: 'claim-website-continue' }` should be fired
8. Click "Complete setup"
	- `wcadmin_pfw_setup { target: 'complete', trigger: 'setup-tracking-complete' }` should be fired
9. Manually go back to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`
10. Click on "Get started"
	-  No `wcadmin_pfw_setup` should be fired
	
#### Try again
I'm not sure what's the recommended way to achieve those states, but you can get there by mocking

##### Tags
![fetch tags](https://user-images.githubusercontent.com/17435/147164765-0dd5834f-2067-4366-abf7-8589a2602e8b.gif)


0. Change the path in https://github.com/woocommerce/pinterest-for-woocommerce/blob/2a6532352c8c3e3a44c8913e09bc753ede306274/assets/source/setup-guide/app/steps/SetupTracking.js#L152 to `'/fooooo/' +`, to mimic a problem in fetching tags.
1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-tracking`
2. Click "Try Again"
	- `wcadmin_pfw_setup { target: 'fetch-tags', trigger: 'setup-tracking-try-again' }` should be fired

##### Advertisers
![fetch advertisers](https://user-images.githubusercontent.com/17435/147164641-598a2b3f-a8d1-48d4-9015-b94ef37df7a8.gif)

0. Do the 0. from the section above. https://github.com/woocommerce/pinterest-for-woocommerce/blob/2a6532352c8c3e3a44c8913e09bc753ede306274/assets/source/setup-guide/app/steps/SetupTracking.js#L152 to `'/fooooo/' +`
1. Add `appSettings.tracking_advertiser = false;` to https://github.com/woocommerce/pinterest-for-woocommerce/blob/add/232-setup-event/assets/source/setup-guide/app/steps/SetupTracking.js#L63:L63
1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-tracking`
2. Click "Try Again"
	- `wcadmin_pfw_setup { target: 'fetch-advertisers', trigger: 'setup-tracking-try-again' }` should be fired


### Additional notes
0. I think the custom matcher added here, could be eventually offloaded to an external package. Like `@woocommerce/test-utils`?
1. I didn't add test for events in Setup Tracking and Wizard, as those components does not have any tests, and are quite complicated. Currently, rendering them throws a number of exceptions. I think we can offload this to a separate issue, as at least to me it would require a significant effort, and probably some cleanup in the those bigger components. For example, to avoid errors like:
	```
	      ReferenceError: Cannot access 'fetchTags' before initialization
	  
	        106 | 		setIsFetching( false );
	        107 | 	}, [
	      > 108 | 		fetchTags,
	            | 		^
	  ```


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry