### PR TITLE
Avoid to constantly create transient options

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -247,6 +247,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
+
+			// Enable customer session if tracking is enabled.
+			add_action( 'woocommerce_init', array( $this, 'enable_woocommerce_session' ) );
 		}
 
 
@@ -276,6 +279,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$admin->register();
 			$attributes_tab->register();
 			$variation_attributes->register();
+		}
+
+		/**
+		 * Enable WC_Sessions on woocommerce_init to track events for unauthorized users.
+		 *
+		 * @return void
+		 */
+		public function enable_woocommerce_session() {
+			if ( is_user_logged_in() || is_admin() || ! self::is_tracking_configured() ) {
+				return;
+			}
+
+			if ( isset( WC()->session ) && ! WC()->session->has_session() ) {
+				WC()->session->set_customer_session_cookie( true );
+			}
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -248,8 +248,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
-			// Enable customer session if tracking is enabled.
-			add_action( 'woocommerce_init', array( $this, 'enable_woocommerce_session' ) );
 		}
 
 
@@ -279,21 +277,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$admin->register();
 			$attributes_tab->register();
 			$variation_attributes->register();
-		}
-
-		/**
-		 * Enable WC_Sessions on woocommerce_init to track events for unauthorized users.
-		 *
-		 * @return void
-		 */
-		public function enable_woocommerce_session() {
-			if ( is_user_logged_in() || is_admin() || ! self::is_tracking_configured() ) {
-				return;
-			}
-
-			if ( isset( WC()->session ) && ! WC()->session->has_session() ) {
-				WC()->session->set_customer_session_cookie( true );
-			}
 		}
 
 		/**

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -93,7 +93,7 @@ class Tracking {
 			}
 
 			// AddToCart - non-ajax.
-			add_action( 'woocommerce_add_to_cart', array( __CLASS__, 'hook_add_to_cart_event' ), 10, 4 );
+			add_action( 'woocommerce_add_to_cart', array( __CLASS__, 'hook_add_to_cart_event' ), 20, 4 );
 
 			// Checkout.
 			add_action( 'woocommerce_before_thankyou', array( __CLASS__, 'hook_checkout_event' ), 10, 1 );

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -105,7 +105,7 @@ class Tracking {
 		add_action( 'shutdown', array( __CLASS__, 'save_async_events' ) );
 
 		// Print to head.
-		add_action( 'wp_head', array( __CLASS__, 'print_script' ), 10 );
+		add_action( 'wp_head', array( __CLASS__, 'print_script' ) );
 
 		add_action( 'admin_init', array( __CLASS__, 'verify_advertiser_connection' ) );
 	}

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -84,7 +84,7 @@ class Tracking {
 		if ( function_exists( 'WC' ) ) {
 
 			if ( ! wp_doing_ajax() ) {
-				add_action( 'wp', array( __CLASS__, 'late_events_handling' ) );
+				add_action( 'wp_head', array( __CLASS__, 'late_events_handling' ), 20 );
 			}
 
 			// AddToCart - ajax.
@@ -105,7 +105,7 @@ class Tracking {
 		add_action( 'shutdown', array( __CLASS__, 'save_async_events' ) );
 
 		// Print to head.
-		add_action( 'wp_head', array( __CLASS__, 'print_script' ) );
+		add_action( 'wp_head', array( __CLASS__, 'print_script' ), 10 );
 
 		add_action( 'admin_init', array( __CLASS__, 'verify_advertiser_connection' ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #336 .
Closes #359 .

The plugin is creating some uncaught transient events (for the event `pagevisit`).

---
The name of the transients are based on the customer_id of the user, when a user that is not logged nor registered visits a page a transient is generated and since the customer_id is not set, the transient can't be caught on `shutdown` to print it and remove it.
We need to change the logic that captures the events in order to print all events in the same runtime and avoid storing transients for anonymous users. We are only storing the transient for `add_to_cart` events when redirect to cart is enabled.

### Screenshots:


### Detailed test instructions:
1. Install Pinterest for WooCommerce.
2. Navigate on the site.
3. Transient options for pagevisit event should not remain on wp_options table.


### Additional details:
