### PR TITLE
Fix fatal error on deactivating or uninstalling the plugin

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -247,6 +247,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
+
+			// Unschedule tasks if woocommerce is deactivated.
+			add_action( 'deactivate_woocommerce/woocommerce.php', array( Pinterest\ProductSync::class, 'cancel_jobs' ) );
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -249,7 +249,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
 			// Unschedule tasks if woocommerce is deactivated.
-			add_action( 'deactivate_woocommerce/woocommerce.php', array( Pinterest\ProductSync::class, 'cancel_jobs' ) );
+			if ( defined( 'WC_PLUGIN_FILE' ) ) {
+				register_deactivation_hook( WC_PLUGIN_FILE, array( Pinterest\ProductSync::class, 'cancel_jobs' ) );
+			}
 		}
 
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -690,6 +690,5 @@ class ProductSync {
 
 		as_unschedule_all_actions( self::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		as_unschedule_all_actions( self::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
-		
 	}
 }

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -684,7 +684,9 @@ class ProductSync {
 	 * @return void
 	 */
 	public static function cancel_jobs() {
-		as_unschedule_all_actions( self::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
-		as_unschedule_all_actions( self::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( self::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+			as_unschedule_all_actions( self::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		}
 	}
 }

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -684,9 +684,12 @@ class ProductSync {
 	 * @return void
 	 */
 	public static function cancel_jobs() {
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( self::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
-			as_unschedule_all_actions( self::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+			return;
 		}
+
+		as_unschedule_all_actions( self::ACTION_HANDLE_SYNC, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		as_unschedule_all_actions( self::ACTION_FEED_GENERATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #360  .

Fix the fatal error if the plugin is uninstalled or deactivated and WooCommerce is installed but no active.
---
- Verify if action scheduler actions exists during deactivation of the plugin.
- Unschedule tasks on WooCommerce deactivation.

### Screenshots:


### Detailed test instructions:
1. Install WooCommerce plugin but don't activate it.
2. Install Pinterest for WooCommerce plugin and activate it.
3. Uninstalling/deactivating the Pinterest for WooCommerce plugin should not throw fatal error.


### Additional details:

### Changelog entry

> Fix - Fatal error on plugin deactivation if WooCommerce is not active.
