### PR TITLE
Escape XML special chars in SKU for the XML MPN section.

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -395,7 +395,7 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_property_g_mpn( $product, $property ) {
-		return '<' . $property . '>' . $product->get_sku() . '</' . $property . '>';
+		return '<' . $property . '>' . esc_xml( $product->get_sku() ) . '</' . $property . '>';
 	}
 
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -533,6 +533,22 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( '<g:mpn>DUMMY SKU</g:mpn>', $xml );
 	}
 
+
+	/**
+	 * @group feed
+	 */
+	public function testEscapeSpecialCharsInSKUForMpnXML() {
+		$mpn_method = $this->getProductsXmlFeedAttributeMethod( 'g:mpn' );
+		$product    = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'sku' => "invalid&sku"
+			)
+		 );
+		$xml        = $mpn_method( $product );
+		$this->assertEquals( '<g:mpn>invalid&amp;sku</g:mpn>', $xml );
+	}
+
 	/**
 	 * @group feed
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Escape special chars for XML during MPN/SKU fetching for the feed file.

Closes #365  .


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a simple product.
2. Assign a SKU to the product that has one of the XML special chars like `&`
3. Check for the feed file generation.
4. The MPN xml node for the product should have the special char escaped.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Escape XML special chars in SKU for the XML MPN section.
