### PR TITLE
Allow code to create merchant when no merchant was found.

### DIFF
--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -59,7 +59,7 @@ class Merchants {
 			try {
 				$merchant = Base::get_merchant( $merchant_id );
 			} catch ( Throwable $th ) {
-				throw new Exception( __( 'There was an error trying to get the merchant object.', 'pinterest-for-woocommerce' ), 400 );
+				$merchant = false;
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #338  .

It looks like the code introduced in #305 

https://github.com/woocommerce/pinterest-for-woocommerce/pull/305/files?diff=unified&w=0#diff-165dc486d272cdd52e9f8f67ea2fd88e3dacf5e7600d6e2e398303fb46cf04d0R62

was too aggressive in throwing errors. In the case of the initial setup, this was blocking the code that should be executed after the throw. This code would set up everything correctly during the first pass.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Check #338 for reproduction and testing instructions.

### Additional details:
With this accepted, we will need to release 1.0.3 with this patch.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Allow proper setup for new merchants with no catalogs.
