### PR TITLE
Add plugin update framework.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -235,6 +235,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Tracking::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
+			add_action( 'plugins_loaded', array( Pinterest\PluginUpdate::class, 'maybe_update_plugin' ) );
 
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -235,7 +235,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Tracking::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
-			add_action( 'plugins_loaded', array( Pinterest\PluginUpdate::class, 'maybe_update_plugin' ) );
+			add_action( 'plugins_loaded', array( $this, 'maybe_update_plugin' ) );
 
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
@@ -331,6 +331,17 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			}
 
 			return false;
+		}
+
+		/**
+		 * Plugin update entry point.
+		 *
+		 * @since x.x.x
+		 * @return void
+		 */
+		public function maybe_update_plugin() {
+			$plugin_update = new Pinterest\PluginUpdate();
+			$plugin_update->maybe_update();
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -235,7 +235,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Tracking::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
-			add_action( 'plugins_loaded', array( $this, 'maybe_update_plugin' ) );
 
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
@@ -248,6 +247,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
+
+			$this->maybe_update_plugin();
 		}
 
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -159,8 +159,10 @@ class PluginUpdate {
 	 */
 	private function update_to_1_0_9(): void {
 		if ( ! $this->version_needs_update( '1.0.9' ) ) {
+			// Already up to date.
 			return;
 		}
+		// Perform update.
 	}
 
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -34,10 +34,10 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return boolean
 	 */
-	public static function plugin_is_up_to_date(): bool {
+	public function plugin_is_up_to_date(): bool {
 		return version_compare(
-			self::get_plugin_update_version(),
-			self::get_plugin_current_version(),
+			$this->get_plugin_update_version(),
+			$this->get_plugin_current_version(),
 			'=='
 		);
 	}
@@ -49,9 +49,9 @@ class PluginUpdate {
 	 * @param string $version Version string for which we check if update is needed.
 	 * @return boolean
 	 */
-	private static function version_needs_update( string $version ): bool {
+	private function version_needs_update( string $version ): bool {
 		return version_compare(
-			self::get_plugin_update_version(),
+			$this->get_plugin_update_version(),
 			$version,
 			'<'
 		);
@@ -65,7 +65,7 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return string
 	 */
-	private static function get_plugin_update_version(): string {
+	private function get_plugin_update_version(): string {
 		return get_option( self::PLUGIN_UPDATE_VERSION_OPTION, '1.0.0' );
 	}
 
@@ -75,7 +75,7 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return string
 	 */
-	private static function get_plugin_current_version(): string {
+	private function get_plugin_current_version(): string {
 		return PINTEREST_FOR_WOOCOMMERCE_VERSION;
 	}
 
@@ -86,17 +86,17 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return void
 	 */
-	private static function update_plugin_update_version_option(): void {
+	private function update_plugin_update_version_option(): void {
 		update_option(
 			self::PLUGIN_UPDATE_VERSION_OPTION,
-			self::get_plugin_current_version()
+			$this->get_plugin_current_version()
 		);
 
 		Logger::log(
 			sprintf(
 				// translators: plugin version.
 				__( 'Plugin updated to version: %s.', 'pinterest-for-woocommerce' ),
-				self::get_plugin_current_version()
+				$this->get_plugin_current_version()
 			)
 		);
 	}
@@ -107,21 +107,21 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return void
 	 */
-	public static function maybe_update(): void {
+	public function maybe_update(): void {
 
 		// Return if the plugin is up to date.
-		if ( self::plugin_is_up_to_date() ) {
+		if ( $this->plugin_is_up_to_date() ) {
 			return;
 		}
 
 		try {
-			self::perform_plugin_updates();
+			$this->perform_plugin_updates();
 		} catch ( Throwable $th ) {
 			Logger::log(
 				sprintf(
 					// translators: 1: plugin version, 2: error message.
 					__( 'Plugin update to version %1$s error: %2$s', 'pinterest-for-woocommerce' ),
-					self::get_plugin_current_version(),
+					$this->get_plugin_current_version(),
 					$th->getMessage()
 				),
 				'error',
@@ -131,10 +131,13 @@ class PluginUpdate {
 		}
 
 		/**
-		 * Even if the update procedure has errored we still want to update the update version.
-		 * This avoids
+		 * Even if the update procedure has errored we still want to
+		 * update the update version. This avoids problems where the
+		 * update procedure will be called again and again. Update
+		 * problems will need to be fixed in the next patch release
+		 * in this case.
 		 */
-		self::update_plugin_update_version_option();
+		$this->update_plugin_update_version_option();
 	}
 
 	/**
@@ -144,8 +147,8 @@ class PluginUpdate {
 	 * @throws Throwable Update procedure failures.
 	 * @return void
 	 */
-	private static function perform_plugin_updates(): void {
-		self::update_to_1_0_9();
+	private function perform_plugin_updates(): void {
+		$this->update_to_1_0_9();
 	}
 
 	/**
@@ -154,8 +157,8 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return void
 	 */
-	private static function update_to_1_0_9(): void {
-		if ( ! self::version_needs_update( '1.0.9' ) ) {
+	private function update_to_1_0_9(): void {
+		if ( ! $this->version_needs_update( '1.0.9' ) ) {
 			return;
 		}
 	}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Helper class for performing various update procedures.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Throwable;
+/**
+ * Class PluginUpdate
+ *
+ * 1. Check if the plugin is up to date. If yes return immediately.
+ * 2. Perform update procedures.
+ * 3. Bump update version string.
+ */
+class PluginUpdate {
+
+	/**
+	 * Option name used for storing version of the plugin before the update procedure.
+	 */
+	const PLUGIN_UPDATE_VERSION_OPTION = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-update-version';
+
+	/**
+	 * Check if the plugin is up to date.
+	 *
+	 * @since x.x.x
+	 * @return boolean
+	 */
+	private static function plugin_is_up_to_date(): bool {
+		return version_compare(
+			self::get_plugin_update_version(),
+			self::get_plugin_current_version(),
+			'=='
+		);
+	}
+
+	/**
+	 * Gets the previous version of the plugin. The one before the update has
+	 * happened. After the update procedure this will return the same version
+	 * as get_plugin_current_version().
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private static function get_plugin_update_version(): string {
+		return get_option( self::PLUGIN_UPDATE_VERSION_OPTION, '1.0.0' );
+	}
+
+	/**
+	 * Returns the version of the plugin as defined in the main plugin file.
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private static function get_plugin_current_version(): string {
+		return PINTEREST_FOR_WOOCOMMERCE_VERSION;
+	}
+
+	/**
+	 * Helper function to check if update to $version is needed.
+	 *
+	 * @param string $version Version string for which we check if update is needed.
+	 * @return boolean
+	 */
+	private static function version_needs_update( string $version ): bool {
+		return version_compare(
+			self::get_plugin_update_version(),
+			'1.0.9',
+			'<'
+		);
+	}
+
+	/**
+	 * After the update has been completed bump the previous version option to
+	 * the current version option.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private static function update_plugin_previous_version(): void {
+		update_option(
+			self::PLUGIN_UPDATE_VERSION_OPTION,
+			self::get_plugin_current_version()
+		);
+
+		Logger::log(
+			sprintf(
+				// translators: plugin version.
+				__( 'Plugin updated to version: %s.', 'pinterest-for-woocommerce' ),
+				self::get_plugin_current_version()
+			)
+		);
+	}
+
+	/**
+	 * Update procedures entry point.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public static function maybe_update(): void {
+
+		// Return if the plugin is up to date.
+		if ( self::plugin_is_up_to_date() ) {
+			return;
+		}
+
+		try {
+			self::perform_plugin_updates();
+		} catch ( Throwable $th ) {
+			Logger::log(
+				sprintf(
+					// translators: 1: plugin version, 2: error message.
+					__( 'Plugin update to version %1$s error: %2$s', 'pinterest-for-woocommerce' ),
+					self::get_plugin_current_version(),
+					$th->getMessage()
+				),
+				'error',
+				null,
+				true
+			);
+		}
+
+		/**
+		 * Even if the update procedure has errored we still want to update the update version.
+		 * This avoids
+		 */
+		self::update_plugin_previous_version();
+	}
+
+	/**
+	 * Perform update procedures.
+	 *
+	 * @since x.x.x
+	 * @throws Throwable Update procedure failures.
+	 * @return void
+	 */
+	private static function perform_plugin_updates(): void {
+		self::update_to_1_0_9();
+	}
+
+	/**
+	 * Update procedure for the 1.0.9 version of the plugin.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private static function update_to_1_0_9(): void {
+		if ( ! self::version_needs_update( '1.0.9' ) ) {
+			return;
+		}
+	}
+
+}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -34,7 +34,7 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return boolean
 	 */
-	private static function plugin_is_up_to_date(): bool {
+	public static function plugin_is_up_to_date(): bool {
 		return version_compare(
 			self::get_plugin_update_version(),
 			self::get_plugin_current_version(),
@@ -85,7 +85,7 @@ class PluginUpdate {
 	 * @since x.x.x
 	 * @return void
 	 */
-	private static function update_plugin_previous_version(): void {
+	private static function update_plugin_update_version_option(): void {
 		update_option(
 			self::PLUGIN_UPDATE_VERSION_OPTION,
 			self::get_plugin_current_version()
@@ -133,7 +133,7 @@ class PluginUpdate {
 		 * Even if the update procedure has errored we still want to update the update version.
 		 * This avoids
 		 */
-		self::update_plugin_previous_version();
+		self::update_plugin_update_version_option();
 	}
 
 	/**

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -147,7 +147,7 @@ class PluginUpdate {
 	 * @throws Throwable Update procedure failures.
 	 * @return void
 	 */
-	private function perform_plugin_updates(): void {
+	protected function perform_plugin_updates(): void {
 		$this->update_to_1_0_9();
 	}
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -67,6 +67,7 @@ class PluginUpdate {
 	/**
 	 * Helper function to check if update to $version is needed.
 	 *
+	 * @since x.x.x
 	 * @param string $version Version string for which we check if update is needed.
 	 * @return boolean
 	 */

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -52,7 +52,7 @@ class PluginUpdate {
 	private static function version_needs_update( string $version ): bool {
 		return version_compare(
 			self::get_plugin_update_version(),
-			'1.0.9',
+			$version,
 			'<'
 		);
 	}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -43,6 +43,21 @@ class PluginUpdate {
 	}
 
 	/**
+	 * Helper function to check if update to $version is needed.
+	 *
+	 * @since x.x.x
+	 * @param string $version Version string for which we check if update is needed.
+	 * @return boolean
+	 */
+	private static function version_needs_update( string $version ): bool {
+		return version_compare(
+			self::get_plugin_update_version(),
+			'1.0.9',
+			'<'
+		);
+	}
+
+	/**
 	 * Gets the previous version of the plugin. The one before the update has
 	 * happened. After the update procedure this will return the same version
 	 * as get_plugin_current_version().
@@ -62,21 +77,6 @@ class PluginUpdate {
 	 */
 	private static function get_plugin_current_version(): string {
 		return PINTEREST_FOR_WOOCOMMERCE_VERSION;
-	}
-
-	/**
-	 * Helper function to check if update to $version is needed.
-	 *
-	 * @since x.x.x
-	 * @param string $version Version string for which we check if update is needed.
-	 * @return boolean
-	 */
-	private static function version_needs_update( string $version ): bool {
-		return version_compare(
-			self::get_plugin_update_version(),
-			'1.0.9',
-			'<'
-		);
 	}
 
 	/**

--- a/tests/Unit/PluginUpdateTest.php
+++ b/tests/Unit/PluginUpdateTest.php
@@ -43,10 +43,10 @@ class Pinterest_Test_Plugin_Update extends TestCase {
 		 */
 		$this->mock_logger = new class {
 
-			static $message = '';
+			public $message = array();
 			public function log( $level, $msg )
 			{
-				self::$message = $msg;
+				$this->message[] = $msg;
 			}
 		};
 		Logger::$logger = $this->mock_logger;
@@ -122,12 +122,12 @@ class Pinterest_Test_Plugin_Update extends TestCase {
 		$mock_plugin_update->maybe_update();
 
 		// No exception generated, logger message should be empty.
-		$this->assertEmpty( $this->mock_logger::$message );
+		$this->assertEquals( 'Plugin updated to version: 1.0.8.', $this->mock_logger->message[0] );
 
 		$this->assertTrue( $this->plugin_update->plugin_is_up_to_date() );
 	}
 
-		/**
+	/**
 	 * Test main update flow.
 	 * perform_plugin_updates does not throw.
 	 *
@@ -141,13 +141,16 @@ class Pinterest_Test_Plugin_Update extends TestCase {
 			->getMock();
 
 		$ex = new Exception( 'Veni, vidi, error!' );
-		$mock_plugin_update->method('perform_plugin_updates')
+		$mock_plugin_update->method( 'perform_plugin_updates' )
 			->willThrowException( $ex );
 
 		$mock_plugin_update->maybe_update();
 
-		// Exception was caught and logged;
-		$this->assertEquals( "Plugin update to version 1.0.8 error: Veni, vidi, error!", $this->mock_logger::$message );
+		// Exception was caught and logged.
+		$this->assertEquals( "Plugin update to version 1.0.8 error: Veni, vidi, error!", $this->mock_logger->message[0] );
+
+		// Plugin update message logged.
+		$this->assertEquals( 'Plugin updated to version: 1.0.8.', $this->mock_logger->message[1] );
 
 		/**
 		 * Plugin should be marked as up to date. To avoid update loop.

--- a/tests/Unit/PluginUpdateTest.php
+++ b/tests/Unit/PluginUpdateTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit\PluginUpdate;
+
+use ReflectionClass;
+use \WC_Unit_Test_Case;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+use Automattic\WooCommerce\Pinterest\Logger;
+use Automattic\WooCommerce\Pinterest\PluginUpdate;
+use Exception;
+
+/**
+ * Plugin Update Procedures test class.
+ */
+class Pinterest_Test_Plugin_Update extends TestCase {
+
+	/**
+	 * Variable that holds the plugin update object used by tests.
+	 *
+	 * @var PluginUpdate|null
+	 */
+	private $plugin_update = null;
+
+	/**
+	 * Mocked logger.
+	 *
+	 * @var object|null Mocked logger object.
+	 */
+	private $mock_logger = null;
+
+	/**
+	 * Clear =the update version option used to detect if the plugin has been updated.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		delete_option( PluginUpdate::PLUGIN_UPDATE_VERSION_OPTION );
+		$this->plugin_update = new PluginUpdate();
+
+		/**
+		 * Mock logger object that will catch any logged messages.
+		 */
+		$this->mock_logger = new class {
+
+			static $message = '';
+			public function log( $level, $msg )
+			{
+				self::$message = $msg;
+			}
+		};
+		Logger::$logger = $this->mock_logger;
+	}
+
+	/**
+	 * plugin_is_up_to_date test before update.
+	 * When the method is called before the update procedure it should return false.
+	 *
+	 * @group update
+	 */
+	public function testPluginUpToDateDefault() {
+		$this->assertFalse( $this->plugin_update->plugin_is_up_to_date() );
+	}
+
+	/**
+	 * Method that finalizes the update procedure.
+	 * After this gets called the plugin_is_up_to_date() should return true.
+	 *
+	 * @group update
+	*/
+	public function testUpdatePluginUpdateVersionOption() {
+		$this->call_update_plugin_update_version_option();
+		$this->assertTrue( $this->plugin_update->plugin_is_up_to_date() );
+	}
+
+	/**
+	 * During update procedure update method to the latest version should be called.
+	 *
+	 * @group update
+	 * @return void
+	 */
+	public function testVersionNeedsUpdate__OlderVersion() {
+		$method = ( new ReflectionClass( PluginUpdate::class ) )->getMethod( 'version_needs_update' );
+		$method->setAccessible( true );
+		$this->assertTrue(
+			$method->invoke( $this->plugin_update, PINTEREST_FOR_WOOCOMMERCE_VERSION )
+		);
+	}
+
+	/**
+	 * During update procedure update to the method to which update has already
+	 * happened should not be called. Simulated using the same version for the check.
+	 *
+	 * @group update
+	 * @return void
+	 */
+	public function testVersionNeedsUpdate__SameVersion() {
+		$this->call_update_plugin_update_version_option();
+		$method = ( new ReflectionClass( PluginUpdate::class ) )->getMethod( 'version_needs_update' );
+		$method->setAccessible( true );
+		$this->assertFalse(
+			$method->invoke( $this->plugin_update, PINTEREST_FOR_WOOCOMMERCE_VERSION )
+		);
+	}
+
+	/**
+	 * Test main update flow.
+	 * perform_plugin_updates does not throw.
+	 *
+	 * @group update
+	 * @return void
+	 */
+	public function testUpdateFlowNoThrow() {
+
+		$mock_plugin_update = $this->getMockBuilder( PluginUpdate::class )
+			->setMethods( ['perform_plugin_updates'] )
+			->getMock();
+
+		$mock_plugin_update->method('perform_plugin_updates')
+			->willReturn( null );
+
+		$mock_plugin_update->maybe_update();
+
+		// No exception generated, logger message should be empty.
+		$this->assertEmpty( $this->mock_logger::$message );
+
+		$this->assertTrue( $this->plugin_update->plugin_is_up_to_date() );
+	}
+
+		/**
+	 * Test main update flow.
+	 * perform_plugin_updates does not throw.
+	 *
+	 * @group update
+	 * @return void
+	 */
+	public function testUpdateFlowWithThrow() {
+
+		$mock_plugin_update = $this->getMockBuilder( PluginUpdate::class )
+			->setMethods( ['perform_plugin_updates'] )
+			->getMock();
+
+		$ex = new Exception( 'Veni, vidi, error!' );
+		$mock_plugin_update->method('perform_plugin_updates')
+			->willThrowException( $ex );
+
+		$mock_plugin_update->maybe_update();
+
+		// Exception was caught and logged;
+		$this->assertEquals( "Plugin update to version 1.0.8 error: Veni, vidi, error!", $this->mock_logger::$message );
+
+		/**
+		 * Plugin should be marked as up to date. To avoid update loop.
+		 * Check maybe_update for explanation why.
+		 */
+		$this->assertTrue( $this->plugin_update->plugin_is_up_to_date() );
+	}
+
+	/**
+	 * Helper method for calling update_plugin_update_version_option.
+	 *
+	 * @return void
+	 */
+	private function call_update_plugin_update_version_option() {
+		$method = ( new ReflectionClass( PluginUpdate::class ) )->getMethod( 'update_plugin_update_version_option' );
+		$method->setAccessible( true );
+		$method->invoke( $this->plugin_update );
+	}
+
+}
+

--- a/tests/Unit/PluginUpdateTest.php
+++ b/tests/Unit/PluginUpdateTest.php
@@ -30,7 +30,7 @@ class Pinterest_Test_Plugin_Update extends TestCase {
 	private $mock_logger = null;
 
 	/**
-	 * Clear =the update version option used to detect if the plugin has been updated.
+	 * Clear the update version option used to detect if the plugin has been updated.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add plugin update framework.
The code in this PR allows adding plugin update procedures in a centralized location. It provides structure and helper methods that allow clean implementation of migrations, updates, DB patches, and so on.

This PR was created in a response to https://github.com/woocommerce/pinterest-for-woocommerce/pull/358 where I have observed that we have the update code intertwined with application code.   


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

No testing, this is just a framework.
Unit tests are added to verify the basic behavior of the update component.

### Additional details:

How to use the framework?
Create your update procedure as a method in the PluginUpdate class.
Add it to the `perform_plugin_updates()` method.
Inside your update method test using `version_needs_update`  if the update should be performed.

Check https://github.com/woocommerce/pinterest-for-woocommerce/pull/391 to see a real-life implementation.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add -  Plugin update framework.
