### PR TITLE
Refactor `AccountConnection` component.

### DIFF
--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -65,6 +65,8 @@ const PinterestLogo = () => {
 /**
  * Pinterest account connection component.
  *
+ * This renders the body of `SetupAccount` card, to connect or disconnect Pinterest account.
+ *
  * @fires wcadmin_pfw_account_connect_button_click
  * @fires wcadmin_pfw_account_disconnect_button_click
  * @fires wcadmin_pfw_modal_open with `{ name: 'account-disconnection', … }`
@@ -172,15 +174,14 @@ const AccountConnection = ( {
 
 	return (
 		<CardBody size="large">
-			{ isConnected === true ? ( // eslint-disable-line no-nested-ternary --- Code is reasonable readable
-				<Flex direction="row" className="connection-info">
-					{ accountData?.id ? (
-						<>
-							<FlexItem className="logo">
-								<PinterestLogo />
-							</FlexItem>
-
-							<FlexBlock className="account-label">
+			<Flex direction="row" className="connection-info">
+				<FlexItem className="logo">
+					<PinterestLogo />
+				</FlexItem>
+				{ isConnected === true ? ( // eslint-disable-line no-nested-ternary --- Code is reasonable readable
+					<>
+						<FlexBlock className="account-label">
+							{ accountData?.id ? (
 								<Text variant="body">
 									{ accountData.username }
 
@@ -198,61 +199,56 @@ const AccountConnection = ( {
 										{ ')' }
 									</span>
 								</Text>
-							</FlexBlock>
-
-							<FlexItem>
-								<Button
-									isLink
-									isDestructive
-									onClick={ openConfirmationModal }
-								>
-									{ __(
-										'Disconnect',
-										'pinterest-for-woocommerce'
-									) }
-								</Button>
-							</FlexItem>
-						</>
-					) : (
-						<Spinner />
-					) }
-				</Flex>
-			) : isConnected === false ? (
-				<Flex direction="row" className="connection-info">
-					<FlexItem className="logo">
-						<PinterestLogo />
-					</FlexItem>
-
-					<FlexBlock>
-						<Text variant="subtitle">
-							{ __(
-								'Connect your Pinterest Account',
-								'pinterest-for-woocommerce'
+							) : (
+								<div className="connection-info__placeholder"></div>
 							) }
-						</Text>
-					</FlexBlock>
+						</FlexBlock>
 
-					<FlexItem>
-						<Button
-							isSecondary
-							href={
-								wcSettings.pinterest_for_woocommerce
-									.serviceLoginUrl
-							}
-							onClick={ () =>
-								recordEvent(
-									'pfw_account_connect_button_click'
-								)
-							}
-						>
-							{ __( 'Connect', 'pinterest-for-woocommerce' ) }
-						</Button>
-					</FlexItem>
-				</Flex>
-			) : (
-				<Spinner />
-			) }
+						<FlexItem>
+							<Button
+								isLink
+								isDestructive
+								onClick={ openConfirmationModal }
+							>
+								{ __(
+									'Disconnect',
+									'pinterest-for-woocommerce'
+								) }
+							</Button>
+						</FlexItem>
+					</>
+				) : isConnected === false ? (
+					<>
+						<FlexBlock>
+							<Text variant="subtitle">
+								{ __(
+									'Connect your Pinterest Account',
+									'pinterest-for-woocommerce'
+								) }
+							</Text>
+						</FlexBlock>
 
+						<FlexItem>
+							<Button
+								isSecondary
+								href={
+									wcSettings.pinterest_for_woocommerce
+										.serviceLoginUrl
+								}
+								onClick={ () =>
+									recordEvent(
+										'pfw_account_connect_button_click'
+									)
+								}
+							>
+								{ __( 'Connect', 'pinterest-for-woocommerce' ) }
+							</Button>
+						</FlexItem>
+					</>
+				) : (
+					<Spinner className="connection-info__preloader" />
+				) }
+			</Flex>
 			{ isConfirmationModalOpen && renderConfirmationModal() }
 		</CardBody>
 	);

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -258,7 +258,7 @@ $root: ".woocommerce-setup-guide";
 
 				.connection-info {
 					// Set minimum height to the height of the spinner preloader.
-					min-height: calc( 40px );
+					min-height: calc(40px);
 
 					.logo {
 						display: flex;
@@ -266,6 +266,7 @@ $root: ".woocommerce-setup-guide";
 					}
 
 					.connection-info__placeholder {
+
 						@include placeholder();
 						width: 50%;
 						min-width: 10em;

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -4,6 +4,23 @@ $root: ".woocommerce-setup-guide";
 @import "~@wordpress/base-styles/mixins";
 @import "~@wordpress/base-styles/breakpoints";
 
+// Adds animation to placeholder section
+// Copied from WC-admin
+// https://github.com/woocommerce/woocommerce-admin/blob/9f68059c7df466ee7a559c555bcb5a7b9e421e6d/packages/style-build/abstracts/_mixins.scss#L22-L35
+@mixin placeholder( $lighten-percentage: 30% ) {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background-color: $gray-100;
+	color: transparent;
+
+	&::after {
+		content: "\00a0";
+	}
+
+	@media screen and ( prefers-reduced-motion: reduce ) {
+		animation: none;
+	}
+}
+
 #{$root} {
 
 	&__body {
@@ -240,9 +257,23 @@ $root: ".woocommerce-setup-guide";
 			&__setup-account {
 
 				.connection-info {
+					// Set minimum height to the height of the spinner preloader.
+					min-height: calc( 40px );
 
 					.logo {
 						display: flex;
+						justify-self: start;
+					}
+
+					.connection-info__placeholder {
+						@include placeholder();
+						width: 50%;
+						min-width: 10em;
+						display: inline-block;
+					}
+
+					.connection-info__preloader {
+						flex: 1;
 					}
 
 					.account-label {

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -258,7 +258,7 @@ $root: ".woocommerce-setup-guide";
 
 				.connection-info {
 					// Set minimum height to the height of the spinner preloader.
-					min-height: calc(40px);
+					min-height: 40px;
 
 					.logo {
 						display: flex;


### PR DESCRIPTION
### Current look

Account Connection card has four distinct states

- connected
- connected but no `accountData`/`id` (yet or at all)
- connection state unknown
- not connected

(see screenshots below)


### Changes proposed in this Pull Request:
I believe there are a few things we can improve from a UX perspective (and one DevX).
I propose to introduce the following changes:



- Show the Pinterest logo, regardless of the state, to reduce the number of moving parts.
- Show the "Disconnect" button even if there is no account data, or before it's loaded. To help users disconnect even if some account data gets corrupted, or simply without waiting for everything to load.
- Show placeholder instead of a spinner when we wait only for the account details.
- Set the minimum height of the card's content to `40px` = the height of the spinner, to reduce the difference between states, and reduce the layout shift when the spinner disappears and the content is loaded.
- Move the spinner to the middle, to let the user anticipate both things to appear: left-aligned text and right-aligned button.
- Make the code DRY, by moving repeated markup outside of conditions.





@shivanarrthine  I'd appreciate your opinion here :)


### Screenshots:

#### Before 

![before Screenshot from 2021-12-28 12-02-48](https://user-images.githubusercontent.com/17435/147581880-b41b9b20-ab57-46c3-9491-e45f4706c4c5.png)

#### After

![Screenshot from 2021-12-28 16-08-03](https://user-images.githubusercontent.com/17435/147581990-4d01f320-64f1-438c-856d-9c672d221dfe.png)


### Detailed test instructions:

1. Go to the `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fconnection`
2. Watch the loading state
3. Disconnect account
4. Watch connect state for a second before get redirected to welcome page (BTW, is that redirect desired here?)
5. Click "Get started" to go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding`
6. Connect it there,
7. Get back to the first step of onboarding stepper
7. See the connected state

- I was not able to reproduce the preloading of connection status other than programmatically, by setting `isConnected` to false manually in https://github.com/woocommerce/pinterest-for-woocommerce/blob/update/account-connection/assets/source/setup-guide/app/steps/SetupAccount.js#L174:L174


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Improved preloading state of Account Connection Card
