### PR TITLE
Enhance webpack config and fix some related problems

### DIFF
--- a/assets/source/setup-task/index.js
+++ b/assets/source/setup-task/index.js
@@ -6,11 +6,6 @@ import { addFilter } from '@wordpress/hooks';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
 
 /**
- * Internal dependencies
- */
-import '../setup-guide/app/style.scss';
-
-/**
  * Use the 'woocommerce_admin_onboarding_task_list' filter to add a task page.
  */
 addFilter(

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -168,8 +168,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			define( 'PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME', 'pinterest_for_woocommerce' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_DATA_NAME', 'pinterest_for_woocommerce_data' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX', 'pinterest-for-woocommerce' );
-			define( 'PINTEREST_FOR_WOOCOMMERCE_SETUP_GUIDE', PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-setup-guide' );
-			define( 'PINTEREST_FOR_WOOCOMMERCE_CATALOG_SYNC', PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-catalog-sync' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_URL', 'https://connect.woocommerce.com/' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE', 'pinterestv3native' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_API_NAMESPACE', 'pinterest' );

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -308,16 +308,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 			);
 
 			wp_enqueue_style( $handle );
-
-			wp_register_style(
-				PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-catalog-sync',
-				Pinterest_For_Woocommerce()->plugin_url() . '/assets/catalog-sync/style-index.css',
-				array( 'wc-admin-app' ),
-				PINTEREST_FOR_WOOCOMMERCE_VERSION
-			);
-
-			wp_enqueue_style( $handle );
-
 		}
 
 		/**

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -251,12 +251,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				return;
 			}
 
+			$build_path = '/assets/build';
+
 			if ( Compat::should_show_tasks() ) {
 
-				$build_path = '/assets/setup-task';
-
-				$handle            = PINTEREST_FOR_WOOCOMMERCE_SETUP_GUIDE . '-setup-task';
-				$script_asset_path = Pinterest_For_Woocommerce()->plugin_path() . $build_path . '/index.asset.php';
+				$handle            = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-setup-task';
+				$script_asset_path = Pinterest_For_Woocommerce()->plugin_path() . $build_path . '/setup-task.asset.php';
 				$script_info       = file_exists( $script_asset_path )
 					? include $script_asset_path
 					: array(
@@ -268,7 +268,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 
 				wp_register_script(
 					$handle,
-					Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/index.js',
+					Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/setup-task.js',
 					$script_info['dependencies'],
 					$script_info['version'],
 					true
@@ -277,10 +277,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				wp_enqueue_script( $handle );
 			}
 
-			$build_path = '/assets/setup-guide';
-
-			$handle            = PINTEREST_FOR_WOOCOMMERCE_SETUP_GUIDE;
-			$script_asset_path = Pinterest_For_Woocommerce()->plugin_path() . $build_path . '/index.asset.php';
+			$handle            = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-setup-guide';
+			$script_asset_path = Pinterest_For_Woocommerce()->plugin_path() . $build_path . '/setup-guide.asset.php';
 			$script_info       = file_exists( $script_asset_path )
 				? include $script_asset_path
 				: array(
@@ -292,7 +290,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 
 			wp_register_script(
 				$handle,
-				Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/index.js',
+				Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/setup-guide.js',
 				$script_info['dependencies'],
 				$script_info['version'],
 				true
@@ -302,7 +300,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 
 			wp_register_style(
 				$handle,
-				Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/style-index.css',
+				Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/style-setup-guide.css',
 				array( 'wc-admin-app' ),
 				PINTEREST_FOR_WOOCOMMERCE_VERSION
 			);

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -275,15 +275,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				);
 
 				wp_enqueue_script( $handle );
-
-				wp_register_style(
-					$handle,
-					Pinterest_For_Woocommerce()->plugin_url() . $build_path . '/style-index.css',
-					array( 'wc-admin-app' ),
-					PINTEREST_FOR_WOOCOMMERCE_VERSION
-				);
-
-				wp_enqueue_style( $handle );
 			}
 
 			$build_path = '/assets/setup-guide';

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "scripts": {
     "prebuild": "composer install --no-dev",
-    "build": "wp-scripts build && gulp build && gulp package",
+    "build": "wp-scripts build && gulp package",
     "postbuild": "composer install",
     "build:zip": "npm run build",
     "dev": "wp-scripts build && gulp build",

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -57,7 +57,7 @@ class Admin {
 		if ( $screen && 'product' === $screen->id ) {
 			wp_enqueue_style(
 				'pinterest-product-attributes-css',
-				Pinterest_For_Woocommerce()->plugin_url() . '/assets/product-attributes/style-index.css',
+				Pinterest_For_Woocommerce()->plugin_url() . '/assets/build/style-product-attributes.css',
 				array(),
 				PINTEREST_FOR_WOOCOMMERCE_VERSION
 			);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,44 +23,19 @@ const ourPlugins = [
 	} ),
 ];
 
-// Webpack config for main admin app - onboarding and settings.
-const SetupGuide = {
+const webpackConfig = {
 	...defaultConfig,
 	plugins: ourPlugins,
 	entry: {
-		index: './assets/source/setup-guide/index.js',
-	},
-	output: {
-		...defaultConfig.output,
-		filename: '[name].js',
-		path: __dirname + '/assets/setup-guide',
-	},
-};
-
-// Webpack config for script to add our setup task.
-const SetupTask = {
-	...defaultConfig,
-	plugins: ourPlugins,
-	entry: {
-		index: './assets/source/setup-task/index.js',
+		'setup-guide': __dirname + '/assets/source/setup-guide/index.js',
+		'setup-task': __dirname + '/assets/source/setup-task/index.js',
+		'product-attributes':
+			__dirname + '/assets/source/product-attributes/index.js',
 	},
 	output: {
 		filename: '[name].js',
-		path: __dirname + '/assets/setup-task',
+		path: __dirname + '/assets/build',
 	},
 };
 
-// Webpack config for product-attributes.
-const ProductAttributes = {
-	...defaultConfig,
-	plugins: ourPlugins,
-	entry: {
-		index: './assets/source/product-attributes/index.js',
-	},
-	output: {
-		filename: '[name].js',
-		path: __dirname + '/assets/product-attributes',
-	},
-};
-
-module.exports = [ SetupGuide, SetupTask, ProductAttributes ];
+module.exports = webpackConfig;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #330 

To prevent the potential problem described in #330 and fix some incorrect importing and registration of CSS files, this PR:

- Merge multiple webpack configs to single one and rename entries to avoid files disappearing when building.
- Remove registration and enqueue for **assets/setup-task/style-index.css** since it doesn't need it.
    - This also fixes the problem that all styles of this extension were duplicated once.
    ![2022-01-20 10 31 42](https://user-images.githubusercontent.com/17420811/150297064-e1fbea0e-08ae-4a84-95ac-3c3352563abd.png)
- Remove ineffective registration and incorrect enqueue for **assets/catalog-sync/style-index.css**.
- Remove `gulp build` from `npm run build` script because `gulp package` already contains the `gulp build` task.
    - `gulp build` was run twice
    ![2022-01-20 16 26 03](https://user-images.githubusercontent.com/17420811/150301194-4ebf55e4-9c80-4b43-a6ca-3ff301e2aa86.png)

### Detailed test instructions:

#### Building

1. `npm run env -- wp-scripts build`
2. Check if all output files are generated in the **assets/build** folder and are not deleted. The file list should be
    - product-attributes.asset.php
    - product-attributes.js
    - setup-guide.asset.php
    - setup-guide.js
    - setup-task.asset.php
    - setup-task.js
    - style-product-attributes.css
    - style-setup-guide.css

#### Packing

1. `npm run build`
2. Check logs if the `gulp build` task was run only one time.
3. Check if the following .js, .css and .asset.php files are present in the generated zip file.
    ![2022-01-20 12 19 45](https://user-images.githubusercontent.com/17420811/150297084-5cad1895-1739-4d22-bc47-ef8cfa6d5d0f.png)

#### Loading of js and css files

1. `npm start` or `npm run dev`
1. Open browser DevTool.
1. Go to the Pinterest admin pages.
1. Pages should be rendered as well as before.
1. Go to WooCommerce's admin Home page.
1. There should be a "Setup Pinterest for WooCommerce" item in the "Things to do next" list.
    ![image](https://user-images.githubusercontent.com/17420811/150328397-fa0bbba1-dcc0-424f-afa1-a80f44ba38ff.png)
1. Go to WooCommerce's products management page and pick a variable product, such as the "Hoodie" imported from the sample data, to edit.
1. Follow the screenshot to navigate to the Pinterest Condition settings, which should have a border around it, meaning the **style-product-attributes.css** is loaded correctly.
    ![2022-01-20 17 57 56](https://user-images.githubusercontent.com/17420811/150316627-6fe3f98e-957f-416d-be0b-6b4180bcc784.png)
1. There should be no 404 errors in DevTool during the overall tests.

#### Development

1. `npm start`
2. Make some changes on js and css.
3. Refresh page and check if it has those changes correspondingly.
4. Randomly inspect UI elements via DevTool to see if there are no duplicate styles.


### Changelog entry

> Tweak - Enhance webpack config to prevent disappearing of output client files when building.
> Fix - Duplicated CSS styles and unnecessary .css file importing.
