### PR TITLE
Fix/228 wrong feed registration status multiple feed profiles

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -516,7 +516,7 @@ class Base {
 	 * @param string $merchant_id The merchant ID the feed belongs to.
 	 * @param string $feed_id     The ID of the feed.
 	 *
-	 * @return mixed
+	 * @return object
 	 *
 	 * @throws \Exception PHP Exception.
 	 */

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -493,48 +493,6 @@ class Base {
 
 
 	/**
-	 * Get a specific merchant feed using the given arguments.
-	 *
-	 * @param string $merchant_id The merchant ID the feed belongs to.
-	 * @param string $feed_id     The ID of the feed.
-	 *
-	 * @return object
-	 *
-	 * @throws \Exception PHP Exception.
-	 */
-	public static function get_merchant_feed( $merchant_id, $feed_id ) {
-		try {
-
-			$feeds = self::get_merchant_feeds( $merchant_id );
-
-			if ( 'success' !== $feeds['status'] ) {
-				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
-			}
-
-			if ( ! is_array( $feeds['data'] ) ) {
-				throw new \Exception( esc_html__( 'Wrong feed info.', 'pinterest-for-woocommerce' ) );
-			}
-
-			foreach ( $feeds['data'] as $feed_profile ) {
-
-				if ( $feed_id === $feed_profile->id ) {
-					return $feed_profile;
-				}
-			}
-
-			// No feed found.
-			throw new \Exception( esc_html__( 'No feed found with the requested ID.', 'pinterest-for-woocommerce' ) );
-
-		} catch ( \Exception $e ) {
-
-			Logger::log( $e->getMessage(), 'error' );
-
-			throw $e;
-		}
-	}
-
-
-	/**
 	 * Get a merchant's feeds.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -493,7 +493,85 @@ class Base {
 
 
 	/**
-	 * Get a specific merchant's feed using the given arguments.
+	 * Updates the merchant's feed using the given arguments.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param string $feed_id     The ID of the feed to be updated.
+	 * @param array  $args        The arguments to be passed to the API request.
+	 *
+	 * @return mixed
+	 */
+	public static function update_merchant_feed( $merchant_id, $feed_id, $args ) {
+
+		return self::make_request(
+			add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ),
+			'PUT'
+		);
+	}
+
+
+	/**
+	 * Get a specific merchant feed using the given arguments.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param string $feed_id     The ID of the feed.
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public static function get_merchant_feed( $merchant_id, $feed_id ) {
+		try {
+
+			$feeds = self::get_merchant_feeds( $merchant_id );
+
+			if ( 'success' !== $feeds['status'] ) {
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
+			if ( ! is_array( $feeds['data'] ) ) {
+				throw new \Exception( esc_html__( 'Wrong feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
+			foreach ( $feeds['data'] as $feed_profile ) {
+
+				if ( $feed_id === $feed_profile->id ) {
+					return $feed_profile;
+				}
+			}
+
+			// No feed found.
+			throw new \Exception( esc_html__( 'No feed found with the requested ID.', 'pinterest-for-woocommerce' ) );
+
+		} catch ( \Exception $e ) {
+
+			Logger::log( $e->getMessage(), 'error' );
+
+			throw $e;
+		}
+	}
+
+
+	/**
+	 * Get a merchant's feeds.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 *
+	 * @return mixed
+	 */
+	public static function get_merchant_feeds( $merchant_id ) {
+		return self::make_request(
+			"catalogs/{$merchant_id}/feed_profiles/",
+			'GET',
+			array(),
+			'',
+			MINUTE_IN_SECONDS
+		);
+	}
+
+
+	/**
+	 * Get a specific merchant's feed report using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
 	 * @param string $feed_id     The ID of the feed.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -475,24 +475,6 @@ class Base {
 
 
 	/**
-	 * Get a merchant's feeds.
-	 *
-	 * @param string $merchant_id The merchant ID the feed belongs to.
-	 *
-	 * @return mixed
-	 */
-	public static function get_merchant_feeds( $merchant_id ) {
-		return self::make_request(
-			"catalogs/{$merchant_id}/feed_profiles/",
-			'GET',
-			array(),
-			'',
-			MINUTE_IN_SECONDS
-		);
-	}
-
-
-	/**
 	 * Updates the merchant's feed using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -262,10 +262,6 @@ class FeedState extends VendorAPI {
 
 			$feed = Base::get_merchant_feed( $merchant_id, $feed_id );
 
-			if ( ! $feed ) {
-				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
-			}
-
 			if ( 'ACTIVE' !== $feed->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -246,18 +246,29 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_registration_state( $result ) {
 
-		$extra_info = '';
+		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
+		$feed_id     = Pinterest_For_Woocommerce()::get_data( 'feed_registered' );
+		$extra_info  = '';
 
 		try {
 
-			// Get the merchant object.
-			$merchant = Pinterest\Merchants::get_merchant();
+			if ( empty( $merchant_id ) || empty( $feed_id ) ) {
+				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
+			}
+
+			$merchant = Base::get_merchant( $merchant_id );
 
 			if ( 'success' !== $merchant['status'] ) {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			if ( 'ACTIVE' !== $merchant['data']->product_pin_feed_profile->feed_status ) {
+			$feed = Pinterest\Feeds::get_merchant_feed( $merchant_id, $feed_id );
+
+			if ( ! $feed ) {
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
+			if ( 'ACTIVE' !== $feed->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}
 

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -246,18 +246,27 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_registration_state( $result ) {
 
-		$extra_info = '';
+		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
+		$feed_id     = Pinterest_For_Woocommerce()::get_data( 'feed_registered' );
+		$extra_info  = '';
 
 		try {
 
-			// Get the merchant object.
-			$merchant = Pinterest\Merchants::get_merchant();
+			if ( empty( $merchant_id ) || empty( $feed_id ) ) {
+				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
+			}
 
 			if ( 'success' !== $merchant['status'] ) {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			if ( 'ACTIVE' !== $merchant['data']->product_pin_feed_profile->feed_status ) {
+			$feed = Base::get_merchant_feed( $merchant_id, $feed_id );
+
+			if ( ! $feed ) {
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
+			if ( 'ACTIVE' !== $feed->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}
 
@@ -268,13 +277,13 @@ class FeedState extends VendorAPI {
 					$status       = 'success';
 					$status_label = esc_html__( 'Product feed configured for ingestion on Pinterest', 'pinterest-for-woocommerce' );
 
-					if ( ! empty( $merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_freq ) ) {
+					if ( ! empty( $feed->location_config->full_feed_fetch_freq ) ) {
 						$extra_info = wp_kses_post(
 							sprintf(
 								/* Translators: %1$s The URL of the product feed, %2$s Time string */
 								__( 'Pinterest will fetch your <a href="%1$s" target="_blank">product feed</a> every %2$s', 'pinterest-for-woocommerce' ),
-								$merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_location,
-								human_time_diff( 0, ( $merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_freq / 1000 ) )
+								$feed->location_config->full_feed_fetch_location,
+								human_time_diff( 0, ( $feed->location_config->full_feed_fetch_freq / 1000 ) )
 							)
 						);
 					}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -256,11 +256,17 @@ class FeedState extends VendorAPI {
 				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
 			}
 
