### PR TITLE
Use website verification instead of domains

### DIFF
--- a/assets/source/setup-guide/app/data/settings/selectors.js
+++ b/assets/source/setup-guide/app/data/settings/selectors.js
@@ -59,11 +59,15 @@ export const isDomainVerified = ( state ) => {
 		return false;
 	}
 
-	const { hostname } = new URL(
+	const { hostname, pathname } = new URL(
 		wcSettings.pinterest_for_woocommerce.homeUrlToVerify
 	);
+
+	// Build url for single site and multisite.
+	const urlToVerify = pathname !== '/' ? hostname + pathname : hostname;
+
 	return state?.settings?.account_data?.verified_user_websites.includes(
-		hostname
+		urlToVerify
 	);
 };
 

--- a/assets/source/setup-guide/app/data/settings/selectors.js
+++ b/assets/source/setup-guide/app/data/settings/selectors.js
@@ -55,14 +55,16 @@ export const isDomainVerified = ( state ) => {
 		return;
 	}
 
-	if ( undefined === state?.settings?.account_data?.verified_domains ) {
+	if ( undefined === state?.settings?.account_data?.verified_user_websites ) {
 		return false;
 	}
 
 	const { hostname } = new URL(
 		wcSettings.pinterest_for_woocommerce.homeUrlToVerify
 	);
-	return state?.settings?.account_data?.verified_domains.includes( hostname );
+	return state?.settings?.account_data?.verified_user_websites.includes(
+		hostname
+	);
 };
 
 /**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -941,7 +941,29 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function is_domain_verified() {
 			$account_data = self::get_setting( 'account_data' );
+
+			if ( isset( $account_data['domain_verified'] ) && isset( $account_data['verified_domains'] ) ) {
+				$verification_response = self::migrate_domain_to_website_verification_data();
+
+				if ( ! is_wp_error( $verification_response ) ) {
+					// Successful verification, cleaning old data.
+					unset( $account_data['domain_verified'] );
+					unset( $account_data['verified_domains'] );
+				} else {
+					// There was an error, returning old data.
+					return isset( $account_data['verified_domains'] ) ? (bool) $account_data['verified_domains'] : false;
+				}
+			}
+
 			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
+		}
+
+
+		/**
+		 * Migrate the old domain verification to website verification
+		 */
+		private static function migrate_domain_to_website_verification_data() {
+			return Pinterest\API\DomainVerification::trigger_domain_verification();
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -769,13 +769,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				$data = array_intersect_key(
 					(array) $account_data['data'],
 					array(
-						'verified_domains' => '',
-						'domain_verified'  => '',
-						'username'         => '',
-						'full_name'        => '',
-						'id'               => '',
-						'image_medium_url' => '',
-						'is_partner'       => '',
+						'verified_user_websites' => '',
+						'domain_verified'        => '',
+						'username'               => '',
+						'full_name'              => '',
+						'id'                     => '',
+						'image_medium_url'       => '',
+						'is_partner'             => '',
 					)
 				);
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -769,13 +769,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				$data = array_intersect_key(
 					(array) $account_data['data'],
 					array(
-						'verified_user_websites' => '',
-						'domain_verified'        => '',
-						'username'               => '',
-						'full_name'              => '',
-						'id'                     => '',
-						'image_medium_url'       => '',
-						'is_partner'             => '',
+						'verified_user_websites'  => '',
+						'is_any_website_verified' => '',
+						'username'                => '',
+						'full_name'               => '',
+						'id'                      => '',
+						'image_medium_url'        => '',
+						'is_partner'              => '',
 					)
 				);
 
@@ -941,7 +941,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function is_domain_verified() {
 			$account_data = self::get_setting( 'account_data' );
-			return isset( $account_data['domain_verified'] ) ? (bool) $account_data['domain_verified'] : false;
+			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
 		}
 
 

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -363,7 +363,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'serviceLoginUrl'          => $this->get_service_login_url(),
 				'createBusinessAccountUrl' => $this->get_create_business_account_url(),
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
-				'homeUrlToVerify'          => home_url(),
+				'homeUrlToVerify'          => get_home_url(),
 				'storeCountry'             => $store_country,
 				'isAdsSupportedCountry'    => in_array( $store_country, Pinterest_For_Woocommerce_Ads_Supported_Countries::get_countries(), true ),
 				'isConnected'              => ! empty( Pinterest_For_Woocommerce()::is_connected() ),

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -275,24 +275,21 @@ class Base {
 	 * @return mixed
 	 */
 	public static function domain_verification_data() {
-		return self::make_request( 'domains/verification', 'GET' );
+		return self::make_request( 'websites/verification', 'GET' );
 	}
 
 
 	/**
 	 * Trigger the (realtime) verification process using the API and return the response.
 	 *
-	 * @param boolean $allow_multiple Parameter passed to the API.
 	 * @return mixed
 	 */
-	public static function trigger_verification( $allow_multiple = true ) {
+	public static function trigger_verification() {
 
-		$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
-		$request_url = "domains/{$domain}/verification/metatag/realtime/";
+		$request_url = 'websites/verification/metatag/realtime/';
 
-		if ( $allow_multiple ) {
-			$request_url = add_query_arg( 'can_claim_multiple', 'true', $request_url );
-		}
+		$parsed_website = wp_parse_url( get_home_url() );
+		$request_url    = add_query_arg( 'website', $parsed_website['host'] . $parsed_website['path'], $request_url );
 
 		return self::make_request( $request_url, 'POST' );
 	}

--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -51,7 +51,18 @@ class DomainVerification extends VendorAPI {
 	 * @throws \Exception PHP Exception.
 	 */
 	public function handle_verification() {
+		return self::trigger_domain_verification();
+	}
 
+
+	/**
+	 * Triggers the realtime verification process using the Pinterst API.
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public static function trigger_domain_verification() {
 		static $verification_data;
 
 		try {

--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -27,7 +27,7 @@ class DomainVerification extends VendorAPI {
 	 *
 	 * @var integer
 	 */
-	private $verification_attempts_remaining = 3;
+	private static $verification_attempts_remaining = 3;
 
 	/**
 	 * Initialize class
@@ -93,9 +93,9 @@ class DomainVerification extends VendorAPI {
 
 			$error_code = $th->getCode() >= 400 ? $th->getCode() : 400;
 
-			if ( 403 === $error_code && $this->verification_attempts_remaining > 0 ) {
-				$this->verification_attempts_remaining--;
-				Logger::log( sprintf( 'Retrying domain verification in 5 seconds. Attempts left: %d', $this->verification_attempts_remaining ), 'debug' );
+			if ( 403 === $error_code && self::$verification_attempts_remaining > 0 ) {
+				self::$verification_attempts_remaining--;
+				Logger::log( sprintf( 'Retrying domain verification in 5 seconds. Attempts left: %d', self::$verification_attempts_remaining ), 'debug' );
 				sleep( 5 );
 				return call_user_func( __METHOD__ );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #354 .

Switch from domain to websites verification API. This will allow users domain + path level verification.


### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/153241530-efce23b1-15fb-45ee-8d8d-b2594e6d08dc.png)

### Detailed test instructions:
1. Setup a WordPress installation that includes a path (e.g: https://example.com/us-site).
2. Install the plugin in the site.
3. The verified domain should include also the path.


### Additional details:

### Changelog entry

