### PR TITLE
Release PR for Pinterest For WooCommerce v1.0.2

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -105,6 +105,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 * Add    - Product attribute for Google product category. ( [#317](https://github.com/wcommerce/pinterest-for-woocommerce/pull/317) )
 * Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
+* Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/README.txt
+++ b/README.txt
@@ -107,6 +107,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
 * Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
 * Fix    - Multiple catalog created on pinterest with no possibility to delete them. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
+* Fix    - Feed registration status is incorrect when user has more than one feed profile. ( [#335](https://github.com/wcommerce/pinterest-for-woocommerce/pull/335) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/README.txt
+++ b/README.txt
@@ -87,7 +87,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
-= 1.0.1 - 2022-xx-xx =
+= 1.0.2 - 2022-xx-xx =
 * Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
 * Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
 * Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )

--- a/README.txt
+++ b/README.txt
@@ -106,6 +106,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 * Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
 * Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
+* Fix    - Multiple catalog created on pinterest with no possibility to delete them. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 5.8
 Requires PHP: 7.3
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -87,7 +87,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
-= 1.0.2 - 2022-xx-xx =
+= 1.0.2 - 2022-01-25 =
 * Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
 * Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
 * Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )

--- a/README.txt
+++ b/README.txt
@@ -87,6 +87,25 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.0.1 - 2022-xx-xx =
+* Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
+* Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
+* Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )
+* Add    - Show a notice on the landing page if this extension does not support store country. ( [#256](https://github.com/woocommerce/pinterest-for-woocommerce/pull/256) )
+* Update - Adjust image size for additional images. ( [#268](https://github.com/woocommerce/pinterest-for-woocommerce/pull/268) )
+* Fix    - Error message for merchants with declined status. ( [#272](https://github.com/woocommerce/pinterest-for-woocommerce/pull/272) )
+* Add    - Pinterest Ads Manager Call To Action UI. ( [#273](https://github.com/woocommerce/pinterest-for-woocommerce/pull/273) )
+* Update - Tweak the UI of claim website. ( [#286](https://github.com/woocommerce/pinterest-for-woocommerce/pull/286) )
+* Update - Remove unused parameters sent in create merchant request. ( [#294](https://github.com/woocommerce/pinterest-for-woocommerce/pull/294) )
+* Add    - Adding Woo Tracker for Usage Tracking. ( [#301](https://github.com/wcommerce/pinterest-for-woocommerce/pull/301) )
+* Add    - Implement Events Tracking. ( [#296](https://github.com/wcommerce/pinterest-for-woocommerce/pull/296) )
+* Add    - Product Attributes. ( [#303](https://github.com/wcommerce/pinterest-for-woocommerce/pull/303) )
+* Update - API to v4. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
+* Update - Refactor AccountConnection component. ( [#312](https://github.com/wcommerce/pinterest-for-woocommerce/pull/312) )
+* Add    - Product attribute for Google product category. ( [#317](https://github.com/wcommerce/pinterest-for-woocommerce/pull/317) )
+* Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
+* Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
+
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.
 * Fix - Enable enhanced match by default .

--- a/bin/generate-categories.php
+++ b/bin/generate-categories.php
@@ -13,7 +13,7 @@
 /**
  * Generate Categories class.
  *
- * @since x.x.x
+ * @since 1.0.2
  */
 class GenerateCategories {
 	const CATEGORIES_FILE_NAME = 'GoogleProductTaxonomy.php';

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
 * Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
 * Fix    - Multiple catalog created on pinterest with no possibility to delete them. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
+* Fix    - Feed registration status is incorrect when user has more than one feed profile. ( [#335](https://github.com/wcommerce/pinterest-for-woocommerce/pull/335) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,24 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.0.1 - 2022-xx-xx =
+* Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
+* Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
+* Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )
+* Add    - Show a notice on the landing page if this extension does not support store country. ( [#256](https://github.com/woocommerce/pinterest-for-woocommerce/pull/256) )
+* Update - Adjust image size for additional images. ( [#268](https://github.com/woocommerce/pinterest-for-woocommerce/pull/268) )
+* Fix    - Error message for merchants with declined status. ( [#272](https://github.com/woocommerce/pinterest-for-woocommerce/pull/272) )
+* Add    - Pinterest Ads Manager Call To Action UI. ( [#273](https://github.com/woocommerce/pinterest-for-woocommerce/pull/273) )
+* Update - Tweak the UI of claim website. ( [#286](https://github.com/woocommerce/pinterest-for-woocommerce/pull/286) )
+* Update - Remove unused parameters sent in create merchant request. ( [#294](https://github.com/woocommerce/pinterest-for-woocommerce/pull/294) )
+* Add    - Adding Woo Tracker for Usage Tracking. ( [#301](https://github.com/wcommerce/pinterest-for-woocommerce/pull/301) )
+* Add    - Implement Events Tracking. ( [#296](https://github.com/wcommerce/pinterest-for-woocommerce/pull/296) )
+* Add    - Product Attributes. ( [#303](https://github.com/wcommerce/pinterest-for-woocommerce/pull/303) )
+* Update - API to v4. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
+* Update - Refactor AccountConnection component. ( [#312](https://github.com/wcommerce/pinterest-for-woocommerce/pull/312) )
+* Add    - Product attribute for Google product category. ( [#317](https://github.com/wcommerce/pinterest-for-woocommerce/pull/317) )
+* Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
+* Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
+
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.
 * Fix - Enable enhanced match by default .

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Pinterest for WooCommerce Changelog ***
 
-= 1.0.2 - 2022-xx-xx =
+= 1.0.2 - 2022-01-25 =
 * Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
 * Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
 * Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Add    - Product attribute for Google product category. ( [#317](https://github.com/wcommerce/pinterest-for-woocommerce/pull/317) )
 * Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
+* Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
 * Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
 * Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
+* Fix    - Multiple catalog created on pinterest with no possibility to delete them. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
 
 = 1.0.1 - 2021-11-16 =
 * Fix - Add PHP, JS & CSS linting GH actions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Pinterest for WooCommerce Changelog ***
 
-= 1.0.1 - 2022-xx-xx =
+= 1.0.2 - 2022-xx-xx =
 * Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
 * Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
 * Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.1' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.2' ); // WRCS: DEFINED_VERSION.
 
 /**
  * Autoload packages.


### PR DESCRIPTION
### Release PR for the next Pinterest plugin release.

Changelog:

* Fix    - Update and improve feedstate. ( [#240](https://github.com/woocommerce/pinterest-for-woocommerce/pull/240) )
* Add    - Tooltips for the Publish Pins and Rich Pins options on the settings page. ( [#253](https://github.com/woocommerce/pinterest-for-woocommerce/pull/253) )
* Add    - Merchant guidelines link in the setup page. ( [#255](https://github.com/woocommerce/pinterest-for-woocommerce/pull/255) )
* Add    - Show a notice on the landing page if this extension does not support store country. ( [#256](https://github.com/woocommerce/pinterest-for-woocommerce/pull/256) )
* Update - Adjust image size for additional images. ( [#268](https://github.com/woocommerce/pinterest-for-woocommerce/pull/268) )
* Fix    - Error message for merchants with declined status. ( [#272](https://github.com/woocommerce/pinterest-for-woocommerce/pull/272) )
* Add    - Pinterest Ads Manager Call To Action UI. ( [#273](https://github.com/woocommerce/pinterest-for-woocommerce/pull/273) )
* Update - Tweak the UI of claim website. ( [#286](https://github.com/woocommerce/pinterest-for-woocommerce/pull/286) )
* Update - Remove unused parameters sent in create merchant request. ( [#294](https://github.com/woocommerce/pinterest-for-woocommerce/pull/294) )
* Add    - Adding Woo Tracker for Usage Tracking. ( [#301](https://github.com/wcommerce/pinterest-for-woocommerce/pull/301) )
* Add    - Implement Events Tracking. ( [#296](https://github.com/wcommerce/pinterest-for-woocommerce/pull/296) )
* Add    - Product Attributes. ( [#303](https://github.com/wcommerce/pinterest-for-woocommerce/pull/303) )
* Update - API to v4. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
* Update - Refactor AccountConnection component. ( [#312](https://github.com/wcommerce/pinterest-for-woocommerce/pull/312) )
* Add    - Product attribute for Google product category. ( [#317](https://github.com/wcommerce/pinterest-for-woocommerce/pull/317) )
* Fix    - Onboarding wizard steps ( 2 and 3 ) are not clickable. ( [#318](https://github.com/wcommerce/pinterest-for-woocommerce/pull/318) )
* Fix    - Fetch parent id for variable product during feed xml generation. ( [#320](https://github.com/wcommerce/pinterest-for-woocommerce/pull/320) )
* Fix    - Plugin is blocking some 3rd party scripts. ( [#324](https://github.com/wcommerce/pinterest-for-woocommerce/pull/324) )
* Fix    - Multiple catalog created on pinterest with no possibility to delete them. ( [#305](https://github.com/wcommerce/pinterest-for-woocommerce/pull/305) )
* Fix    - Feed registration status is incorrect when user has more than one feed profile. ( [#335](https://github.com/wcommerce/pinterest-for-woocommerce/pull/335) )