### PR TITLE
Add `pfw_ads_manager_link_click` track event.

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -38,6 +38,11 @@ Clicking on "Disconnect" Pinterest account button.
 #### Emitters
 - [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L80) with the given `{ context }`
 
+### [`wcadmin_pfw_ads_manager_link_click`](assets/source/catalog-sync/sections/SyncState.js#L24)
+Clicking on the "Pinterest ads manager" link.
+#### Emitters
+- [`SyncState`](assets/source/catalog-sync/sections/SyncState.js#L36)
+
 ### [`wcadmin_pfw_business_account_connect_button_click`](assets/source/setup-guide/app/components/Account/BusinessAccountSelection.js#L24)
 Clicking on "Connect" business account button.
 #### Emitters

--- a/assets/source/catalog-sync/sections/SyncState.js
+++ b/assets/source/catalog-sync/sections/SyncState.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { recordEvent } from '@woocommerce/tracks';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -20,6 +21,18 @@ import { REPORTS_STORE_NAME } from '../data';
 import SyncStateSummary from './SyncStateSummary';
 import SyncStateTable from './SyncStateTable';
 
+/**
+ * Clicking on the "Pinterest ads manager" link.
+ *
+ * @event wcadmin_pfw_ads_manager_link_click
+ */
+
+/**
+ * Catalog cync state overview component.
+ *
+ * @fires wcadmin_pfw_ads_manager_link_click
+ * @return {JSX.Element} Rendered component.
+ */
 const SyncState = () => {
 	const feedState = useSelect( ( select ) =>
 		select( REPORTS_STORE_NAME ).getFeedState()
@@ -49,6 +62,11 @@ const SyncState = () => {
 										wcSettings.pinterest_for_woocommerce
 											.pinterestLinks.adsManager
 									}
+									onClick={ () => {
+										recordEvent(
+											'pfw_ads_manager_link_click'
+										);
+									} }
 								/>
 							),
 						}

--- a/assets/source/catalog-sync/sections/SyncState.test.js
+++ b/assets/source/catalog-sync/sections/SyncState.test.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -29,5 +30,15 @@ describe( 'SyncState component', () => {
 		const { getByText } = render( <SyncState /> );
 
 		expect( getByText( 'Property' ) ).toBeTruthy();
+	} );
+
+	test( 'should fire `pfw_ads_manager_link_click` when "Pinterest ads manager" is clicked', () => {
+		const { getByText } = render( <SyncState /> );
+
+		fireEvent.click( getByText( 'Pinterest ads manager' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'pfw_ads_manager_link_click'
+		);
 	} );
 } );


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Add `pfw_ads_manager_link_click` track event.

Addresses https://github.com/woocommerce/pinterest-for-woocommerce/pull/296#pullrequestreview-842872047


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/148223431-bba20fca-5bd1-483d-8a6f-5550b7ddb98f.png)


### Detailed test instructions:

0. Enable track events logging, with `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fcatalog`
2. Click on _"Pinterest ads manager"_ link
3. You should see `wcadmin_pfw_ads_manager_link_click` logged

(no changelog entry, one will be added for all events)
<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
