### PR TITLE
Sync enhanced match support with Pinterest

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -113,7 +113,7 @@ const SetupPins = ( {} ) => {
 										help={
 											<HelpTooltip
 												text={ __(
-													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled.',
+													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled. Changes on this option are synched with the Pinterest conversion tag.',
 													'pinterest-for-woocommerce'
 												) }
 											/>

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -734,9 +734,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		private static function maybe_sync_enhanced_match_support( $old_value, $new_value ) {
 
-			if (
-				! isset( $old_value['enhanced_match_support'], $new_value['enhanced_match_support'] )
-			) {
+			if ( ! isset( $old_value['enhanced_match_support'], $new_value['enhanced_match_support'] ) ) {
 				return;
 			}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -735,13 +735,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		private static function maybe_sync_enhanced_match_support( $old_value, $new_value ) {
 
 			if (
-				! isset( $old_value['enhanced_match_support'] ) ||
-				! isset( $new_value['enhanced_match_support'] )
+				! isset( $old_value['enhanced_match_support'], $new_value['enhanced_match_support'] )
 			) {
 				return;
 			}
 
-			$tracking_tag = self::get_setting( 'tracking_tag', null );
+			$tracking_tag = self::get_setting( 'tracking_tag' );
 			if ( ! $tracking_tag ) {
 				return;
 			}
@@ -755,8 +754,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		/**
 		 * Update the tag on Pinterest.
 		 *
-		 * @param string  $tracking_tag The connected tag.
-		 * @param boolean $enhanced_match_support The value of the enhanced_math_support option.
+		 * @param string $tracking_tag The connected tag.
+		 * @param bool   $enhanced_match_support The value of the enhanced_math_support option.
 		 */
 		public static function update_tag_config( $tracking_tag, $enhanced_match_support ) {
 			try {
@@ -767,9 +766,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					)
 				);
 
-			} catch ( \Exception $th ) {
+			} catch ( \Exception $e ) {
 
-				Pinterest\Logger::log( esc_html__( 'There was an error updating the tag parameters.', 'pinterest-for-woocommerce' ) );
+				/* Translators: The error message */
+				Pinterest\Logger::log( sprintf( esc_html__( 'There was an error updating the tag parameters.: %s', 'pinterest-for-woocommerce' ), $e->getMessage() ), 'error' );
 			}
 		}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -748,19 +748,28 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Sync setting with Pinterest if old value is different than new ones.
 			if ( $old_value['enhanced_match_support'] !== $new_value['enhanced_match_support'] ) {
+				self::update_tag_config( $tracking_tag, $new_value['enhanced_match_support'] );
+			}
+		}
 
-				try {
-					Pinterest\API\Base::update_tag(
-						$tracking_tag,
-						array(
-							'aem_enabled' => $new_value['enhanced_match_support'],
-						)
-					);
+		/**
+		 * Update the tag on Pinterest.
+		 *
+		 * @param string  $tracking_tag The connected tag.
+		 * @param boolean $enhanced_match_support The value of the enhanced_math_support option.
+		 */
+		public static function update_tag_config( $tracking_tag, $enhanced_match_support ) {
+			try {
+				Pinterest\API\Base::update_tag(
+					$tracking_tag,
+					array(
+						'aem_enabled' => $enhanced_match_support,
+					)
+				);
 
-				} catch ( \Exception $th ) {
+			} catch ( \Exception $th ) {
 
-					Pinterest\Logger::log( esc_html__( 'There was an error updating the tag parameters.', 'pinterest-for-woocommerce' ) );
-				}
+				Pinterest\Logger::log( esc_html__( 'There was an error updating the tag parameters.', 'pinterest-for-woocommerce' ) );
 			}
 		}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -736,8 +736,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			if (
 				! isset( $old_value['enhanced_match_support'] ) ||
-				! isset( $new_value['enhanced_match_support'] ) ||
-				! $new_value['enhanced_match_support']
+				! isset( $new_value['enhanced_match_support'] )
 			) {
 				return;
 			}

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -64,6 +64,9 @@ class AdvertiserConnect extends VendorAPI {
 				);
 			}
 
+			// Sync the enhanced match support option (force syncing in users that already had an existing tag).
+			Pinterest_For_Woocommerce()::update_tag_config( $tag_id, Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
+
 			// Connect new advertiser and tag.
 			return self::connect_advertiser_and_tag( $advertiser_id, $tag_id );
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -13,7 +13,6 @@ use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException as ApiException;
 use \Exception;
-use Pinterest_For_Woocommerce;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -435,7 +434,7 @@ class Base {
 	 * @return mixed
 	 */
 	public static function update_tag( $tag_id, $params = array() ) {
-		$advertiser_id = Pinterest_For_Woocommerce::get_setting( 'tracking_advertiser' );
+		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
 
 		if ( ! $advertiser_id || empty( $params ) ) {
 			return false;

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -418,7 +418,8 @@ class Base {
 			"advertisers/{$advertiser_id}/conversion_tags",
 			'POST',
 			array(
-				'name' => $tag_name,
+				'name'        => $tag_name,
+				'aem_enabled' => (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ),
 			),
 			'ads'
 		);

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException as ApiException;
 use \Exception;
-
+use Pinterest_For_Woocommerce;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -100,7 +100,7 @@ class Base {
 				'args'   => $payload,
 			);
 
-			if ( 'ads/' === $api && 'POST' === $method ) {
+			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
 				// Force json content-type header and json encode payload.
 				$request['headers']['Content-Type'] = 'application/json';
 
@@ -421,6 +421,32 @@ class Base {
 				'name'        => $tag_name,
 				'aem_enabled' => (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ),
 			),
+			'ads'
+		);
+	}
+
+
+	/**
+	 * Update the parameters of an existing tag.
+	 *
+	 * @param string $tag_id The tag_id for which we want to update the parameters.
+	 * @param array  $params The parameters to update.
+	 *
+	 * @return mixed
+	 */
+	public static function update_tag( $tag_id, $params = array() ) {
+		$advertiser_id = Pinterest_For_Woocommerce::get_setting( 'tracking_advertiser' );
+
+		if ( ! $advertiser_id || empty( $params ) ) {
+			return false;
+		}
+
+		$params['id'] = (string) $tag_id;
+
+		return self::make_request(
+			"advertisers/{$advertiser_id}/conversion_tags",
+			'PATCH',
+			$params,
 			'ads'
 		);
 	}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -287,15 +287,6 @@ class PluginUpdate {
 			return;
 		}
 
-		try {
-			API\Base::update_tag(
-				$tracking_tag,
-				array(
-					'aem_enabled' => $aem_enabled,
-				)
-			);
-		} catch ( Exception $th ) {
-			Logger::log( esc_html__( 'There was an error updating the tag.', 'pinterest-for-woocommerce' ) );
-		}
+		Pinterest_For_Woocommerce()::update_tag_config( $tracking_tag, $aem_enabled );
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -282,8 +282,8 @@ class PluginUpdate {
 		$aem_enabled  = (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support', null );
 		$tracking_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag', null );
 
-		// Only update if the setting is enabled and we have a connected tag.
-		if ( ! $aem_enabled || ! $tracking_tag ) {
+		// Update the setting if we have a connected tag.
+		if ( ! $tracking_tag ) {
 			return;
 		}
 
@@ -291,7 +291,7 @@ class PluginUpdate {
 			API\Base::update_tag(
 				$tracking_tag,
 				array(
-					'aem_enabled' => true,
+					'aem_enabled' => $aem_enabled,
 				)
 			);
 		} catch ( Exception $th ) {

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -287,11 +287,15 @@ class PluginUpdate {
 			return;
 		}
 
-		API\Base::update_tag(
-			$tracking_tag,
-			array(
-				'aem_enabled' => true,
-			)
-		);
+		try {
+			API\Base::update_tag(
+				$tracking_tag,
+				array(
+					'aem_enabled' => true,
+				)
+			);
+		} catch ( Exception $th ) {
+			Logger::log( esc_html__( 'There was an error updating the tag.', 'pinterest-for-woocommerce' ) );
+		}
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -105,6 +105,7 @@ class PluginUpdate {
 		return array(
 			'domain_verification_migration',
 			'feed_generation_migration',
+			'enable_enhanced_match',
 		);
 	}
 
@@ -265,5 +266,32 @@ class PluginUpdate {
 		Pinterest_For_Woocommerce()::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 		// Update done.
+	}
+
+	/**
+	 * Enable enhanced match for tags which have already been created.
+	 *
+	 * @return void
+	 */
+	protected function enable_enhanced_match(): void {
+		if ( ! $this->version_needs_update( '1.0.11' ) ) {
+			// Already up to date.
+			return;
+		}
+
+		$aem_enabled  = (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support', null );
+		$tracking_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag', null );
+
+		// Only update if the setting is enabled and we have a connected tag.
+		if ( ! $aem_enabled || ! $tracking_tag ) {
+			return;
+		}
+
+		API\Base::update_tag(
+			$tracking_tag,
+			array(
+				'aem_enabled' => true,
+			)
+		);
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -279,8 +279,8 @@ class PluginUpdate {
 			return;
 		}
 
-		$aem_enabled  = (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support', null );
-		$tracking_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag', null );
+		$aem_enabled  = (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' );
+		$tracking_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag' );
 
 		// Update the setting if we have a connected tag.
 		if ( ! $tracking_tag ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #429
Closes #430 

This PR enables the enhanced match setting and syncs this through the Pinterest API.
It covers the following points:

- Set `aem_enabled` when creating a tag.
- For all users that are updating to 1.0.11 we will update the tag with the same value than the setting.
- When the settings are updated trigger a tag update to sync the option with Pinterest.

### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/161827149-7f130dd7-2a1d-4132-8c96-e6be19f419b5.png)


#### Creating a new tag
1. Create a new Pinterest account or get an account which has 0 tags.
2. Connect the account using the plugin.
3. Visit the store to generate any tag event.
4. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be enabled.

#### Update routine
1. On Pinterest page -> Ads -> Conversions disable/enable the Automatic enhanced match (to make it different than the plugin settings).
2. Temporarily bump the value PINTEREST_FOR_WOOCOMMERCE_VERSION in the main plugin file to 1.0.11.
3. Refresh any admin page.
4. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be synched with the plugin.

#### Enable/Disable in settings
2. On the Pinterest plugin > Settings page enable/disable the enhanced match and save the settings.
3. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be synched with the plugin.

### Additional details:

### Changelog entry
> Fix - Enabling automatic enhanced matching and synching with Pinterest side.
