### PR TITLE
Fix/support new namespace for wc admin install

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4]
-        wp-version: [5.6, 5.7, 5.8]
+        wp-version: [5.6, 5.7, 5.8, latest]
 
     steps:
       - name: Checkout repository

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -76,8 +76,13 @@ function install_woocommerce() {
 	WC_Install::install();
 
 	// Initialize the WC API extensions.
-	\Automattic\WooCommerce\Admin\Install::create_tables();
-	\Automattic\WooCommerce\Admin\Install::create_events();
+	if ( class_exists( '\Automattic\WooCommerce\Internal\Admin\Install' ) ) {
+		\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Internal\Admin\Install::create_events();
+	} else {
+		\Automattic\WooCommerce\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Admin\Install::create_events();
+	}
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce Admin is being moved into the WooCommerce monorepo repository. Since we were basing our unit tests on the trunk branch this was causing some failures.


Closes #431.


### Detailed test instructions:

1. Run PHP unit tests against WC monorepo version. Eg: 6.4.0-rc.1. 
2. All the should be passing


### Changelog entry

> Fix - Unit tests failing on WC 6.4

