### PR TITLE
Take full size images

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -60,13 +60,6 @@ class ProductsXmlFeed {
 	 */
 	const DESCRIPTION_SIZE_CHARS_LIMIT = 10000;
 
-	/**
-	 * Max image resolution (5000px*5000px).
-	 *
-	 * @var int
-	 */
-	const IMAGE_MAX_RESOLUTION = 5000 * 5000;
-
 
 	/**
 	 * Returns the XML header to be printed.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -60,6 +60,13 @@ class ProductsXmlFeed {
 	 */
 	const DESCRIPTION_SIZE_CHARS_LIMIT = 10000;
 
+	/**
+	 * Max image resolution (5000px*5000px).
+	 *
+	 * @var int
+	 */
+	const IMAGE_MAX_RESOLUTION = 5000 * 5000;
+
 
 	/**
 	 * Returns the XML header to be printed.
@@ -304,7 +311,7 @@ class ProductsXmlFeed {
 			return '';
 		}
 
-		$image = wp_get_attachment_image_src( $image_id, 'full' );
+		$image = self::get_product_image( $image_id );
 
 		if ( ! $image ) {
 			return;
@@ -414,7 +421,9 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
+				$image = self::get_product_image( $attachment_id );
+
+				$images[] = $image ? $image[0] : false;
 			}
 		}
 
@@ -534,5 +543,27 @@ class ProductsXmlFeed {
 		}
 
 		return $price;
+	}
+
+	/**
+	 * Helper method to return an image taking into account the limit on resolution 5000x5000.
+	 *
+	 * @param int $image_id The ID of the image.
+	 *
+	 * @return array|false
+	 */
+	private static function get_product_image( $image_id ) {
+		$image = wp_get_attachment_image_src( $image_id, 'full' );
+
+		if ( ! $image ) {
+			return false;
+		}
+
+		if ( $image[1] * $image[2] > self::IMAGE_MAX_RESOLUTION ) {
+
+			$image = wp_get_attachment_image_src( $image_id, 'woocommerce_single' );
+		}
+
+		return $image ?? false;
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -311,7 +311,8 @@ class ProductsXmlFeed {
 			return '';
 		}
 
-		$image = self::get_product_image( $image_id );
+		// Get the image with a filter for default size.
+		$image = wp_get_attachment_image_src( $image_id, apply_filters( 'pinterest_for_woocommerce_feed_image_size', 'full' ) );
 
 		if ( ! $image ) {
 			return;
@@ -421,7 +422,8 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$image = self::get_product_image( $attachment_id );
+				// Get the image with a filter for default size.
+				$image = wp_get_attachment_image_src( $attachment_id, apply_filters( 'pinterest_for_woocommerce_feed_image_size', 'full' ) );
 
 				$images[] = $image ? $image[0] : false;
 			}
@@ -543,28 +545,5 @@ class ProductsXmlFeed {
 		}
 
 		return $price;
-	}
-
-	/**
-	 * Helper method to return an image taking into account the limit on resolution 5000x5000.
-	 *
-	 * @param int $image_id The ID of the image.
-	 *
-	 * @return array|false
-	 */
-	private static function get_product_image( $image_id ) {
-		// Get the image with a filter for default size.
-		$image = wp_get_attachment_image_src( $image_id, apply_filters( 'pinterest_for_woocommerce_feed_image_size', 'full' ) );
-
-		if ( ! $image ) {
-			return false;
-		}
-
-		if ( $image[1] * $image[2] > self::IMAGE_MAX_RESOLUTION ) {
-
-			$image = wp_get_attachment_image_src( $image_id, 'woocommerce_single' );
-		}
-
-		return $image ?? false;
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -304,7 +304,7 @@ class ProductsXmlFeed {
 			return '';
 		}
 
-		$image = wp_get_attachment_image_src( $image_id, 'woocommerce_single' );
+		$image = wp_get_attachment_image_src( $image_id, 'full' );
 
 		if ( ! $image ) {
 			return;
@@ -414,7 +414,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id, 'woocommerce_single' )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
 			}
 		}
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -553,7 +553,8 @@ class ProductsXmlFeed {
 	 * @return array|false
 	 */
 	private static function get_product_image( $image_id ) {
-		$image = wp_get_attachment_image_src( $image_id, 'full' );
+		// Get the image with a filter for default size.
+		$image = wp_get_attachment_image_src( $image_id, apply_filters( 'pinterest_for_woocommerce_feed_image_size', 'full' ) );
 
 		if ( ! $image ) {
 			return false;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #374.

Take the full size image for xml instead of `'woocommerce_single'` size.
- If the image is bigger than [suggested limit](https://github.com/woocommerce/pinterest-for-woocommerce/issues/374#issuecomment-1062288825) `'woocommerce_single'` will be used in its place.
- The default full size can be filtered with `'pinterest_for_woocommerce_feed_image_size'`.

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. Check on the feed that the images are the full size ones.

### Additional details:

### Changelog entry

> Tweak - Take full size images for the feed.
