### PR TITLE
Add Mexico to adds supported countries.

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -43,6 +43,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 				'IT', // Italy.
 				'LU', // Luxembourg.
 				'MT', // Malta.
+				'MX', // Mexico.
 				'NL', // Netherlands.
 				'NZ', // New Zealand.
 				'NO', // Norway.

--- a/tests/Unit/FeedXMLGenerationShippingTest.php
+++ b/tests/Unit/FeedXMLGenerationShippingTest.php
@@ -181,6 +181,11 @@ class Pinterest_Test_Shipping_Feed extends WC_Unit_Test_Case {
 				<g:price>15.00 USD</g:price>
 			</g:shipping>
 			<g:shipping>
+				<g:country>MX</g:country>
+				<g:service>Flat rate</g:service>
+				<g:price>15.00 USD</g:price>
+			</g:shipping>
+			<g:shipping>
 				<g:country>US</g:country>
 				<g:service>Flat rate</g:service>
 				<g:price>15.00 USD</g:price>
@@ -401,6 +406,11 @@ class Pinterest_Test_Shipping_Feed extends WC_Unit_Test_Case {
 		$xml      = $this->ProductsXmlFeed__get_property_g_shipping( end( $this->products ) );
 		$expected = "<g:shipping>
 				<g:country>CA</g:country>
+				<g:service>Free shipping</g:service>
+				<g:price>0.00 USD</g:price>
+			</g:shipping>
+			<g:shipping>
+				<g:country>MX</g:country>
 				<g:service>Free shipping</g:service>
 				<g:price>0.00 USD</g:price>
 			</g:shipping>


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Add Mexico to adds supported countries.
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #425 .


Mexico is supported by Pinterest so we should have it in the list.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the General tab of WC Settings. Change the "Country / State" option to Mexico
2. Go to the landing page: /wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding
3. Everything should work as normal.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Mexico to adds supported countries.
