### PR TITLE
Enable shipping column in feed.

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -42,7 +42,7 @@ class ProductsXmlFeed {
 		'sale_price',
 		'g:mpn',
 		'g:tax',
-		// 'g:shipping',
+		'g:shipping',
 		'g:additional_image_link',
 	);
 


### PR DESCRIPTION
The shipping column was disabled for the 1.0.5 release. We can reenable it now.

After this PR the feed fill will be generated with shipping information. As long as a valid shipping configuration is provided.
The code for this was already tested and reviewed in https://github.com/woocommerce/pinterest-for-woocommerce/pull/331 this just reenables the feature.