### PR TITLE
Fix/315 Pinterest plugin is blocking some scripts

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-tracking.js
+++ b/assets/source/js/pinterest-for-woocommerce-tracking.js
@@ -4,7 +4,8 @@
  * Bind to search form submit in order to track the search event.
  * Site search should use <form role='search'> to integrate with Pinterest for WooCommerce search event automatically.
  */
-window.onload = function () {
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'load', function () {
 	document
 		.querySelectorAll( "form[role='search']" )
 		.forEach( function ( form ) {
@@ -22,4 +23,4 @@ window.onload = function () {
 				}
 			} );
 		} );
-};
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #315.

The plugin was using window.onload method, which can override the same method in other scripts.

### Screenshots:

<!--- Optional --->

### Detailed test instructions:

1. Create a script that uses window.onload method.
2. The script execution should not be overriden by the plugin.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:




Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
