### PR TITLE
Fix/323 strip html shortcodes from feed

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Pinterest;
 use Automattic\WooCommerce\Pinterest\Product\Attributes\AttributeManager;
 use WC_Product_Variation;
 use WC_Product;
+use Automattic\WooCommerce\Pinterest\Logger;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -42,6 +43,14 @@ class ProductsXmlFeed {
 		'g:shipping',
 		'g:additional_image_link',
 	);
+
+
+	/**
+	 * Limit of characters allowed by Pinterest in the product description.
+	 *
+	 * @var int
+	 */
+	private static $limit_chars_product_description = 10000;
 
 
 	/**
@@ -204,7 +213,12 @@ class ProductsXmlFeed {
 		$description = str_replace( '[&hellip;]', '...', $description );
 
 		// Limit the number of characters in the description to 10000.
-		return '<' . $property . '><![CDATA[' . substr( $description, 0, 10000 ) . ']]></' . $property . '>';
+		if ( strlen( $description ) > 10000 ) {
+			Logger::log( sprintf( esc_html__( 'The product [%s] has a description longer than the allowed limit.', 'pinterest-for-woocommerce' ), $product->get_id() ) );
+		}
+		$description = substr( $description, 0, self::$limit_chars_product_description );
+
+		return '<' . $property . '><![CDATA[' . $description . ']]></' . $property . '>';
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -214,6 +214,7 @@ class ProductsXmlFeed {
 
 		// Limit the number of characters in the description to 10000.
 		if ( strlen( $description ) > 10000 ) {
+			/* Translators: Warning for long description */
 			Logger::log( sprintf( esc_html__( 'The product [%s] has a description longer than the allowed limit.', 'pinterest-for-woocommerce' ), $product->get_id() ) );
 		}
 		$description = substr( $description, 0, self::$limit_chars_product_description );

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -159,7 +159,7 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_property_title( $product, $property ) {
-		return '<' . $property . '><![CDATA[' . $product->get_name() . ']]></' . $property . '>';
+		return '<' . $property . '><![CDATA[' . wp_strip_all_tags( $product->get_name() ) . ']]></' . $property . '>';
 	}
 
 	/**
@@ -182,7 +182,26 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '><![CDATA[' . $description . ']]></' . $property . '>';
+		/**
+		 * Filters whether the shortcodes should be applied for product descriptions when generating the feed or be stripped out.
+		 *
+		 * @param bool       $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
+		 * @param WC_Product $product          WooCommerce product object.
+		 */
+		$apply_shortcodes = apply_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes', false, $product );
+		if ( $apply_shortcodes ) {
+			// Apply active shortcodes.
+			$description = do_shortcode( $description );
+		} else {
+			// Strip out active shortcodes.
+			$description = strip_shortcodes( $description );
+		}
+
+		// Strip HTML tags from description.
+		$description = wp_strip_all_tags( $description );
+
+		// Limit the number of characters in the description to 10000.
+		return '<' . $property . '><![CDATA[' . substr( $description, 0, 10000 ) . ']]></' . $property . '>';
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -58,7 +58,7 @@ class ProductsXmlFeed {
 	 *
 	 * @var int
 	 */
-	private static $limit_chars_product_description = 10000;
+	const DESCRIPTION_SIZE_CHARS_LIMIT = 10000;
 
 
 	/**
@@ -246,11 +246,11 @@ class ProductsXmlFeed {
 		$description = str_replace( '[&hellip;]', '...', $description );
 
 		// Limit the number of characters in the description to 10000.
-		if ( strlen( $description ) > 10000 ) {
+		if ( strlen( $description ) > self::DESCRIPTION_SIZE_CHARS_LIMIT ) {
 			/* Translators: Warning for long description */
 			Logger::log( sprintf( esc_html__( 'The product [%s] has a description longer than the allowed limit.', 'pinterest-for-woocommerce' ), $product->get_id() ) );
 		}
-		$description = substr( $description, 0, self::$limit_chars_product_description );
+		$description = substr( $description, 0, self::DESCRIPTION_SIZE_CHARS_LIMIT );
 
 		return '<' . $property . '><![CDATA[' . $description . ']]></' . $property . '>';
 	}

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -247,7 +247,7 @@ class ProductsXmlFeed {
 
 		// Limit the number of characters in the description to 10000.
 		if ( strlen( $description ) > self::DESCRIPTION_SIZE_CHARS_LIMIT ) {
-			/* Translators: Warning for long description */
+			/* translators: %s product id */
 			Logger::log( sprintf( esc_html__( 'The product [%s] has a description longer than the allowed limit.', 'pinterest-for-woocommerce' ), $product->get_id() ) );
 		}
 		$description = substr( $description, 0, self::DESCRIPTION_SIZE_CHARS_LIMIT );

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -200,6 +200,9 @@ class ProductsXmlFeed {
 		// Strip HTML tags from description.
 		$description = wp_strip_all_tags( $description );
 
+		// Strip [&hellip] character from description.
+		$description = str_replace( '[&hellip;]', '...', $description );
+
 		// Limit the number of characters in the description to 10000.
 		return '<' . $property . '><![CDATA[' . substr( $description, 0, 10000 ) . ']]></' . $property . '>';
 	}

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -235,6 +235,21 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	/**
 	 * @group feed
 	 */
+	public function testStripHtmlTagsPropertyDescriptionXML() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+		$product            = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'short_description' => 'Dummy Description <h1>Dummy Tag</h1>',
+			)
+		);
+		$xml                = $description_method( $product );
+		$this->assertEquals( '<description><![CDATA[Dummy Description Dummy Tag]]></description>', $xml );
+	}
+
+	/**
+	 * @group feed
+	 */
 	public function testPropertyProductTypeXML() {
 		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
 		$product             = WC_Helper_Product::create_simple_product();

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -220,6 +220,21 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	/**
 	 * @group feed
 	 */
+	public function testStripHtmlTagsPropertyTitleXML() {
+		$title_method = $this->getProductsXmlFeedAttributeMethod( 'title' );
+		$product      = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Dummy Product <h1>Dummy Tag</h1>',
+			)
+		);
+		$xml          = $title_method( $product );
+		$this->assertEquals( '<title><![CDATA[Dummy Product Dummy Tag]]></title>', $xml );
+	}
+
+	/**
+	 * @group feed
+	 */
 	public function testPropertyProductTypeXML() {
 		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
 		$product             = WC_Helper_Product::create_simple_product();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #323 
Closes #344 

The PR aims to strip the HTML tags and shortcodes from feed file.

- ProductsXmlFeed::description creates an XML that conforms the requirements in the documentation.
- The shortcodes are stripped from description field by default.
- Added a filter to allow merchants to enable shortcodes to be applied if they wish.
- Added unit tests.

### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/152207293-6a958671-2faf-480f-91ea-aa354a0fd05c.png)


### Detailed test instructions:
1. Create a simple product.
2. Add HTML tags on the title.
3. Add a shortcode and/or HTML tags on the product's description.
4. Verify that HTML tags were stripped in title and description fields.
5. Verify that shortcodes are stripped by default from the description field.
6. Shortcode in product's description should be allowed if the filter `pinterest_for_woocommerce_product_description_apply_shortcodes` returns `true`.

### Additional details:

### Changelog entry
> Update - Strip html shortcodes from feed entries.