### PR TITLE
Move deactivation hook to plugin file

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -248,11 +248,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
-			// Unschedule tasks if woocommerce is deactivated.
-			if ( defined( 'WC_PLUGIN_FILE' ) ) {
-				register_deactivation_hook( WC_PLUGIN_FILE, array( Pinterest\ProductSync::class, 'cancel_jobs' ) );
-			}
-
 			$this->maybe_update_plugin();
 		}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -252,7 +252,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
-			$this->maybe_update_plugin();
 		}
 
 

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -128,3 +128,13 @@ register_deactivation_hook(
 		Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
 	}
 );
+
+// Register deactivation hook for WooCommerce.
+if ( defined( 'WC_PLUGIN_FILE' ) ) {
+	register_deactivation_hook(
+		WC_PLUGIN_FILE,
+		function () {
+			Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
+		}
+	);
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #360.
An extra change for consistency on where we put the deactivation hooks.
This PR is a little amendment of the previous one PR #373.

### Screenshots:

### Detailed test instructions:

### Additional details:

### Changelog entry

> Tweak - Place all deactivation hooks in the same place.
