### PR TITLE
Fix/325 consistent price format

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -418,9 +418,15 @@ class ProductsXmlFeed {
 	 */
 	private static function get_currency_decimals() {
 		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
-		$country     = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
 
-		return $locale_info[ $country ]['num_decimals'] ?? wc_get_price_decimals();
+		$currencies = get_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_currencies_list' );
+
+		if ( ! $currencies ) {
+			$currencies = wp_list_pluck( $locale_info, 'num_decimals', 'currency_code' );
+			set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_currencies_list', $currencies, DAY_IN_SECONDS );
+		}
+
+		return $currencies[ get_woocommerce_currency() ];
 	}
 
 	/** Fetch shipping object.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -426,7 +426,7 @@ class ProductsXmlFeed {
 			set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_currencies_list', $currencies, DAY_IN_SECONDS );
 		}
 
-		return $currencies[ get_woocommerce_currency() ];
+		return $currencies[ get_woocommerce_currency() ] ?? 2;
 	}
 
 	/** Fetch shipping object.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -292,7 +292,7 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '>' . $price . get_woocommerce_currency() . '</' . $property . '>';
+		return '<' . $property . '>' . wc_format_decimal( $price, wc_get_price_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
 	}
 
 	/**
@@ -317,7 +317,7 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '>' . $price . get_woocommerce_currency() . '</' . $property . '>';
+		return '<' . $property . '>' . wc_format_decimal( $price, wc_get_price_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -417,11 +417,11 @@ class ProductsXmlFeed {
 	 * Get locale currency decimals
 	 */
 	private static function get_currency_decimals() {
-		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
-
 		$currencies = get_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_currencies_list' );
 
 		if ( ! $currencies ) {
+			$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+
 			$currencies = wp_list_pluck( $locale_info, 'num_decimals', 'currency_code' );
 			set_transient( PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_currencies_list', $currencies, DAY_IN_SECONDS );
 		}

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -292,7 +292,7 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '>' . wc_format_decimal( $price, wc_get_price_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
+		return '<' . $property . '>' . wc_format_decimal( $price, self::get_currency_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
 	}
 
 	/**
@@ -317,7 +317,7 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '>' . wc_format_decimal( $price, wc_get_price_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
+		return '<' . $property . '>' . wc_format_decimal( $price, self::get_currency_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
 	}
 
 	/**
@@ -376,5 +376,14 @@ class ProductsXmlFeed {
 		}
 
 		return wp_list_pluck( $terms, 'name' );
+	}
+
+	/**
+	 * Get locale currency decimals
+	 */
+	private static function get_currency_decimals() {
+		$locale = localeconv();
+
+		return $locale['num_decimals'] ?? wc_get_price_decimals();
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -423,7 +423,7 @@ class ProductsXmlFeed {
 		return $locale_info[ $country ]['num_decimals'] ?? wc_get_price_decimals();
 	}
 
-	 * Fetch shipping object.
+	/** Fetch shipping object.
 	 *
 	 * @since x.x.x
 	 *

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -382,8 +382,9 @@ class ProductsXmlFeed {
 	 * Get locale currency decimals
 	 */
 	private static function get_currency_decimals() {
-		$locale = localeconv();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$country     = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
 
-		return $locale['num_decimals'] ?? wc_get_price_decimals();
+		return $locale_info[ $country ]['num_decimals'] ?? wc_get_price_decimals();
 	}
 }

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -90,7 +90,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( 'in stock', $g_children['availability'] );
 
 		// Default price from WC_Helper_Product.
-		$this->assertEquals( '10USD', $g_children['price'] );
+		$this->assertEquals( '10.00USD', $g_children['price'] );
 
 		// No description set.
 		$this->assertArrayNotHasKey( 'image_link', $g_children, "By default product does not have an image link." );
@@ -309,7 +309,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$price_method = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
 		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
 		$xml          = $price_method( $product );
-		$this->assertEquals( '<g:price>15USD</g:price>', $xml );
+		$this->assertEquals( '<g:price>15.00USD</g:price>', $xml );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 			)
 		);
 		$xml     = $sale_price_method( $product );
-		$this->assertEquals( '<sale_price>5USD</sale_price>', $xml );
+		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $xml );
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -310,6 +310,17 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
 		$xml          = $price_method( $product );
 		$this->assertEquals( '<g:price>15.00USD</g:price>', $xml );
+
+		// Test with another currency.
+		$old_currency = get_woocommerce_currency();
+		update_option( 'woocommerce_currency', 'JPY' );
+		$price_method = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
+		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
+		$xml          = $price_method( $product );
+		$this->assertEquals( '<g:price>15JPY</g:price>', $xml );
+
+		// Update again the currency to the old currency.
+		update_option( 'woocommerce_currency', $old_currency );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #325 .

Add the prices to the feed with the proper decimal format like 10.00USD (second format of the screenshot).
UT was updated to success with the new changes.


### Screenshots:

![149070840-9fa2244d-f306-4b30-8626-73ecca462068](https://user-images.githubusercontent.com/40774170/151850671-226e28d2-61cf-4bbf-8961-f1005592108a.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a product with a non-decimal price (like 10USD).
2. Verify that the price in the feed is in decimal format (like 10.00USD).
3. Verify that UT are success with the new changes.


### Additional details:

### Changelog entry

> Update - Ensure that the prices are formatted in a consistent way across the feed file.