### PR TITLE
Clean account data on disconnect if there is no business account yet

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -591,9 +591,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @throws \Exception PHP Exception.
 		 */
 		public static function disconnect() {
-
-			// If there is no business connected, disconnecting merchant will throw error.
-			// Just need to clean account data in these cases.
+			/*
+			 * If there is no business connected, disconnecting merchant will throw error.
+			 * Just need to clean account data in these cases.
+			 */
 			if ( ! self::is_business_connected() ) {
 
 				self::flush_options();

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -592,6 +592,16 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function disconnect() {
 
+			// If there is no business connected, disconnecting merchant will throw error.
+			// Just need to clean account data in these cases.
+			if ( ! self::is_business_connected() ) {
+
+				self::clean_options_on_disconnect();
+
+				// At this point we're disconnected.
+				return true;
+			}
+
 			try {
 				// Disconnect merchant from Pinterest.
 				$result = Pinterest\API\Base::disconnect_merchant();
@@ -618,16 +628,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					}
 				}
 
-				// Flush the whole data option.
-				delete_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
-
-				// Remove settings that may cause issues if stale on disconnect.
-				self::save_setting( 'account_data', null );
-				self::save_setting( 'tracking_advertiser', null );
-				self::save_setting( 'tracking_tag', null );
-
-				// Cancel scheduled jobs.
-				Pinterest\ProductSync::cancel_jobs();
+				self::clean_options_on_disconnect();
 
 				// At this point we're disconnected.
 				return true;
@@ -636,6 +637,26 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				// There was an error disconnecting merchant.
 				return false;
 			}
+		}
+
+
+		/**
+		 * Flush data option and remove settings.
+		 *
+		 * @return void
+		 */
+		private static function clean_options_on_disconnect() {
+
+			// Flush the whole data option.
+			delete_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+
+			// Remove settings that may cause issues if stale on disconnect.
+			self::save_setting( 'account_data', null );
+			self::save_setting( 'tracking_advertiser', null );
+			self::save_setting( 'tracking_tag', null );
+
+			// Cancel scheduled jobs.
+			Pinterest\ProductSync::cancel_jobs();
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -596,7 +596,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Just need to clean account data in these cases.
 			if ( ! self::is_business_connected() ) {
 
-				self::clean_options_on_disconnect();
+				self::flush_options();
 
 				// At this point we're disconnected.
 				return true;
@@ -628,7 +628,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					}
 				}
 
-				self::clean_options_on_disconnect();
+				self::flush_options();
 
 				// At this point we're disconnected.
 				return true;
@@ -645,7 +645,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 *
 		 * @return void
 		 */
-		private static function clean_options_on_disconnect() {
+		private static function flush_options() {
 
 			// Flush the whole data option.
 			delete_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #361.

The account data was not being cleaned if a user disconnect during the onboarding process after being connected with a personal account.


### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/156812831-3a9c169c-dda5-4828-bbb9-4a2b864d4215.png)


### Detailed test instructions:
1. Initialize onboarding process after creating a personal account on Pinterest.
2. Disconnect during the onboarding process before creating a Business account.
3. When you start the onboarding again, the user should not be connected.

### Additional details:

### Changelog entry

> Fix - Clean account data if user Disconnect during the onboarding process with a personal account.
