### PR TITLE
Disable enchanced match support when tracking is disabled.

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@woocommerce/components';
 import {
@@ -11,7 +12,6 @@ import {
 	Icon,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -121,15 +121,15 @@ const SetupPins = ( {} ) => {
 										checked={
 											appSettings.enhanced_match_support
 										}
-										className = {
-											classnames(
-												'woocommerce-setup-guide__checkbox-group',
-												{
-													'pinterest-for-woocommerce-settings-checkbox-disabled' : ! appSettings.track_conversions
-												}
-											)
+										className={ classnames(
+											'woocommerce-setup-guide__checkbox-group',
+											{
+												'pinterest-for-woocommerce-settings-checkbox-disabled': ! appSettings.track_conversions,
+											}
+										) }
+										disabled={
+											! appSettings.track_conversions
 										}
-										disabled = { ! appSettings.track_conversions }
 										onChange={ () =>
 											handleOptionChange(
 												'enhanced_match_support'

--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -11,6 +11,7 @@ import {
 	Icon,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -112,7 +113,7 @@ const SetupPins = ( {} ) => {
 										help={
 											<HelpTooltip
 												text={ __(
-													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts.',
+													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled.',
 													'pinterest-for-woocommerce'
 												) }
 											/>
@@ -120,7 +121,15 @@ const SetupPins = ( {} ) => {
 										checked={
 											appSettings.enhanced_match_support
 										}
-										className="woocommerce-setup-guide__checkbox-group"
+										className = {
+											classnames(
+												'woocommerce-setup-guide__checkbox-group',
+												{
+													'pinterest-for-woocommerce-settings-checkbox-disabled' : ! appSettings.track_conversions
+												}
+											)
+										}
+										disabled = { ! appSettings.track_conversions }
 										onChange={ () =>
 											handleOptionChange(
 												'enhanced_match_support'

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -674,3 +674,7 @@ $root: ".woocommerce-setup-guide";
 	}
 }
 
+.pinterest-for-woocommerce-settings-checkbox-disabled {
+	color: gray;
+	pointer-events: none;
+}

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -675,6 +675,6 @@ $root: ".woocommerce-setup-guide";
 }
 
 .pinterest-for-woocommerce-settings-checkbox-disabled {
-	color: gray;
+	color: $gray-700;
 	pointer-events: none;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #384 .

Disable `Enhanced Match support` when `Track conversion` is disabled.


### Screenshots:


https://user-images.githubusercontent.com/17271089/157430789-d30bd582-3408-4d12-a205-85b0ec8ba045.mov



<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open Pinterest settings.
2. Toggle `Track conversion`
3. Observe `Enhanced Match support` 

Since on the backend if `Track conversion` is disabled the `Enhanced Match support` does nothing ( no matter what state it is in ) there is no functional test needed.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Disable Enhanced Match support option when the Track conversion option is disabled.
