### PR TITLE
Include all tracking properties with JS tracking

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -305,15 +305,21 @@ class Tracking {
 	 * @return void
 	 */
 	public static function ajax_tracking_snippet() {
-
-		$tracking = 'jQuery( function( $ ) { ;
-				$( document.body ).on( \'added_to_cart\', function ( e, fragments, cart_hash, thisbutton ) {
-					pintrk( \'track\', \'AddToCart\', {
-						\'product_id\': thisbutton.data( \'product_id\' ),
-						\'order_quantity\': thisbutton.data( \'quantity\' ),
-					});
-				} );
-			} )';
+		$wc_currency = get_woocommerce_currency();
+		$tracking    = <<< JS
+jQuery( function( $ ) {
+	$( document.body ).on( 'added_to_cart', function( e, fragments, cart_hash, thisbutton ) {
+		var quantity = thisbutton.data( 'quantity' );
+		pintrk( 'track', 'AddToCart', {
+			'product_id': thisbutton.data( 'product_id' ),
+			'product_name': thisbutton.data( 'product_name' ),
+			'value': thisbutton.data( 'price' ) * quantity,
+			'order_quantity': quantity,
+			'currency': '{$wc_currency}'
+		} );
+	} );
+} );
+JS;
 
 		wp_add_inline_script( 'wc-add-to-cart', $tracking );
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Pinterest\API\AdvertiserConnect;
+use WC_Product;
 
 /**
  * Class adding Save Pin support.
@@ -90,6 +91,14 @@ class Tracking {
 			// AddToCart - ajax.
 			if ( 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' ) && 'yes' !== get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				add_action( 'wp_enqueue_scripts', array( __CLASS__, 'ajax_tracking_snippet' ), 20 );
+				add_filter(
+					'woocommerce_loop_add_to_cart_args',
+					function( $args, $product ) {
+						return self::filter_add_to_cart_attributes( $args, $product );
+					},
+					10,
+					2
+				);
 			}
 
 			// AddToCart - non-ajax.
@@ -522,5 +531,28 @@ class Tracking {
 		if ( ! $is_connected && $connected_advertiser && $connected_tag ) {
 			AdvertiserConnect::connect_advertiser_and_tag( $connected_advertiser, $connected_tag );
 		}
+	}
+
+	/**
+	 * Filter the "Add to cart" button attributes to include more data.
+	 *
+	 * @see woocommerce_template_loop_add_to_cart()
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array      $args The arguments used for the Add to cart button.
+	 * @param WC_Product $product The product object.
+	 *
+	 * @return array The filtered arguments for the Add to cart button.
+	 */
+	private static function filter_add_to_cart_attributes( array $args, WC_Product $product ) {
+		$attributes = array(
+			'data-product_name' => $product->get_name(),
+			'data-price'        => $product->get_price(),
+		);
+
+		$args['attributes'] = array_merge( $args['attributes'], $attributes );
+
+		return $args;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #400.

This updates the tracking code triggered by the "Add to cart" button to include the same data that is provided from the regular product page.

### Detailed test instructions:

1. Install the plugin and do the onboarding with a merchant.
2. Make sure that tracking is properly configured.
3. From the shop page, click the "Add to cart" button for a product. In the network tab of your browser dev tools, you should see the data in the tracking event named `AddToCart` includes all of the correct items: `product_id`, `product_name`, `value`, `order_quantity`, and `currency`.
4. Navigate to an individual product page, and add the product to the cart
5. Check the event and see that all of the same parameters are included in the `AddToCart` event

### Screenshots

<img width="931" alt="Screen Shot 2022-04-05 at 6 07 08 PM" src="https://user-images.githubusercontent.com/871924/161859979-7c69d728-3d43-47c3-a0fa-a1d707133a07.png">


### Changelog entry


> Fix - Ensure Add to cart tag data is consistent
