### PR TITLE
Add UT to test product attributes.

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
 use WC_Product_Variation;
+use WC_Product;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -407,7 +407,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$xml = $method->invoke( null, $product, '\t' );
+		$xml = $method->invoke( null, $product, '' );
 		// No attributes set, output should be empty.
 		$this->assertEquals( '', $xml );
 
@@ -431,7 +431,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$xml = $method->invoke( null, $product, '\t' );
+		$xml = $method->invoke( null, $product, '' );
 		// No attributes set, output should be empty.
 		$this->assertEquals( '', $xml );
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -440,7 +440,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$taxonomy                  = GoogleProductTaxonomy::TAXONOMY[502979]; // Randomly selected category - i just made sure that it has parent.
 		$full_taxonomy_name        = $full_category_name_method->invoke( new GoogleCategorySearch(), $taxonomy );
 		$condition                 = new GoogleCategory( $full_taxonomy_name );
-		$attribute_manager = AttributeManager::instance();
+		$attribute_manager         = AttributeManager::instance();
 		$attribute_manager->update( $product, $condition );
 
 		$xml = $method->invoke( null, $product, '' );

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -444,7 +444,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$attribute_manager->update( $product, $condition );
 
 		$xml = $method->invoke( null, $product, '' );
-		// Condition attribute was set, we should see it in the output.
+		// Google product category attribute was set, we should see it in the output.
 		$this->assertEquals( '<g:google_product_category>Arts &amp; Entertainment &gt; Hobbies &amp; Creative Arts &gt; Arts &amp; Crafts &gt; Art &amp; Craft Kits &gt; Jewelry Making Kits</g:google_product_category>' . PHP_EOL, $xml );
 	}
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -2,18 +2,18 @@
 
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit\Feed;
 
+use ReflectionClass;
+use ReflectionMethod;
+use \WC_Helper_Product;
 use \WC_Unit_Test_Case;
 use \WC_Product_Variable;
-use \WC_Helper_Product;
-use \ReflectionClass;
 
 use Automattic\WooCommerce\Pinterest\ProductsXmlFeed;
-use Automattic\WooCommerce\Pinterest\Product\GoogleProductTaxonomy;
 use Automattic\WooCommerce\Pinterest\Product\GoogleCategorySearch;
+use Automattic\WooCommerce\Pinterest\Product\GoogleProductTaxonomy;
+use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\Pinterest\Product\Attributes\Condition;
 use Automattic\WooCommerce\Pinterest\Product\Attributes\GoogleCategory;
-use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
-use ReflectionMethod;
 
 /**
  * Feed file generation testing class.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new test case to check the presence of the product attributes ( if set ). So far we only support `condition` and `google_category` and that is what is being tested. We have two assertions: the first one when no attribute is set, the second one when we add an attribute.

Google test is more of an integration test to not duplicate what is actually being tested. 

This is built on top of https://github.com/woocommerce/pinterest-for-woocommerce/pull/321

### Detailed test instructions:

Check the Ci results for confirmation that it works.

### Changelog entry

> Add - Product attribute unit tests. 
