### PR TITLE
Remove invalid XML characters from feed.

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -464,7 +464,7 @@ class ProductsXmlFeed {
 				'<g:shipping>' . PHP_EOL .
 					"\t\t\t\t<g:country>$info[country]</g:country>" . PHP_EOL .
 					( $info['state'] ? "\t\t\t\t<g:region>$info[state]</g:region>" . PHP_EOL : '' ) .
-					"\t\t\t\t<g:service>$info[name]</g:service>" . PHP_EOL .
+					"\t\t\t\t<g:service>" . self::sanitize( $info['name'] ) . "</g:service>" . PHP_EOL .
 					"\t\t\t\t<g:price>$info[cost] $currency</g:price>" . PHP_EOL .
 				"\t\t\t</g:shipping>";
 		}

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -202,7 +202,7 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_title( $product, $property ) {
 		$title = wp_strip_all_tags( $product->get_name() );
-		return "<$property>" . self::sanitize( '<![CDATA[' . $title  . ']]>' ) . "</$property>";
+		return "<$property>" . self::sanitize( '<![CDATA[' . $title . ']]>' ) . "</$property>";
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -460,11 +460,12 @@ class ProductsXmlFeed {
 		 *	</g:shipping>
 		 */
 		foreach ( $shipping_info as $info ) {
+			$shipping_name    = self::sanitize( $info['name'] );
 			$shipping_nodes[] =
 				'<g:shipping>' . PHP_EOL .
 					"\t\t\t\t<g:country>$info[country]</g:country>" . PHP_EOL .
 					( $info['state'] ? "\t\t\t\t<g:region>$info[state]</g:region>" . PHP_EOL : '' ) .
-					"\t\t\t\t<g:service>" . self::sanitize( $info['name'] ) . "</g:service>" . PHP_EOL .
+					"\t\t\t\t<g:service>$shipping_name</g:service>" . PHP_EOL .
 					"\t\t\t\t<g:price>$info[cost] $currency</g:price>" . PHP_EOL .
 				"\t\t\t</g:shipping>";
 		}

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -202,7 +202,7 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_title( $product, $property ) {
 		$title = wp_strip_all_tags( $product->get_name() );
-		return '<' . $property . '><![CDATA[' . self::sanitize( $title ) . ']]></' . $property . '>';
+		return "<$property>" . self::sanitize( '<![CDATA[' . $title  . ']]>' ) . "</$property>";
 	}
 
 	/**
@@ -253,7 +253,7 @@ class ProductsXmlFeed {
 		}
 		$description = substr( $description, 0, self::DESCRIPTION_SIZE_CHARS_LIMIT );
 
-		return '<' . $property . '><![CDATA[' . self::sanitize( $description ) . ']]></' . $property . '>';
+		return "<$property>" . self::sanitize( '<![CDATA[' . $description . ']]>' ) . "</$property>";
 	}
 
 	/**
@@ -544,7 +544,8 @@ class ProductsXmlFeed {
 	/**
 	 * Sanitize XML.
 	 * After this method the string should be a valid XML string to fit inside
-	 * a XML tag directly or in CDATA enclosing tag.
+	 * a XML tag directly. If a CDATA markup is used it also needs to be passed
+	 * along the string.
 	 *
 	 * This operation consist of two steps:
 	 *
@@ -564,7 +565,7 @@ class ProductsXmlFeed {
 	 */
 	private static function sanitize( $xml_fragment ) {
 		return esc_xml(
-			preg_replace( '/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD]/', ' ', $xml_fragment )
+			preg_replace( '/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u', ' ', $xml_fragment )
 		);
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -267,7 +267,10 @@ class ProductsXmlFeed {
 	private static function get_property_g_product_type( $product, $property ) {
 
 		$id         = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
-		$taxonomies = self::get_taxonomies( $id );
+		$taxonomies = array_map(
+			'self::sanitize',
+			self::get_taxonomies( $id )
+		);
 
 		if ( empty( $taxonomies ) ) {
 			return;

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -560,12 +560,12 @@ class ProductsXmlFeed {
 	 *
 	 *
 	 * @since x.x.x
-	 * @param string XML fragment for sanitization.
-	 * @return string Sanitized XML fragment.
+	 * @param string  $xml_fragment XML fragment for sanitization.
+	 * @return string               Sanitized XML fragment.
 	*/
-	private static function sanitize( $string ) {
+	private static function sanitize( $xml_fragment ) {
 		return esc_xml(
-			preg_replace('/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD\\x10000-\\x10FFFF]/', ' ', $string )
+			preg_replace( '/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD]/' , ' ', $xml_fragment )
 		);
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -155,7 +155,7 @@ class ProductsXmlFeed {
 
 		foreach ( $attributes as $name => $value ) {
 			$property = "g:{$name}";
-			$value    = esc_html( $value );
+			$value    = esc_xml( $value );
 			$xml     .= "{$indent}<{$property}>{$value}</{$property}>" . PHP_EOL;
 		}
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -397,7 +397,7 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_property_g_mpn( $product, $property ) {
-		return '<' . $property . '>' . esc_xml( $product->get_sku() ) . '</' . $property . '>';
+		return '<' . $property . '>' . self::sanitize( $product->get_sku() ) . '</' . $property . '>';
 	}
 
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -202,7 +202,7 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_title( $product, $property ) {
 		$title = wp_strip_all_tags( $product->get_name() );
-		return '<' . $property . '><![CDATA[' .  self::sanitize(( $title )) . ']]></' . $property . '>';
+		return '<' . $property . '><![CDATA[' . self::sanitize( $title ) . ']]></' . $property . '>';
 	}
 
 	/**
@@ -558,14 +558,13 @@ class ProductsXmlFeed {
 	 *    For information about allowed UTF-8 characters please go to
 	 *    https://www.w3.org/TR/xml/ documentation, section charsets.
 	 *
-	 *
 	 * @since x.x.x
-	 * @param string  $xml_fragment XML fragment for sanitization.
+	 * @param string $xml_fragment XML fragment for sanitization.
 	 * @return string               Sanitized XML fragment.
-	*/
+	 */
 	private static function sanitize( $xml_fragment ) {
 		return esc_xml(
-			preg_replace( '/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD]/' , ' ', $xml_fragment )
+			preg_replace( '/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD]/', ' ', $xml_fragment )
 		);
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -201,7 +201,8 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_property_title( $product, $property ) {
-		return '<' . $property . '><![CDATA[' . wp_strip_all_tags( $product->get_name() ) . ']]></' . $property . '>';
+		$title = wp_strip_all_tags( $product->get_name() );
+		return '<' . $property . '><![CDATA[' .  self::sanitize(( $title )) . ']]></' . $property . '>';
 	}
 
 	/**
@@ -252,7 +253,7 @@ class ProductsXmlFeed {
 		}
 		$description = substr( $description, 0, self::DESCRIPTION_SIZE_CHARS_LIMIT );
 
-		return '<' . $property . '><![CDATA[' . $description . ']]></' . $property . '>';
+		return '<' . $property . '><![CDATA[' . self::sanitize( $description ) . ']]></' . $property . '>';
 	}
 
 	/**
@@ -538,5 +539,33 @@ class ProductsXmlFeed {
 		}
 
 		return $price;
+	}
+
+	/**
+	 * Sanitize XML.
+	 * After this method the string should be a valid XML string to fit inside
+	 * a XML tag directly or in CDATA enclosing tag.
+	 *
+	 * This operation consist of two steps:
+	 *
+	 * 1. First a standardized esc_xml WordPress method is used.
+	 *    This escapes XML control characters inside the text block.
+	 *
+	 * 2. Remove all UTF-8 characters that are not part of the XML specification.
+	 *    We search the whole string and remove the not-allowed chars. Since XML
+	 *    does not understand them removing is the only operation that we can do
+	 *    that will produce a valid XML.
+	 *    For information about allowed UTF-8 characters please go to
+	 *    https://www.w3.org/TR/xml/ documentation, section charsets.
+	 *
+	 *
+	 * @since x.x.x
+	 * @param string XML fragment for sanitization.
+	 * @return string Sanitized XML fragment.
+	*/
+	private static function sanitize( $string ) {
+		return esc_xml(
+			preg_replace('/[^\\x0009\\x000A\\x000D\\x0020-\\xD7FF\\xE000-\\xFFFD\\x10000-\\x10FFFF]/', ' ', $string )
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove invalid XML characters from the XML sections.

Closes #401 .

XML defines a correct ranges for allowed characters https://www.w3.org/TR/REC-xml/#charsets we need to remove characters that are not in the ranges.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Configure the plugin
2. Create a product.
3. Update the description to contain an invalid XML char. For example copy a char from here https://www.fileformat.info/info/unicode/char/0003/browsertest.htm Mark and copy inside the UTF-8 section - you can't see it but it is there.
4. Generate the feed.
5. Open the feed in the browser using the link from Marketing > Pinterest > Catalog - it should open correctly. Browsers validate the XML. For double-checking check that the copied char is not there.
6. Do the same on develop - the XML should be corrupted.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Fix - Remove invalid XML characters from the feed.
