### PR TITLE
Pinterest For WooCommerce 1.0.8 Release

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -87,6 +87,15 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.0.8 - 2022-xx-xx =
+* Update - Shipping column format. ( [#370](https://github.com/woocommerce/pinterest-for-woocommerce/pull/370) )
+* Fix    - Escape XML special chars in SKU for the XML MPN section. ( [#371](https://github.com/woocommerce/pinterest-for-woocommerce/pull/371) )
+* Fix    - Clean account data if user Disconnect during the onboarding process with a personal account. ( [#381](https://github.com/woocommerce/pinterest-for-woocommerce/pull/381) )
+* Fix    - Do not create merchant on get_feed_state. ( [#353](https://github.com/woocommerce/pinterest-for-woocommerce/pull/353) )
+* Update - Disable enhanced match support when tracking is disabled. ( [#386](https://github.com/woocommerce/pinterest-for-woocommerce/pull/386) )
+* Tweak  - Take full size images for the feed. ( [#383](https://github.com/woocommerce/pinterest-for-woocommerce/pull/383) )
+* Update - Enable shipping column in the feed. ( [#388](https://github.com/woocommerce/pinterest-for-woocommerce/pull/388) )
+
 = 1.0.7 - 2022-02-24 =
 * Fix - Critical error on Jetpack sites.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 5.8
 Requires PHP: 7.3
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -87,7 +87,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
-= 1.0.8 - 2022-xx-xx =
+= 1.0.8 - 2022-03-11 =
 * Update - Shipping column format. ( [#370](https://github.com/woocommerce/pinterest-for-woocommerce/pull/370) )
 * Fix    - Escape XML special chars in SKU for the XML MPN section. ( [#371](https://github.com/woocommerce/pinterest-for-woocommerce/pull/371) )
 * Fix    - Clean account data if user Disconnect during the onboarding process with a personal account. ( [#381](https://github.com/woocommerce/pinterest-for-woocommerce/pull/381) )

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Pinterest for WooCommerce Changelog ***
 
-= 1.0.8 - 2022-xx-xx =
+= 1.0.8 - 2022-03-11 =
 * Update - Shipping column format. ( [#370](https://github.com/woocommerce/pinterest-for-woocommerce/pull/370) )
 * Fix    - Escape XML special chars in SKU for the XML MPN section. ( [#371](https://github.com/woocommerce/pinterest-for-woocommerce/pull/371) )
 * Fix    - Clean account data if user Disconnect during the onboarding process with a personal account. ( [#381](https://github.com/woocommerce/pinterest-for-woocommerce/pull/381) )

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.0.8 - 2022-xx-xx =
+* Update - Shipping column format. ( [#370](https://github.com/woocommerce/pinterest-for-woocommerce/pull/370) )
+* Fix    - Escape XML special chars in SKU for the XML MPN section. ( [#371](https://github.com/woocommerce/pinterest-for-woocommerce/pull/371) )
+* Fix    - Clean account data if user Disconnect during the onboarding process with a personal account. ( [#381](https://github.com/woocommerce/pinterest-for-woocommerce/pull/381) )
+* Fix    - Do not create merchant on get_feed_state. ( [#353](https://github.com/woocommerce/pinterest-for-woocommerce/pull/353) )
+* Update - Disable enhanced match support when tracking is disabled. ( [#386](https://github.com/woocommerce/pinterest-for-woocommerce/pull/386) )
+* Tweak  - Take full size images for the feed. ( [#383](https://github.com/woocommerce/pinterest-for-woocommerce/pull/383) )
+* Update - Enable shipping column in the feed. ( [#388](https://github.com/woocommerce/pinterest-for-woocommerce/pull/388) )
+
 = 1.0.7 - 2022-02-24 =
 * Fix - Critical error on Jetpack sites.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.0.7
+ * Version:           1.0.8
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.7' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.8' ); // WRCS: DEFINED_VERSION.
 
 /**
  * Autoload packages.


### PR DESCRIPTION
PR for the 1.0.8 release.

Changelog:

* Update - Shipping column format. ( [#370](https://github.com/woocommerce/pinterest-for-woocommerce/pull/370) )
* Fix    - Escape XML special chars in SKU for the XML MPN section. ( [#371](https://github.com/woocommerce/pinterest-for-woocommerce/pull/371) )
* Fix    - Clean account data if user Disconnect during the onboarding process with a personal account. ( [#381](https://github.com/woocommerce/pinterest-for-woocommerce/pull/381) )
* Fix    - Do not create merchant on get_feed_state. ( [#353](https://github.com/woocommerce/pinterest-for-woocommerce/pull/353) )
* Update - Disable enhanced match support when tracking is disabled. ( [#386](https://github.com/woocommerce/pinterest-for-woocommerce/pull/386) )
* Tweak  - Take full size images for the feed. ( [#383](https://github.com/woocommerce/pinterest-for-woocommerce/pull/383) )
* Update - Enable shipping column in the feed. ( [#388](https://github.com/woocommerce/pinterest-for-woocommerce/pull/388) )