### PR TITLE
Fetch and store merchant id during setup.

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -246,17 +246,25 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_registration_state( $result ) {
 
+		$merchant    = null;
 		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
 		$feed_id     = Pinterest_For_Woocommerce()::get_data( 'feed_registered' );
 		$extra_info  = '';
 
 		try {
 
+			if ( empty( $merchant_id ) ) {
+				$merchant    = Pinterest\Merchants::get_merchant();
+				$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
+			}
+
 			if ( empty( $merchant_id ) || empty( $feed_id ) ) {
 				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
 			}
 
-			$merchant = Base::get_merchant( $merchant_id );
+			if ( empty( $merchant ) ) {
+				$merchant = Base::get_merchant( $merchant_id );
+			}
 
 			if ( 'success' !== $merchant['status'] ) {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -71,6 +71,8 @@ class Merchants {
 				throw new Exception( __( 'Wrong response when trying to create or update merchant.', 'pinterest-for-woocommerce' ), 400 );
 			}
 
+			$merchant_id = $response['merchant_id'];
+
 			try {
 				$merchant = Base::get_merchant( $merchant_id );
 			} catch ( Throwable $th ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #342  .

This adjusts the logic introduced in https://github.com/woocommerce/pinterest-for-woocommerce/pull/335 and in https://github.com/woocommerce/pinterest-for-woocommerce/pull/305
Before this change the code was setting up the feed but was failing to store the merchant id. This resulted in the scenario where the code did not recognize that the feed and merchant were already set up and was redoing the operation. 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Please check #342 for testing and reproduction instructions.


### Additional details:

I don't really understand why this scenario is different compared to the scenario without a linked business account - If someone knows please share, if not then I will need to dig deeper.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Store merchant id during the account creatioin.
