### PR TITLE
Add context property to `wcadmin_pfw_account_disconnect_button_click` event

### DIFF
--- a/assets/source/setup-guide/app/components/Account/Connection.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.js
@@ -40,9 +40,10 @@ const PinterestLogo = () => {
  * @event wcadmin_pfw_account_connect_button_click
  */
 /**
- * Clicking on "Disconnect" Pinterest account button during account setup.
+ * Clicking on "Disconnect" Pinterest account button.
  *
  * @event wcadmin_pfw_account_disconnect_button_click
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
  */
 /**
  * Opening a modal.
@@ -66,7 +67,7 @@ const PinterestLogo = () => {
  * Pinterest account connection component.
  *
  * @fires wcadmin_pfw_account_connect_button_click
- * @fires wcadmin_pfw_account_disconnect_button_click
+ * @fires wcadmin_pfw_account_disconnect_button_click with the given `{ context }`
  * @fires wcadmin_pfw_modal_open with `{ name: 'account-disconnection', … }`
  * @fires wcadmin_pfw_modal_closed with `{ name: 'account-disconnection', … }`
  * @param {Object} props React props.
@@ -90,7 +91,7 @@ const AccountConnection = ( {
 	);
 
 	const openConfirmationModal = () => {
-		recordEvent( 'pfw_account_disconnect_button_click' );
+		recordEvent( 'pfw_account_disconnect_button_click', { context } );
 		setIsConfirmationModalOpen( true );
 		recordEvent( 'pfw_modal_open', { context, name: modalName } );
 	};

--- a/assets/source/setup-guide/app/components/Account/Connection.test.js
+++ b/assets/source/setup-guide/app/components/Account/Connection.test.js
@@ -41,6 +41,16 @@ describe( 'AccountConnection component', () => {
 				fireEvent.click( disconnectButton );
 			} );
 
+			it( 'Should call `pfw_account_disconnect_button_click { context }` track event', () => {
+				// Assert fired event.
+				expect( recordEvent ).toHaveBeenCalledWith(
+					'pfw_account_disconnect_button_click',
+					{
+						context: 'foo',
+					}
+				);
+			} );
+
 			it( "Should call `pfw_modal_open { name: 'account-disconnection', context}` track event", () => {
 				// Assert fired event.
 				expect( recordEvent ).toHaveBeenCalledWith( 'pfw_modal_open', {


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Add context property to `wcadmin_pfw_account_disconnect_button_click` event,
to avoid the need of a separate `disconnected_account_link_click` one.

Implements part of https://github.com/woocommerce/pinterest-for-woocommerce/issues/232.


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/147587154-7d4063d3-0b7a-4395-81a1-50504657c352.png)

### Detailed test instructions:

0. Enable track events logging, with `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Go to 
2. Click "Disconnect"
3. Check that `pfw_account_disconnect_button_click { context: 'settings' }` is fired
4. Go To `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding&step=setup-account&view=wizard`
2. Click "Disconnect"
3. Check that `pfw_account_disconnect_button_click { context: 'wizard' }` is fired

(no changelog entry, we will add one for all events)
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.


Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