+			$merchant = Base::get_merchant( $merchant_id );
+
 			if ( 'success' !== $merchant['status'] ) {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
 			$feed = Base::get_merchant_feed( $merchant_id, $feed_id );
+
+			if ( ! $feed ) {
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
+			}
 
 			if ( 'ACTIVE' !== $feed->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -246,29 +246,18 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_registration_state( $result ) {
 
-		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
-		$feed_id     = Pinterest_For_Woocommerce()::get_data( 'feed_registered' );
-		$extra_info  = '';
+		$extra_info = '';
 
 		try {
 
-			if ( empty( $merchant_id ) || empty( $feed_id ) ) {
-				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
-			}
-
-			$merchant = Base::get_merchant( $merchant_id );
+			// Get the merchant object.
+			$merchant = Pinterest\Merchants::get_merchant();
 
 			if ( 'success' !== $merchant['status'] ) {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			$feed = Base::get_merchant_feed( $merchant_id, $feed_id );
-
-			if ( ! $feed ) {
-				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
-			}
-
-			if ( 'ACTIVE' !== $feed->feed_status ) {
+			if ( 'ACTIVE' !== $merchant['data']->product_pin_feed_profile->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -520,17 +520,6 @@ class ProductSync {
 			self::log( 'Pinterest returned a Declined status for product_pin_approval_status' );
 
 		} else {
-			$product_pin_feed_profile    = $merchant['data']->product_pin_feed_profile;
-			$product_pin_feed_profile_id = false;
-			$prev_registered             = self::get_registered_feed_id();
-			if ( false !== $prev_registered ) {
-				try {
-					$feed                        = API\Base::get_merchant_feed_report( $merchant['data']->id, $prev_registered );
-					$product_pin_feed_profile_id = $feed['data']->feed_profile_id;
-				} catch ( \Throwable $e ) {
-					$product_pin_feed_profile_id = false;
-				}
-			}
 
 			// Update feed if we don't have a feed_id saved or if local feed is not properly registered.
 			// for cases where the already existed in the API.

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -520,6 +520,17 @@ class ProductSync {
 			self::log( 'Pinterest returned a Declined status for product_pin_approval_status' );
 
 		} else {
+			$product_pin_feed_profile    = $merchant['data']->product_pin_feed_profile;
+			$product_pin_feed_profile_id = false;
+			$prev_registered             = self::get_registered_feed_id();
+			if ( false !== $prev_registered ) {
+				try {
+					$feed                        = API\Base::get_merchant_feed_report( $merchant['data']->id, $prev_registered );
+					$product_pin_feed_profile_id = $feed['data']->feed_profile_id;
+				} catch ( \Throwable $e ) {
+					$product_pin_feed_profile_id = false;
+				}
+			}
 
 			// Update feed if we don't have a feed_id saved or if local feed is not properly registered.
 			// for cases where the already existed in the API.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #228 .

**Replaces the already approved #293 as due to some issues in the original repo, the change-set was incorrect**

**The original PR which also shows the original file changes is [here](https://github.com/saucal/pinterest-for-woocommerce/pull/6)**

---

When a merchant has multiple feeds, we should get the feed report, in order to populate the status of the feed, using the stored feed_id. 

### Screenshots:
![image](https://user-images.githubusercontent.com/4016167/145265426-327a9c4a-38f8-4ee3-8c40-14fefa9c4d72.png)

<!--- Optional --->


### Detailed test instructions:

1. Create a feed profile using https://www.pinterest.com/product-catalogs/ directly and then disable it.
2. Install & finish onboarding of the plugin so that a new feed profile is registered by the plugin.
3. Verify that the status shown in the product catalog page is of the expected feed (the one created by the plugin).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:




Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Get feed report for the stored Feed ID instead for the first feed returned by the API.
> Add - get_merchant_feed_report() method that fetches the feed_report
> Tweak - get_merchant_feed() now fetches the feed instead of the feed_report.

