### PR TITLE
Omit zero price products

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -180,7 +180,7 @@ class FeedState extends VendorAPI {
 					/* Translators: %1$s Time string, %2$s current index of written products, %3$s total number of products, %4$s Opening link tag, %5$s closing link tag */
 					esc_html__( 'Last activity: %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['current_index'],
+					$state['current_products'],
 					$state['product_count'],
 					'<a href="' . $local_feed['feed_url'] . '" target="_blank">',
 					'</a>',
@@ -194,7 +194,7 @@ class FeedState extends VendorAPI {
 					/* Translators: %1$s Time string, %2$s current index of written products, %3$s total number of products, %4$s Opening link tag, %5$s closing link tag */
 					esc_html__( 'Successfully generated %1$s ago - Wrote %2$s out of %3$s products to %4$sfeed file%5$s.', 'pinterest-for-woocommerce' ),
 					human_time_diff( $state['last_activity'] ),
-					$state['current_index'],
+					$state['current_products'],
 					$state['product_count'],
 					'<a href="' . $local_feed['feed_url'] . '" target="_blank">',
 					'</a>',

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -18,11 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ProductFeedStatus {
 
 	const STATE_PROPS = array(
-		'status'        => 'pending_config',
-		'current_index' => false,
-		'last_activity' => 0,
-		'product_count' => 0,
-		'error_message' => '',
+		'status'           => 'pending_config',
+		'current_index'    => false,
+		'current_products' => 0,
+		'last_activity'    => 0,
+		'product_count'    => 0,
+		'error_message'    => '',
 	);
 
 	/**

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -382,7 +382,7 @@ class ProductSync {
 
 				$xml_item = ProductsXmlFeed::get_xml_item( wc_get_product( $product_id ) );
 
-				if ( $xml_item ) {
+				if ( '' !== $xml_item ) {
 					$products_fit_count++;
 					$step_fit_products++;
 					self::$current_products++;

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -41,7 +41,7 @@ class ProductSync {
 	 *
 	 * @var integer
 	 */
-	private static $products_per_step = 50;
+	private static $products_per_step = 500;
 
 	/**
 	 * The number of products to hold in a buffer variable before writing their XML output to a file.
@@ -49,7 +49,7 @@ class ProductSync {
 	 *
 	 * @var integer
 	 */
-	private static $products_per_write = 25;
+	private static $products_per_write = 100;
 
 	/**
 	 * The current index of the loop iterating through feed creation steps.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Pinterest;
 use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
 use WC_Product_Variation;
 use WC_Product;
+use WC_Product_Variable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -288,11 +289,7 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_g_price( $product, $property ) {
 
-		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
-			$price = $product->get_variation_regular_price();
-		} else {
-			$price = $product->get_regular_price();
-		}
+		$price = self::get_product_regular_price( $product );
 
 		if ( empty( $price ) ) {
 			return;
@@ -445,5 +442,22 @@ class ProductsXmlFeed {
 			wc_load_cart();
 		}
 		return self::$shipping;
+	}
+
+	/**
+	 * Helper method to return the regular price of a product.
+	 *
+	 * @param WC_Product|WC_Product_Variable $product The product.
+	 *
+	 * @return string
+	 */
+	private static function get_product_regular_price( $product ) {
+		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
+			$price = $product->get_variation_regular_price();
+		} else {
+			$price = $product->get_regular_price();
+		}
+
+		return $price;
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -76,12 +76,12 @@ class ProductsXmlFeed {
 	 *
 	 * @param WC_Product $product  The product to print the XML for.
 	 *
-	 * @return string|null
+	 * @return string XML string
 	 */
 	public static function get_xml_item( $product ) {
 
 		if ( ! self::is_product_fit_for_feed( $product ) ) {
-			return null;
+			return '';
 		}
 
 		$xml = "\t\t<item>" . PHP_EOL;

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -74,11 +74,15 @@ class ProductsXmlFeed {
 	/**
 	 * Returns the Item's XML for the given product.
 	 *
-	 * @param WC_Product $product The product to print the XML for.
+	 * @param WC_Product $product  The product to print the XML for.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public static function get_xml_item( $product ) {
+
+		if ( ! self::is_product_fit_for_feed( $product ) ) {
+			return null;
+		}
 
 		$xml = "\t\t<item>" . PHP_EOL;
 
@@ -96,6 +100,27 @@ class ProductsXmlFeed {
 
 		return apply_filters( 'pinterest_for_woocommerce_feed_item_xml', $xml, $product );
 	}
+
+
+	/**
+	 * Helper method to return if a product is fit for the feed profile.
+	 *
+	 * @param WC_Product $product The product.
+	 *
+	 * @return boolean
+	 */
+	private static function is_product_fit_for_feed( $product ) {
+
+		// Decide if product is fit for the feed based on price.
+		$price = self::get_product_regular_price( $product );
+
+		if ( empty( $price ) || empty( floatval( $price ) ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
 
 	/**
 	 * Get the XML for all the product attributes.

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -115,6 +115,24 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test if a product with price set to 0 is skipped from the feed
+	 *
+	 * @group feed
+	 */
+	public function testSkipZeroPriceProductXML() {
+		// Create product with zero price
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 0,
+			)
+		);
+
+		$xml = ProductsXmlFeed::get_xml_item( $product );
+		$this->assertEquals( null, $xml );
+	}
+
+	/**
 	 * @group feed
 	 */
 	public function testDescriptionForSimpleProductXML() {

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -129,7 +129,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		);
 
 		$xml = ProductsXmlFeed::get_xml_item( $product );
-		$this->assertEquals( null, $xml );
+		$this->assertEquals( '', $xml );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #265 .

Exclude $0.00 price products on feed generation.
---
**Pinterest** does not support ingesting $0.00 price products.

### Screenshots:

### Detailed test instructions:
1. Add a product with 0.00 price
2. Verify that is not included in the feed

### Additional details:
### Changelog entry

> Update - Omit zero price products from the feed file.