### PR TITLE
Break the log loop.

### DIFF
--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -99,7 +99,8 @@ class Auth extends VendorAPI {
 
 		if ( ! empty( $error ) ) {
 			$error_args = '&error=' . $error;
-			Logger::log( wp_json_encode( $error ), 'error' );
+			// Force the logs to debug the connection procedure.
+			Logger::log( wp_json_encode( $error ), 'error', null, true );
 		}
 
 		// Save token information.

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -49,7 +49,7 @@ class Logger {
 			$allow_logging = Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' );
 		}
 
-		if ( $force) {
+		if ( $force ) {
 			$allow_logging = true;
 		}
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -38,21 +38,18 @@ class Logger {
 	 * @param string $message The message to be logged.
 	 * @param string $level   The level/context of the message.
 	 * @param string $feature Used to direct logs to a separate file.
+	 * @param string $force   Used to bypass system settings and force the logs.
 	 *
 	 * @return string
 	 */
-	public static function log( $message, $level = 'debug', $feature = null ) {
+	public static function log( $message, $level = 'debug', $feature = null, $force = false ) {
 
 		$allow_logging = true;
 		if ( 'debug' === $level ) {
 			$allow_logging = Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' );
 		}
 
-		/*
-		 * When the integration is not connected force the logs.
-		 * This will allow to debug potential connection issues.
-		 */
-		if ( ! Pinterest_For_Woocommerce()::is_setup_complete() ) {
+		if ( $force) {
 			$allow_logging = true;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #375 .

Don't use `is_connected()` in the Logger code. If decrypting of the token in `is_conected()` fails the Logger will be called yet again triggering `is_connected()` hence the loop.

I don't have the setup at hand so I don't really have a way to reproduce and test. 

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check #375 for reproduction.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Critical error on Jetpack sites.
