### PR TITLE
Use website verification instead of domains.

### DIFF
--- a/assets/source/setup-guide/app/data/settings/selectors.js
+++ b/assets/source/setup-guide/app/data/settings/selectors.js
@@ -59,11 +59,15 @@ export const isDomainVerified = ( state ) => {
 		return false;
 	}
 
-	const { hostname } = new URL(
+	const { hostname, pathname } = new URL(
 		wcSettings.pinterest_for_woocommerce.homeUrlToVerify
 	);
+
+	// Build url for single site and multisite.
+	const urlToVerify = pathname !== '/' ? hostname + pathname : hostname;
+
 	return state?.settings?.account_data?.verified_user_websites.includes(
-		hostname
+		urlToVerify
 	);
 };
 

--- a/assets/source/setup-guide/app/data/settings/selectors.js
+++ b/assets/source/setup-guide/app/data/settings/selectors.js
@@ -55,14 +55,16 @@ export const isDomainVerified = ( state ) => {
 		return;
 	}
 
-	if ( undefined === state?.settings?.account_data?.verified_domains ) {
+	if ( undefined === state?.settings?.account_data?.verified_user_websites ) {
 		return false;
 	}
 
 	const { hostname } = new URL(
 		wcSettings.pinterest_for_woocommerce.homeUrlToVerify
 	);
-	return state?.settings?.account_data?.verified_domains.includes( hostname );
+	return state?.settings?.account_data?.verified_user_websites.includes(
+		hostname
+	);
 };
 
 /**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -976,7 +976,29 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function is_domain_verified() {
 			$account_data = self::get_setting( 'account_data' );
+
+			if ( isset( $account_data['domain_verified'] ) && isset( $account_data['verified_domains'] ) ) {
+				$verification_response = self::migrate_domain_to_website_verification_data();
+
+				if ( ! is_wp_error( $verification_response ) ) {
+					// Successful verification, cleaning old data.
+					unset( $account_data['domain_verified'] );
+					unset( $account_data['verified_domains'] );
+				} else {
+					// There was an error, returning old data.
+					return isset( $account_data['verified_domains'] ) ? (bool) $account_data['verified_domains'] : false;
+				}
+			}
+
 			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
+		}
+
+
+		/**
+		 * Migrate the old domain verification to website verification
+		 */
+		private static function migrate_domain_to_website_verification_data() {
+			return Pinterest\API\DomainVerification::trigger_domain_verification();
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -804,13 +804,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				$data = array_intersect_key(
 					(array) $account_data['data'],
 					array(
-						'verified_domains' => '',
-						'domain_verified'  => '',
-						'username'         => '',
-						'full_name'        => '',
-						'id'               => '',
-						'image_medium_url' => '',
-						'is_partner'       => '',
+						'verified_user_websites' => '',
+						'domain_verified'        => '',
+						'username'               => '',
+						'full_name'              => '',
+						'id'                     => '',
+						'image_medium_url'       => '',
+						'is_partner'             => '',
 					)
 				);
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -976,29 +976,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function is_domain_verified() {
 			$account_data = self::get_setting( 'account_data' );
-
-			if ( isset( $account_data['domain_verified'] ) && isset( $account_data['verified_domains'] ) ) {
-				$verification_response = self::migrate_domain_to_website_verification_data();
-
-				if ( ! is_wp_error( $verification_response ) ) {
-					// Successful verification, cleaning old data.
-					unset( $account_data['domain_verified'] );
-					unset( $account_data['verified_domains'] );
-				} else {
-					// There was an error, returning old data.
-					return isset( $account_data['verified_domains'] ) ? (bool) $account_data['verified_domains'] : false;
-				}
-			}
-
 			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
-		}
-
-
-		/**
-		 * Migrate the old domain verification to website verification
-		 */
-		private static function migrate_domain_to_website_verification_data() {
-			return Pinterest\API\DomainVerification::trigger_domain_verification();
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -804,13 +804,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				$data = array_intersect_key(
 					(array) $account_data['data'],
 					array(
-						'verified_user_websites' => '',
-						'domain_verified'        => '',
-						'username'               => '',
-						'full_name'              => '',
-						'id'                     => '',
-						'image_medium_url'       => '',
-						'is_partner'             => '',
+						'verified_user_websites'  => '',
+						'is_any_website_verified' => '',
+						'username'                => '',
+						'full_name'               => '',
+						'id'                      => '',
+						'image_medium_url'        => '',
+						'is_partner'              => '',
 					)
 				);
 
@@ -976,7 +976,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function is_domain_verified() {
 			$account_data = self::get_setting( 'account_data' );
-			return isset( $account_data['domain_verified'] ) ? (bool) $account_data['domain_verified'] : false;
+			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
 		}
 
 

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -363,7 +363,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'serviceLoginUrl'          => $this->get_service_login_url(),
 				'createBusinessAccountUrl' => $this->get_create_business_account_url(),
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
-				'homeUrlToVerify'          => home_url(),
+				'homeUrlToVerify'          => get_home_url(),
 				'storeCountry'             => $store_country,
 				'isAdsSupportedCountry'    => in_array( $store_country, Pinterest_For_Woocommerce_Ads_Supported_Countries::get_countries(), true ),
 				'isConnected'              => ! empty( Pinterest_For_Woocommerce()::is_connected() ),

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -275,24 +275,21 @@ class Base {
 	 * @return mixed
 	 */
 	public static function domain_verification_data() {
-		return self::make_request( 'domains/verification', 'GET' );
+		return self::make_request( 'websites/verification', 'GET' );
 	}
 
 
 	/**
 	 * Trigger the (realtime) verification process using the API and return the response.
 	 *
-	 * @param boolean $allow_multiple Parameter passed to the API.
 	 * @return mixed
 	 */
-	public static function trigger_verification( $allow_multiple = true ) {
+	public static function trigger_verification() {
 
-		$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
-		$request_url = "domains/{$domain}/verification/metatag/realtime/";
+		$request_url = 'websites/verification/metatag/realtime/';
 
-		if ( $allow_multiple ) {
-			$request_url = add_query_arg( 'can_claim_multiple', 'true', $request_url );
-		}
+		$parsed_website = wp_parse_url( get_home_url() );
+		$request_url    = add_query_arg( 'website', $parsed_website['host'] . $parsed_website['path'], $request_url );
 
 		return self::make_request( $request_url, 'POST' );
 	}

--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -51,7 +51,18 @@ class DomainVerification extends VendorAPI {
 	 * @throws \Exception PHP Exception.
 	 */
 	public function handle_verification() {
+		return self::trigger_domain_verification();
+	}
 
+
+	/**
+	 * Triggers the realtime verification process using the Pinterst API.
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public static function trigger_domain_verification() {
 		static $verification_data;
 
 		try {

--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -27,7 +27,7 @@ class DomainVerification extends VendorAPI {
 	 *
 	 * @var integer
 	 */
-	private $verification_attempts_remaining = 3;
+	private static $verification_attempts_remaining = 3;
 
 	/**
 	 * Initialize class
@@ -93,9 +93,9 @@ class DomainVerification extends VendorAPI {
 
 			$error_code = $th->getCode() >= 400 ? $th->getCode() : 400;
 
-			if ( 403 === $error_code && $this->verification_attempts_remaining > 0 ) {
-				$this->verification_attempts_remaining--;
-				Logger::log( sprintf( 'Retrying domain verification in 5 seconds. Attempts left: %d', $this->verification_attempts_remaining ), 'debug' );
+			if ( 403 === $error_code && self::$verification_attempts_remaining > 0 ) {
+				self::$verification_attempts_remaining--;
+				Logger::log( sprintf( 'Retrying domain verification in 5 seconds. Attempts left: %d', self::$verification_attempts_remaining ), 'debug' );
 				sleep( 5 );
 				return call_user_func( __METHOD__ );
 			}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Exception;
 use Throwable;
 /**
  * Class PluginUpdate
@@ -155,6 +156,7 @@ class PluginUpdate {
 	 * Update procedure for the 1.0.9 version of the plugin.
 	 *
 	 * @since x.x.x
+	 * @throws Exception Verification error.
 	 * @return void
 	 */
 	private function update_to_1_0_9(): void {
@@ -162,7 +164,19 @@ class PluginUpdate {
 			// Already up to date.
 			return;
 		}
-		// Perform update.
-	}
+		$account_data = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
 
+		/**
+		 * Trigger update only if the user has performed verification
+		 * procedure already. Otherwise we rely on the setup wizard process.
+		 */
+		if ( ! ( isset( $account_data['domain_verified'] ) && isset( $account_data['verified_domains'] ) ) ) {
+			return;
+		}
+
+		$response = API\DomainVerification::trigger_domain_verification();
+		if ( is_wp_error( $response ) ) {
+			throw new Exception( $response->get_error_message() );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #354 .

This PR is an implementation of #358 ( Use website verification instead of domains ) using an Update Framework that I have created in #390.

When I have noticed that #358 requires an update procedure for the plugin I have decided that it will be better if we will decouple the plugin execution code with the update procedure code. This is why #390 was created. This PR reworks #358 by moving the update code to a specialized update procedure in the update class.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Starting from the `develop` branch connect to Pinterest.
2. Checkout this branch.
3. Reload the page.
4. Observe that the feed is broken and the site is not verified. Feed claims that it is disabled but that is not true.
<img width="857" alt="image" src="https://user-images.githubusercontent.com/17271089/158145122-fb27e6ce-484d-465d-be55-0353deb01578.png">

6. Change manually in code `PINTEREST_FOR_WOOCOMMERCE_VERSION` to `1.0.9`
7. Reload the page.
8. Feed should work again.

During the release, the version in `PINTEREST_FOR_WOOCOMMERCE_VERSION` will be changed by the release script which means that the update code will be triggered during the first plugin load.

### Additional details:

After #390 will be merged this will be automatically targeted at `develop` branch by Facebook.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Use website verification instead of domain verification.
