### PR TITLE
Send currency in product page visit event

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -368,6 +368,7 @@ class Tracking {
 				'product_id'    => $product->get_id(),
 				'product_name'  => $product->get_name(),
 				'product_price' => $product->get_price(),
+				'currency'      => get_woocommerce_currency(),
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #421.

Double check all events to send the currency in all events.
- Added currency on product page visit event.
- Verified: currency sent on checkout event.
- Verified: currency sent on add to cart event.

- Missing: currency on add to cart event using AJAX.
NOTE: The PR #428 from @JPry adds the currency in the AJAX event, so we don't need to add it here.

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding with a merchant.
2. Make sure that tracking is properly configured.
3. Visit a product page and check the `pagevisit` event, currency should be sent along with the other product parameters.
4. Verify that currency is also sent on addToCart (not AJAX) event and checkout event.

### Additional details:

> Fix - Currency is now being sent on the product page visit event.

### Changelog entry

