### PR TITLE
Add `wcadmin_pfw_domain_verify_success` event

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -17,7 +17,7 @@ Do not edit it manually!
 ### [`wcadmin_pfw_account_connect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L37)
 Clicking on "Connect" Pinterest account button.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L80)
 
 ### [`wcadmin_pfw_account_convert_button_click`](assets/source/setup-guide/app/steps/SetupAccount.js#L32)
 Clicking on "… convert your personal account" button.
@@ -30,9 +30,13 @@ Clicking on "… create a new Pinterest account" button.
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 
 ### [`wcadmin_pfw_account_disconnect_button_click`](assets/source/setup-guide/app/components/Account/Connection.js#L42)
-Clicking on "Disconnect" Pinterest account button during account setup.
+Clicking on "Disconnect" Pinterest account button.
+#### Properties
+|   |   |   |
+|---|---|---|
+`context` | `string` | `'settings' \| 'wizard'` In which context it was used?
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79)
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L80) with the given `{ context }`
 
 ### [`wcadmin_pfw_business_account_connect_button_click`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L24)
 Clicking on "Connect" business account button.
@@ -54,7 +58,7 @@ Clicking on an external documentation link.
 `href` | `string` | Href to which the user was navigated to.
 #### Emitters
 - [`documentationLinkProps`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L49) on click, with given `linkId` and `context`.
-- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L82) with `{ link_id: 'claim-website', context: props.view }`
+- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L99) with `{ link_id: 'claim-website', context: props.view }`
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L54)
 	- with `{ link_id: 'ad-guidelines', context: props.view }`
 	- with `{ link_id: 'merchant-guidelines', context: props.view }`
@@ -64,6 +68,20 @@ Clicking on an external documentation link.
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
 - [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L47) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+
+### [`wcadmin_pfw_domain_verify_failure`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L69)
+Triggered when domain verification fails.
+#### Properties
+|   |   |   |
+|---|---|---|
+`step` | `string` | Identifier of the step when verification failed.
+#### Emitters
+- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L99)
+
+### [`wcadmin_pfw_domain_verify_success`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L77)
+Triggered when a site is successfully verified.
+#### Emitters
+- [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L99)
 
 ### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L222)
 Clicking on getting started page faq item to collapse or expand it.
@@ -87,7 +105,7 @@ Clicking on the link inside the notice.
 - [`PrelaunchNotice`](assets/source/components/prelaunch-notice/index.js#L18) `{ context: 'pinterest-landing', link_id: 'prelaunch-notice' }`
 - [`UnsupportedCountryNotice`](assets/source/setup-guide/app/components/UnsupportedCountryNotice/index.js#L31) with `{ context: 'pinterest-landing', linkId: 'ads-availability' | 'unsupported-country-link' }`
 
-### [`wcadmin_pfw_modal_closed`](assets/source/setup-guide/app/components/Account/Connection.js#L54)
+### [`wcadmin_pfw_modal_closed`](assets/source/setup-guide/app/components/Account/Connection.js#L55)
 Closing a modal.
 #### Properties
 |   |   |   |
@@ -96,9 +114,9 @@ Closing a modal.
 `context` | `string` | `'settings' \| 'wizard'` In which context it was used?
 `action` | `string` | `confirm` - When the final "Yes, I'm sure" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79) with `{ name: 'account-disconnection', … }`
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L80) with `{ name: 'account-disconnection', … }`
 
-### [`wcadmin_pfw_modal_open`](assets/source/setup-guide/app/components/Account/Connection.js#L47)
+### [`wcadmin_pfw_modal_open`](assets/source/setup-guide/app/components/Account/Connection.js#L48)
 Opening a modal.
 #### Properties
 |   |   |   |
@@ -106,7 +124,7 @@ Opening a modal.
 `name` | `string` | Which modal is it?
 `context` | `string` | `'settings' \| 'wizard'` In which context it was used?
 #### Emitters
-- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L79) with `{ name: 'account-disconnection', … }`
+- [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L80) with `{ name: 'account-disconnection', … }`
 
 ### [`wcadmin_pfw_save_changes_button_click`](assets/source/setup-guide/app/components/SaveSettingsButton.js#L18)
 Clicking on "… Save changes" button.

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.js
@@ -75,12 +75,19 @@ const StaticError = ( { reqError } ) => {
  */
 
 /**
+ * Triggered when a site is successfully verified.
+ *
+ * @event wcadmin_pfw_domain_verify_success
+ */
+
+/**
  * Claim Website step component.
  * Renders a UI with section block and <Card> to claim website (if not yet completed) and display its status.
  *
  * To be used in onboarding setup stepper.
  *
  * @fires wcadmin_pfw_domain_verify_failure
+ * @fires wcadmin_pfw_domain_verify_success
  * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'claim-website', context: props.view }`
  * @param {Object} props React props.
  * @param {'wizard'|'settings'} props.view Indicate which view this component is rendered on.
@@ -113,6 +120,8 @@ const ClaimWebsite = ( { goToNextStep, view } ) => {
 				method: 'POST',
 			} );
 			await setAppSettings( { account_data: results.account_data } );
+
+			recordEvent( 'pfw_domain_verify_success' );
 
 			setStatus( STATUS.SUCCESS );
 		} catch ( error ) {

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
@@ -26,16 +26,12 @@ jest.mock( '@wordpress/api-fetch', () => {
  */
 import { recordEvent } from '@woocommerce/tracks';
 import apiFetch from '@wordpress/api-fetch';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import ClaimWebsite from './ClaimWebsite';
-
-async function sleep( ms ) {
-	return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
-}
 
 describe( 'Claim Website Record Events', () => {
 	afterEach( () => {
@@ -70,12 +66,10 @@ describe( 'Claim Website Record Events', () => {
 		fireEvent.click( getByText( 'Start verification' ) );
 
 		// Wait for async click handler and apiFetch resolution.
-		const delay = sleep( 1 );
-		jest.runAllTimers();
-		await delay;
-
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'pfw_domain_verify_success'
+		await waitFor( () =>
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'pfw_domain_verify_success'
+			)
 		);
 	} );
 } );

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
@@ -8,12 +8,6 @@ jest.mock( '../helpers/effects', () => {
 	};
 } );
 
-jest.mock( '@woocommerce/tracks', () => {
-	return {
-		recordEvent: jest.fn(),
-	};
-} );
-
 jest.mock( '@wordpress/api-fetch', () => {
 	return {
 		__esModule: true,

--- a/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
+++ b/assets/source/setup-guide/app/steps/ClaimWebsite.test.js
@@ -16,6 +16,7 @@ jest.mock( '@woocommerce/tracks', () => {
 
 jest.mock( '@wordpress/api-fetch', () => {
 	return {
+		__esModule: true,
 		default: jest.fn(),
 	};
 } );
@@ -34,7 +35,7 @@ import ClaimWebsite from './ClaimWebsite';
 
 describe( 'Claim Website Record Events', () => {
 	it( 'pfw_domain_verify_failure is called on domain verification failure', () => {
-		apiFetch.default.mockImplementation( async () => {
+		apiFetch.mockImplementation( () => {
 			throw 'Ups';
 		} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fix `pfw_domain_verify_failure` tests, 
   Mock ESM default export, make the mock sync.
- Fire `wcadmin_pfw_domain_verify_success` event, 
   implements part of #232


### Screenshots:

<!--- Optional --->

![verify](https://user-images.githubusercontent.com/17435/147793787-cc9a262e-b1d9-4c9e-a64e-fc7201b8c4d2.gif)


### Detailed test instructions:

0. Start ngrok, or other tunnel to publish your local site.
1. Enable track events logging, with `localStorage.setItem( 'debug', 'wc-admin:*' );`
2. Disconnect your account if needed `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fconnection`
1. Start the onboarding `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fonboarding`
2. Follow the wizard, to step 2
3. Click "Start verification"
4. Once successfully verified, you should see `wcadmin_pfw_domain_verify_success` fired.



<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
