### PR TITLE
Remove unused css copy from GLA.

### DIFF
--- a/assets/source/product-attributes/style.scss
+++ b/assets/source/product-attributes/style.scss
@@ -48,9 +48,3 @@
 
 	}
 }
-
-.gla-channel-visibility-box .form-row > select {
-	display: block;
-	margin: 8px 0;
-	max-width: 100%;
-}


### PR DESCRIPTION
Per this commit note from a different pull request https://github.com/woocommerce/pinterest-for-woocommerce/pull/349#pullrequestreview-870449178

This change has no effect. Removed CSS was not used.