### PR TITLE
Update code paths for WC 6.4 in Unit Tests.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -76,8 +76,8 @@ function install_woocommerce() {
 	WC_Install::install();
 
 	// Initialize the WC API extensions.
-	\Automattic\WooCommerce\Admin\Install::create_tables();
-	\Automattic\WooCommerce\Admin\Install::create_events();
+	\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+	\Automattic\WooCommerce\Internal\Admin\Install::create_events();
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
Since this https://github.com/woocommerce/woocommerce/commit/3dd60322d5490d7d86ad33e7d732f276df73a12d change has happened we need to update the paths for our Unit Tests.

No changelog entry is needed.
### Changelog entry
