### PR TITLE
Release 1.0.5

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 5.8
 Requires PHP: 7.3
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -87,7 +87,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
-= 1.0.5 - 2022-xx-xx =
+= 1.0.5 - 2022-02-15 =
 * Add – Shipping column for developers and testers.
 
 = 1.0.4 - 2022-02-03 =

--- a/README.txt
+++ b/README.txt
@@ -87,6 +87,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.0.5 - 2022-xx-xx =
+* Add – Shipping column for developers and testers.
+
 = 1.0.4 - 2022-02-03 =
 * Fix - Store merchant id during the account creation. ( [#343](https://github.com/woocommerce/pinterest-for-woocommerce/pull/343) )
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Pinterest for WooCommerce Changelog ***
 
-= 1.0.5 - 2022-xx-xx =
+= 1.0.5 - 2022-02-15 =
 * Add – Shipping column for developers and testers.
 
 = 1.0.4 - 2022-02-03 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.0.5 - 2022-xx-xx =
+* Add – Shipping column for developers and testers.
+
 = 1.0.4 - 2022-02-03 =
 * Fix - Store merchant id during the account creation. ( [#343](https://github.com/woocommerce/pinterest-for-woocommerce/pull/343) )
 

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -3,7 +3,7 @@
  * Ads supported countries.
  *
  * @package     Pinterest
- * @since x.x.x
+ * @since 1.0.5
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     }
   },
   "scripts": {
-    "prebuild": "composer install --no-dev",
+    "prebuild": "composer install --no-dev --no-interaction",
     "build": "wp-scripts build && gulp package",
     "postbuild": "composer install",
     "build:zip": "npm run build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.0.4
+ * Version:           1.0.5
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.4' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.5' ); // WRCS: DEFINED_VERSION.
 
 /**
  * Autoload packages.

--- a/src/PinterestShippingZone.php
+++ b/src/PinterestShippingZone.php
@@ -2,7 +2,7 @@
 /**
  * Represents a single Pinterest shipping zone
  *
- * @since   x.x.x
+ * @since   1.0.5
  * @package Automattic\WooCommerce\Pinterest
  */
 
@@ -18,7 +18,7 @@ use \WC_Shipping_Zone;
  * By extending WC_Shipping_Zone we are able to add functionality necessary for Pinterest shipping column generation.
  * This allows us to operate on familiar interface which will be useful when we will continue to expand the functionality.
  *
- * @since x.x.x
+ * @since 1.0.5
  */
 class PinterestShippingZone extends WC_Shipping_Zone {
 
@@ -49,7 +49,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	/**
 	 * From the list of countries filter out those which are not supported right now.
 	 *
-	 * @since   x.x.x
+	 * @since   1.0.5
 	 *
 	 * @param  array $locations List of countries to filter.
 	 * @return array            List of filtered countries.
@@ -69,7 +69,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	 * States are optional and added only if specified.
 	 * Countries are filtered to only include supported countries.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @return array Array of locations supported by this zone.
 	 */
@@ -129,7 +129,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	 *
 	 * Correctness of this approach is verified indirectly by shipping UT.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param array $locations Array of locations.
 	 * @return array Array of locations with duplications removed.
@@ -141,7 +141,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	/**
 	 * Turn country and state into location array.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param string $country Location country.
 	 * @param string $state   Location state.
@@ -157,7 +157,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	/**
 	 * Combines zone locations with allowed shipping methods.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @return array Array with locations and allowed shipping methods.
 	 */
@@ -180,7 +180,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	 * Get shipping methods supported by the implementation.
 	 * Methods are filtered by allowed types and features.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @return array Supported shipping methods.
 	 */
@@ -201,7 +201,7 @@ class PinterestShippingZone extends WC_Shipping_Zone {
 	/**
 	 * Verify if shipping method is supported.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param WC_Shipping_Method $shipping_method Shipping rate to verify.
 	 * @return boolean

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -428,7 +428,7 @@ class ProductsXmlFeed {
 	/**
 	 * Returns the product shipping information.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param WC_Product $product  The product.
 	 * @param string     $property The name of the property.
@@ -491,7 +491,7 @@ class ProductsXmlFeed {
 
 	/** Fetch shipping object.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @return Shipping
 	 */

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -42,7 +42,7 @@ class ProductsXmlFeed {
 		'sale_price',
 		'g:mpn',
 		'g:tax',
-		'g:shipping',
+		// 'g:shipping',
 		'g:additional_image_link',
 	);
 

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -3,7 +3,7 @@
  * Utility class used by the Feed generation to create the shipping column.
  *
  * @package Pinterest
- * @since   x.x.x
+ * @since   1.0.5
  */
 
 namespace Automattic\WooCommerce\Pinterest;
@@ -27,7 +27,7 @@ use \WC_Data_Store;
  * - Simple products.
  * - Variable products.
  *
- * @since x.x.x
+ * @since 1.0.5
  */
 class Shipping {
 
@@ -41,7 +41,7 @@ class Shipping {
 	/**
 	 * Prepare shipping information for $product.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param  WC_Product $product Product for which we want to generate the shipping column.
 	 * @return array               Shipping information $product.
@@ -98,7 +98,7 @@ class Shipping {
 	 * Get shipping zones defined in WooCommerce settings.
 	 * Cache for efficiency - this information will not change between different products.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @return array Shipping zones.
 	 */
@@ -124,7 +124,7 @@ class Shipping {
 	 * Normally this would be done by checking values in cart. Because we are not operating on cart we filter out
 	 * this value ourselves.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param bool                      $is_available    Wether this shipping method should be available.
 	 * @param array                     $package         Shipping package.
@@ -148,7 +148,7 @@ class Shipping {
 	/**
 	 * Get the lowest possible shipping cost for given location and shipping methods for that location.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param array      $shipping_location Country and state values of the location.
 	 * @param array      $shipping_methods  List of shippings methods we use to calculate the best rate.
@@ -185,7 +185,7 @@ class Shipping {
 	/**
 	 * Pick the best rate from an array of rates.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param  array $rates List of shipping rates.
 	 * @return array        Name and cost for the best found rate or null in case nothing was found.
@@ -216,7 +216,7 @@ class Shipping {
 	/**
 	 * Helper function that packs products into a package structure required by the shipping methods.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.5
 	 *
 	 * @param WC_Product $product  Product to package.
 	 * @param array      $location Product destination location.


### PR DESCRIPTION
This is a PR for 1.0.5 release.

The only way it differs from the `develop` branch is the absence of the shipping column feature. This was done by simply commenting out the `g:shipping` element from the feed structure array.