### PR TITLE
Use Pinterest dasicon for the Pinterest Attribues tab.

### DIFF
--- a/assets/source/product-attributes/style.scss
+++ b/assets/source/product-attributes/style.scss
@@ -40,6 +40,15 @@
 	}
 }
 
+#woocommerce-product-data ul.wc-tabs li.pinterest_attributes_tab{
+
+	a::before {
+
+		content: "\f192";
+
+	}
+}
+
 .gla-channel-visibility-box .form-row > select {
 	display: block;
 	margin: 8px 0;

--- a/assets/source/product-attributes/style.scss
+++ b/assets/source/product-attributes/style.scss
@@ -40,7 +40,7 @@
 	}
 }
 
-#woocommerce-product-data ul.wc-tabs li.pinterest_attributes_tab{
+#woocommerce-product-data ul.wc-tabs li.pinterest_attributes_tab {
 
 	a::before {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use Pinterest Dashicon for product attributes tab.

### Screenshots:

From this:
![image](https://user-images.githubusercontent.com/17271089/152029367-80a3b9ac-fd7d-4c25-a557-1efe16f77a3c.png)

to this:
![image](https://user-images.githubusercontent.com/17271089/152029993-e4bf6d00-2afa-415c-b724-d95f32cb1f14.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

0. Build the assets
1. Open then wp-admin
2. Open products.
3. Got to a product.
4. Observe the icon :) 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry
