### PR TITLE
Take taxes into account in tracking events

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -76,6 +76,22 @@ class ProductSync {
 				self::$feed_generator->mark_feed_dirty();
 			}
 		);
+
+		/**
+		 * Mark feed as needing re-generation on changes to the woocommerce_tax_display_shop or woocommerce_tax_display_cart settings
+		 */
+		add_action(
+			'update_option_woocommerce_tax_display_shop',
+			function () {
+				self::$feed_generator->mark_feed_dirty();
+			}
+		);
+		add_action(
+			'update_option_woocommerce_tax_display_cart',
+			function () {
+				self::$feed_generator->mark_feed_dirty();
+			}
+		);
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -551,9 +551,9 @@ class ProductsXmlFeed {
 	 */
 	private static function get_product_regular_price( $product ) {
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
-			$price = $product->get_variation_regular_price();
+			$price = $product->get_variation_regular_price( 'min', true );
 		} else {
-			$price = $product->get_regular_price();
+			$price = wc_get_price_to_display( $product );
 		}
 
 		return $price;

--- a/src/RichPins.php
+++ b/src/RichPins.php
@@ -159,7 +159,7 @@ class RichPins {
 
 		// mandatory tags.
 		$tags['product:price:currency'] = get_woocommerce_currency();
-		$tags['product:price:amount']   = $product->get_price();
+		$tags['product:price:amount']   = wc_get_price_to_display( $product );
 
 		// tags enabled by setup.
 		if ( $product->is_on_sale() ) {

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -221,12 +221,14 @@ class Tracking {
 		$object_id = empty( $variation_id ) ? $product_id : $variation_id;
 		$product   = wc_get_product( $object_id );
 
+		$product_price = WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : wc_get_price_excluding_tax( $product );
+
 		self::add_event(
 			'AddToCart',
 			array(
 				'product_id'     => $product->get_id(),
 				'product_name'   => $product->get_name(),
-				'value'          => ( $product->get_price() * $quantity ),
+				'value'          => ( $product_price * $quantity ),
 				'order_quantity' => $quantity,
 				'currency'       => get_woocommerce_currency(),
 			)
@@ -260,13 +262,15 @@ class Tracking {
 
 			$product = $order_item->get_product();
 
+			$product_price = WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : wc_get_price_excluding_tax( $product );
+
 			$terms      = wc_get_object_terms( $product->get_id(), 'product_cat' );
 			$categories = ! empty( $terms ) ? wp_list_pluck( $terms, 'name' ) : array();
 
 			$order_items[] = array(
 				'product_id'       => $order_item->get_id(),
 				'product_name'     => $order_item->get_name(),
-				'product_price'    => $product->get_price(),
+				'product_price'    => $product_price,
 				'product_quantity' => $order_item->get_quantity(),
 				'product_category' => $categories,
 			);
@@ -367,7 +371,7 @@ class Tracking {
 			$data = array(
 				'product_id'    => $product->get_id(),
 				'product_name'  => $product->get_name(),
-				'product_price' => $product->get_price(),
+				'product_price' => wc_get_price_to_display( $product ),
 			);
 		}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -268,7 +268,7 @@ class Tracking {
 			$categories = ! empty( $terms ) ? wp_list_pluck( $terms, 'name' ) : array();
 
 			$order_items[] = array(
-				'product_id'       => $order_item->get_id(),
+				'product_id'       => $product->get_id(),
 				'product_name'     => $order_item->get_name(),
 				'product_price'    => $product_price,
 				'product_quantity' => $order_item->get_quantity(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #402.

Fix the product's price mismatch if the prices are shown including taxes or not.
- Fix the price mismatch on shop and product pages, also on cart and checkout.
- Fix the price mismatch on feed file (the price on feed will be the same than shop and product pages).

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. Set the options 'Display prices in the shop' and 'Display prices during cart and checkout' to 'Including tax' located on WooCommerce Settings -> Tax -> Tax Options.
3. Visit a product page and add to cart a product.
4. The price shown in the tracking events should be the same than product page and cart.
5. Verify that the price is also correct on the feed file.


### Additional details:

> Fix - Price mismatch when price includes taxes.

### Changelog entry

