### PR TITLE
Exclude products with zero price on feed generation

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -243,6 +243,20 @@ class FeedGenerator extends AbstractChainedJob {
 
 			$products = wc_get_products( $products_query_args );
 
+			// Exclude products with zero price.
+			$products = array_filter(
+				$products,
+				function ( $product ) {
+					if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
+						$price = $product->get_variation_regular_price();
+					} else {
+						$price = $product->get_regular_price();
+					}
+
+					return ! ( empty( $price ) || empty( floatval( $price ) ) );
+				}
+			);
+
 			$this->prepare_feed_buffers();
 
 			array_walk(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #265 .

Exclude $0.00 price products on feed generation.
---
**Pinterest** does not support ingesting $0.00 price products.

### Screenshots:

### Detailed test instructions:
1. Add a product with 0.00 price
2. Verify that is not included in the feed

### Additional details:
### Changelog entry
