### PR TITLE
Enable enhanced match and sync to Pinterest

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -78,33 +78,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		protected static $initialized = false;
 
 		/**
-		 * When set to true, the settings have been
-		 * changed and the runtime cached must be flushed
-		 *
-		 * @var Pinterest_For_Woocommerce
-		 * @since 1.0.0
-		 */
-		protected static $dirty_settings = array();
-
-		/**
-		 * The default settings that will be created
-		 * with the given values, if they don't exist.
-		 *
-		 * @var Pinterest_For_Woocommerce
-		 * @since 1.0.0
-		 */
-		protected static $default_settings = array(
-			'track_conversions'      => true,
-			'enhanced_match_support' => true,
-			'save_to_pinterest'      => true,
-			'rich_pins_on_posts'     => true,
-			'rich_pins_on_products'  => true,
-			'product_sync_enabled'   => true,
-			'enable_debug_logging'   => false,
-			'erase_plugin_data'      => false,
-		);
-
-		/**
 		 * Main Pinterest_For_Woocommerce Instance.
 		 *
 		 * Ensures only one instance of Pinterest_For_Woocommerce is loaded or can be loaded.
@@ -239,19 +212,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Tracking::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
+			add_action( 'init', array( Pinterest\Settings::class, 'maybe_init' ) );
 
-			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
-
-			// Allow access to our option through the REST API.
-			add_filter( 'woocommerce_rest_api_option_permissions', array( $this, 'add_option_permissions' ), 10, 1 );
-
-			// Disconnect advertiser if advertiser or tag change.
-			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
-
 		}
 
 
@@ -402,97 +368,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 
 		/**
-		 * Allow access to our option through the REST API for a user that can manage the store.
-		 * The UI relies on this option being available through the API.
-		 *
-		 * @param array $permissions The permissions array.
-		 *
-		 * @return array
-		 */
-		public function add_option_permissions( $permissions ) {
-
-			$permissions[ PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ] = current_user_can( 'manage_woocommerce' );
-			return $permissions;
-		}
-
-
-		/**
-		 * Return APP Settings
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param boolean $force  Controls whether to force getting a fresh value instead of one from the runtime cache.
-		 * @param string  $option Controls which option to read/write to.
-		 *
-		 * @return array
-		 */
-		public static function get_settings( $force = false, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
-
-			static $settings;
-
-			if ( $force || is_null( $settings ) || ! isset( $settings[ $option ] ) || ( isset( self::$dirty_settings[ $option ] ) && self::$dirty_settings[ $option ] ) ) {
-				$settings[ $option ] = get_option( $option );
-			}
-
-			return $settings[ $option ];
-		}
-
-
-		/**
-		 * Return APP Setting based on its key
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string  $key The key of specific option to retrieve.
-		 * @param boolean $force Controls whether to force getting a fresh value instead of one from the runtime cache.
-		 *
-		 * @return mixed
-		 */
-		public static function get_setting( $key, $force = false ) {
-
-			$settings = self::get_settings( $force );
-
-			return empty( $settings[ $key ] ) ? false : $settings[ $key ];
-		}
-
-
-		/**
-		 * Save APP Setting
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $key The key of specific option to retrieve.
-		 * @param mixed  $data The data to save for this option key.
-		 *
-		 * @return boolean
-		 */
-		public static function save_setting( $key, $data ) {
-
-			$settings = self::get_settings( true );
-
-			$settings[ $key ] = $data;
-
-			return self::save_settings( $settings );
-		}
-
-
-		/**
-		 * Save APP Settings
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array  $settings The array of settings to save.
-		 * @param string $option Controls which option to read/write to.
-		 *
-		 * @return boolean
-		 */
-		public static function save_settings( $settings, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
-			self::$dirty_settings[ $option ] = true;
-			return update_option( $option, $settings );
-		}
-
-
-		/**
 		 * Return APP Data based on its key
 		 *
 		 * @since 1.0.0
@@ -504,7 +379,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function get_data( $key, $force = false ) {
 
-			$settings = self::get_settings( $force, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			$settings = Pinterest\Settings::get_settings( $force, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 			return empty( $settings[ $key ] ) ? null : $settings[ $key ];
 		}
@@ -522,13 +397,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_data( $key, $data ) {
 
-			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			$settings = Pinterest\Settings::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 			$settings[ $key ] = $data;
 
-			return self::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			return Pinterest\Settings::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 		}
-
 
 		/**
 		 * Add API endpoints
@@ -628,8 +502,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				}
 
 				// Disconnect the advertiser from Pinterest.
-				$connected_advertiser = self::get_setting( 'tracking_advertiser', null );
-				$connected_tag        = self::get_setting( 'tracking_tag', null );
+				$connected_advertiser = Pinterest\Settings::get_setting( 'tracking_advertiser', null );
+				$connected_tag        = Pinterest\Settings::get_setting( 'tracking_tag', null );
 
 				if ( $connected_advertiser && $connected_tag ) {
 
@@ -668,48 +542,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			delete_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 			// Remove settings that may cause issues if stale on disconnect.
-			self::save_setting( 'account_data', null );
-			self::save_setting( 'tracking_advertiser', null );
-			self::save_setting( 'tracking_tag', null );
+			Pinterest\Settings::save_setting( 'account_data', null );
+			Pinterest\Settings::save_setting( 'tracking_advertiser', null );
+			Pinterest\Settings::save_setting( 'tracking_tag', null );
 
 			// Cancel scheduled jobs.
 			Pinterest\ProductSync::cancel_jobs();
-		}
-
-
-		/**
-		 * Disconnect advertiser from the platform if advertiser or tag change.
-		 *
-		 * @param array $old_value The old value of the option.
-		 * @param array $new_value The new value of the option.
-		 */
-		public static function maybe_disconnect_advertiser( $old_value, $new_value ) {
-
-			if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
-				return;
-			}
-
-			if (
-				! isset( $old_value['tracking_advertiser'] ) ||
-				! isset( $old_value['tracking_tag'] ) ||
-				! isset( $new_value['tracking_advertiser'] ) ||
-				! isset( $new_value['tracking_tag'] )
-			) {
-				return;
-			}
-
-			// Disconnect merchant if old values are different than new ones.
-			if ( $old_value['tracking_advertiser'] !== $new_value['tracking_advertiser'] || $old_value['tracking_tag'] !== $new_value['tracking_tag'] ) {
-
-				try {
-
-					Pinterest\API\AdvertiserConnect::disconnect_advertiser( $old_value['tracking_advertiser'], $old_value['tracking_tag'] );
-
-				} catch ( \Exception $th ) {
-
-					Pinterest\Logger::log( esc_html__( 'There was an error disconnecting the Advertiser. Please try again.', 'pinterest-for-woocommerce' ) );
-				}
-			}
 		}
 
 		/**
@@ -817,7 +655,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					)
 				);
 
-				Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
+				Pinterest\Settings::save_setting( 'account_data', $data );
 				return $data;
 			}
 
@@ -863,7 +701,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return array
 		 */
 		public static function update_linked_businesses() {
-			$account_data       = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
+			$account_data       = Pinterest\Settings::get_setting( 'account_data' );
 			$fetched_businesses = ( ! empty( $account_data ) && ! $account_data['is_partner'] ) ? Pinterest\API\Base::get_linked_businesses() : array();
 
 			if ( ! empty( $fetched_businesses ) && 'success' === $fetched_businesses['status'] ) {
@@ -883,23 +721,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return string|false
 		 */
 		public static function get_account_id() {
-			$account_data = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
+			$account_data = Pinterest\Settings::get_setting( 'account_data' );
 			return isset( $account_data['id'] ) ? $account_data['id'] : false;
-		}
-
-		/**
-		 * Sets the default settings based on the
-		 * given values in self::$default_settings
-		 *
-		 * @return boolean
-		 */
-		public static function set_default_settings() {
-
-			$settings = self::get_settings( true );
-			$settings = wp_parse_args( $settings, self::$default_settings );
-
-			return self::save_settings( $settings );
-
 		}
 
 		/**
@@ -964,7 +787,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				return false;
 			}
 
-			$account_data = self::get_setting( 'account_data' );
+			$account_data = Pinterest\Settings::get_setting( 'account_data' );
 
 			return isset( $account_data['is_partner'] ) ? (bool) $account_data['is_partner'] : false;
 		}
@@ -978,7 +801,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return boolean
 		 */
 		public static function is_domain_verified() {
-			$account_data = self::get_setting( 'account_data' );
+			$account_data = Pinterest\Settings::get_setting( 'account_data' );
 			return isset( $account_data['is_any_website_verified'] ) ? (bool) $account_data['is_any_website_verified'] : false;
 		}
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -412,13 +412,15 @@ class Base {
 	 */
 	public static function create_tag( $advertiser_id ) {
 
-		$tag_name = apply_filters( 'pinterest_for_woocommerce_default_tag_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
+		$tag_name    = apply_filters( 'pinterest_for_woocommerce_default_tag_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
+		$aem_enabled = boolval( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
 
 		return self::make_request(
 			"advertisers/{$advertiser_id}/conversion_tags",
 			'POST',
 			array(
-				'name' => $tag_name,
+				'name'        => $tag_name,
+				'aem_enabled' => $aem_enabled,
 			),
 			'ads'
 		);

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -100,7 +100,7 @@ class Base {
 				'args'   => $payload,
 			);
 
-			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH', true ) ) ) {
+			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
 				// Force json content-type header and json encode payload.
 				$request['headers']['Content-Type'] = 'application/json';
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -426,6 +426,30 @@ class Base {
 		);
 	}
 
+	/**
+	 * Update an existing tag.
+	 *
+	 * @param string $tag_id The tag_id to update.
+	 * @param array  $params Tag parameters to update.
+	 *
+	 * @return mixed
+	 */
+	public static function update_tag( $tag_id, $params = array() ) {
+		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser', null );
+
+		if ( ! $advertiser_id || empty( $params ) ) {
+			return false;
+		}
+
+		$params['id'] = (string) $tag_id;
+
+		return self::make_request(
+			"advertisers/{$advertiser_id}/conversion_tags",
+			'PATCH',
+			$params,
+			'ads'
+		);
+	}
 
 	/**
 	 * Update the tags configuration.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\Pinterest\API;
 use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException as ApiException;
+use Automattic\WooCommerce\Pinterest\Settings;
 use \Exception;
 
 
@@ -413,7 +414,7 @@ class Base {
 	public static function create_tag( $advertiser_id ) {
 
 		$tag_name    = apply_filters( 'pinterest_for_woocommerce_default_tag_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
-		$aem_enabled = boolval( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
+		$aem_enabled = boolval( Settings::get_setting( 'enhanced_match_support' ) );
 
 		return self::make_request(
 			"advertisers/{$advertiser_id}/conversion_tags",
@@ -435,7 +436,7 @@ class Base {
 	 * @return mixed
 	 */
 	public static function update_tag( $tag_id, $params = array() ) {
-		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser', null );
+		$advertiser_id = Settings::get_setting( 'tracking_advertiser' );
 
 		if ( ! $advertiser_id || empty( $params ) ) {
 			return false;

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -100,7 +100,7 @@ class Base {
 				'args'   => $payload,
 			);
 
-			if ( 'ads/' === $api && 'POST' === $method ) {
+			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH', true ) ) ) {
 				// Force json content-type header and json encode payload.
 				$request['headers']['Content-Type'] = 'application/json';
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -46,7 +46,7 @@ class Logger {
 
 		$allow_logging = true;
 		if ( 'debug' === $level ) {
-			$allow_logging = Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' );
+			$allow_logging = Settings::get_setting( 'enable_debug_logging' );
 		}
 
 		if ( $force ) {

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -266,4 +266,31 @@ class PluginUpdate {
 
 		// Update done.
 	}
+
+	/**
+	 * Enable enhanced match for tags which have already been created.
+	 *
+	 * @return void
+	 */
+	protected function enable_enhanced_match(): void {
+		if ( ! $this->version_needs_update( '1.0.11' ) ) {
+			// Already up to date.
+			return;
+		}
+
+		$aem_enabled   = boolval( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
+		$connected_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag', null );
+
+		// Only update if the setting is enabled and we have a connected tag.
+		if ( ! $aem_enabled || ! $connected_tag ) {
+			return;
+		}
+
+		Base::update_tag(
+			$connected_tag,
+			array(
+				'aem_enabled' => true,
+			)
+		);
+	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -105,6 +105,7 @@ class PluginUpdate {
 		return array(
 			'domain_verification_migration',
 			'feed_generation_migration',
+			'enable_enhanced_match',
 		);
 	}
 
@@ -286,11 +287,15 @@ class PluginUpdate {
 			return;
 		}
 
-		Base::update_tag(
-			$connected_tag,
-			array(
-				'aem_enabled' => true,
-			)
-		);
+		try {
+			API\Base::update_tag(
+				$connected_tag,
+				array(
+					'aem_enabled' => true,
+				)
+			);
+		} catch ( Exception $th ) {
+			Logger::log( esc_html__( 'There was an error updating the tag.', 'pinterest-for-woocommerce' ) );
+		}
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -183,7 +183,7 @@ class PluginUpdate {
 			// Already up to date.
 			return;
 		}
-		$account_data = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
+		$account_data = Settings::get_setting( 'account_data' );
 
 		/**
 		 * Trigger update only if the user has performed verification
@@ -258,11 +258,11 @@ class PluginUpdate {
 		/*
 		 * 3. Clear data.
 		 */
-		$settings = Pinterest_For_Woocommerce()::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+		$settings = Settings::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 		unset( $settings['local_feed_id'] );
 
-		Pinterest_For_Woocommerce()::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+		Settings::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 		// Update done.
 	}
@@ -278,8 +278,8 @@ class PluginUpdate {
 			return;
 		}
 
-		$aem_enabled   = boolval( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
-		$connected_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag', null );
+		$aem_enabled   = boolval( Settings::get_setting( 'enhanced_match_support' ) );
+		$connected_tag = Settings::get_setting( 'tracking_tag' );
 
 		// Only update if the setting is enabled and we have a connected tag.
 		if ( ! $aem_enabled || ! $connected_tag ) {

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -124,7 +124,7 @@ class ProductSync {
 		$domain_verified  = Pinterest_For_Woocommerce()::is_domain_verified();
 		$tracking_enabled = $domain_verified && Pinterest_For_Woocommerce()::is_tracking_configured();
 
-		return (bool) $domain_verified && $tracking_enabled && Pinterest_For_Woocommerce()::get_setting( 'product_sync_enabled' );
+		return (bool) $domain_verified && $tracking_enabled && Settings::get_setting( 'product_sync_enabled' );
 	}
 
 	/**

--- a/src/RichPins.php
+++ b/src/RichPins.php
@@ -49,8 +49,8 @@ class RichPins {
 
 		if ( ! $disable_rich_pins ) {
 
-			$rich_pins_on_products = Pinterest_For_Woocommerce()::get_setting( 'rich_pins_on_products' );
-			$rich_pins_on_posts    = Pinterest_For_Woocommerce()::get_setting( 'rich_pins_on_posts' );
+			$rich_pins_on_products = Settings::get_setting( 'rich_pins_on_products' );
+			$rich_pins_on_posts    = Settings::get_setting( 'rich_pins_on_posts' );
 
 			if ( $rich_pins_on_products || $rich_pins_on_posts ) {
 

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -95,7 +95,7 @@ class SaveToPinterest {
 	 * @return bool
 	 */
 	public static function show_pin_button() {
-		return (bool) Pinterest_For_Woocommerce()::get_setting( 'save_to_pinterest' );
+		return (bool) Settings::get_setting( 'save_to_pinterest' );
 	}
 
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -170,6 +170,7 @@ class Settings {
 		}
 
 		self::maybe_disconnect_advertiser( $old_value, $new_value );
+		self::maybe_update_tag( $old_value, $new_value );
 	}
 
 	/**
@@ -199,6 +200,40 @@ class Settings {
 
 				Logger::log( esc_html__( 'There was an error disconnecting the Advertiser. Please try again.', 'pinterest-for-woocommerce' ) );
 			}
+		}
+	}
+
+	/**
+	 * Disconnect advertiser from the platform if advertiser or tag change.
+	 * Only update if tag is being enabled.
+	 *
+	 * @param array $old_value The old value of the option.
+	 * @param array $new_value The new value of the option.
+	 */
+	private static function maybe_update_tag( $old_value, $new_value ) {
+		$connected_tag = self::get_setting( 'tracking_tag' );
+
+		if (
+			! $connected_tag ||
+			! isset( $new_value['enhanced_match_support'] ) ||
+			! $new_value['enhanced_match_support'] ||
+			(
+				isset( $old_value['enhanced_match_support'] ) &&
+				$new_value['enhanced_match_support'] === $old_value['enhanced_match_support']
+			)
+		) {
+			return;
+		}
+
+		try {
+			API\Base::update_tag(
+				$connected_tag,
+				array(
+					'aem_enabled' => true,
+				)
+			);
+		} catch ( \Exception $th ) {
+			Logger::log( esc_html__( 'There was an error updating the tag.', 'pinterest-for-woocommerce' ) );
 		}
 	}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Helper class for managing the settings.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Settings
+ */
+class Settings {
+
+	/**
+	 * When set to true, the settings have been
+	 * changed and the runtime cached must be flushed
+	 *
+	 * @var Pinterest_For_Woocommerce
+	 * @since 1.0.0
+	 */
+	protected static $dirty_settings = array();
+
+	/**
+	 * The default settings that will be created
+	 * with the given values, if they don't exist.
+	 *
+	 * @var Pinterest_For_Woocommerce
+	 * @since 1.0.0
+	 */
+	protected static $default_settings = array(
+		'track_conversions'      => true,
+		'enhanced_match_support' => true,
+		'save_to_pinterest'      => true,
+		'rich_pins_on_posts'     => true,
+		'rich_pins_on_products'  => true,
+		'product_sync_enabled'   => true,
+		'enable_debug_logging'   => false,
+		'erase_plugin_data'      => false,
+	);
+
+	/**
+	 * Initiate class.
+	 */
+	public static function maybe_init() {
+		add_action( 'pinterest_for_woocommerce_token_saved', array( __CLASS__, 'set_default_settings' ) );
+
+		// Allow access to our option through the REST API.
+		add_filter( 'woocommerce_rest_api_option_permissions', array( __CLASS__, 'add_option_permissions' ), 10, 1 );
+
+		// Disconnect advertiser if advertiser or tag change.
+		add_action( 'update_option_pinterest_for_woocommerce', array( __CLASS__, 'settings_update' ), 10, 2 );
+	}
+
+	/**
+	 * Return APP Settings
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param boolean $force  Controls whether to force getting a fresh value instead of one from the runtime cache.
+	 * @param string  $option Controls which option to read/write to.
+	 *
+	 * @return array
+	 */
+	public static function get_settings( $force = false, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
+
+		static $settings;
+
+		if ( $force || is_null( $settings ) || ! isset( $settings[ $option ] ) || ( isset( self::$dirty_settings[ $option ] ) && self::$dirty_settings[ $option ] ) ) {
+			$settings[ $option ] = get_option( $option );
+		}
+
+		return $settings[ $option ];
+	}
+
+	/**
+	 * Return APP Setting based on its key
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string  $key The key of specific option to retrieve.
+	 * @param boolean $force Controls whether to force getting a fresh value instead of one from the runtime cache.
+	 *
+	 * @return mixed
+	 */
+	public static function get_setting( $key, $force = false ) {
+
+		$settings = self::get_settings( $force );
+
+		return empty( $settings[ $key ] ) ? false : $settings[ $key ];
+	}
+
+	/**
+	 * Save APP Setting
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The key of specific option to retrieve.
+	 * @param mixed  $data The data to save for this option key.
+	 *
+	 * @return boolean
+	 */
+	public static function save_setting( $key, $data ) {
+
+		$settings = self::get_settings( true );
+
+		$settings[ $key ] = $data;
+
+		return self::save_settings( $settings );
+	}
+
+	/**
+	 * Save APP Settings
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings The array of settings to save.
+	 * @param string $option Controls which option to read/write to.
+	 *
+	 * @return boolean
+	 */
+	public static function save_settings( $settings, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
+		self::$dirty_settings[ $option ] = true;
+		return update_option( $option, $settings );
+	}
+
+	/**
+	 * Sets the default settings based on the
+	 * given values in self::$default_settings
+	 *
+	 * @return boolean
+	 */
+	public static function set_default_settings() {
+
+		$settings = self::get_settings( true );
+		$settings = wp_parse_args( $settings, self::$default_settings );
+
+		return self::save_settings( $settings );
+	}
+
+	/**
+	 * Allow access to our option through the REST API for a user that can manage the store.
+	 * The UI relies on this option being available through the API.
+	 *
+	 * @param array $permissions The permissions array.
+	 *
+	 * @return array
+	 */
+	public static function add_option_permissions( $permissions ) {
+
+		$permissions[ PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ] = current_user_can( 'manage_woocommerce' );
+		return $permissions;
+	}
+
+	/**
+	 * Triggered when the settings are updated through the API.
+	 *
+	 * @param array $old_value The old value of the option.
+	 * @param array $new_value The new value of the option.
+	 */
+	public static function settings_update( $old_value, $new_value ) {
+		if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
+			return;
+		}
+
+		self::maybe_disconnect_advertiser( $old_value, $new_value );
+	}
+
+	/**
+	 * Disconnect advertiser from the platform if advertiser or tag change.
+	 *
+	 * @param array $old_value The old value of the option.
+	 * @param array $new_value The new value of the option.
+	 */
+	private static function maybe_disconnect_advertiser( $old_value, $new_value ) {
+		if (
+			! isset( $old_value['tracking_advertiser'] ) ||
+			! isset( $old_value['tracking_tag'] ) ||
+			! isset( $new_value['tracking_advertiser'] ) ||
+			! isset( $new_value['tracking_tag'] )
+		) {
+			return;
+		}
+
+		// Disconnect merchant if old values are different than new ones.
+		if ( $old_value['tracking_advertiser'] !== $new_value['tracking_advertiser'] || $old_value['tracking_tag'] !== $new_value['tracking_tag'] ) {
+
+			try {
+
+				API\AdvertiserConnect::disconnect_advertiser( $old_value['tracking_advertiser'], $old_value['tracking_tag'] );
+
+			} catch ( \Exception $th ) {
+
+				Logger::log( esc_html__( 'There was an error disconnecting the Advertiser. Please try again.', 'pinterest-for-woocommerce' ) );
+			}
+		}
+	}
+
+}

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -71,7 +71,7 @@ class TrackerSnapshot {
 	 */
 	protected static function parse_settings(): array {
 
-		$settings = Pinterest_For_Woocommerce::get_settings( true );
+		$settings = Settings::get_settings( true );
 
 		$tracked_settings = array(
 			'track_conversions',

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -318,7 +318,7 @@ class Tracking {
 	 */
 	private static function tracking_enabled() {
 
-		if ( ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' ) || ! self::get_active_tag() ) {
+		if ( ! Settings::get_setting( 'track_conversions' ) || ! self::get_active_tag() ) {
 			return false;
 		}
 
@@ -340,7 +340,7 @@ class Tracking {
 			return;
 		}
 
-		if ( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) ) {
+		if ( Settings::get_setting( 'enhanced_match_support' ) ) {
 			$email = self::get_hashed_customer_email();
 		}
 
@@ -465,7 +465,7 @@ class Tracking {
 	 * @return object|boolean
 	 */
 	public static function get_active_tag() {
-		return Pinterest_For_Woocommerce()::get_setting( 'tracking_tag' );
+		return Settings::get_setting( 'tracking_tag' );
 	}
 
 
@@ -514,9 +514,9 @@ class Tracking {
 	 */
 	private static function maybe_connect_advertiser_tag() {
 
-		$is_connected         = Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' );
-		$connected_advertiser = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
-		$connected_tag        = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag' );
+		$is_connected         = Settings::get_data( 'is_advertiser_connected' );
+		$connected_advertiser = Settings::get_setting( 'tracking_advertiser' );
+		$connected_tag        = Settings::get_setting( 'tracking_tag' );
 
 		// Check if advertiser is already connected.
 		if ( ! $is_connected && $connected_advertiser && $connected_tag ) {

--- a/tests/Unit/FeedXMLGenerationShippingTest.php
+++ b/tests/Unit/FeedXMLGenerationShippingTest.php
@@ -10,6 +10,7 @@ use \WC_Unit_Test_Case;
 
 use Automattic\WooCommerce\Pinterest\Logger;
 use Automattic\WooCommerce\Pinterest\ProductsXmlFeed;
+use Automattic\WooCommerce\Pinterest\Settings;
 use Exception;
 
 /**
@@ -620,7 +621,7 @@ class Pinterest_Test_Shipping_Feed extends WC_Unit_Test_Case {
 		ShippingHelpers::addFlatRateShippingMethodToZone( $zone );
 
 		// Enable logging.
-		Pinterest_For_WooCommerce()::save_setting( 'enable_debug_logging', true );
+		Settings::save_setting( 'enable_debug_logging', true );
 
 		/**
 		 * Mock logger object that will catch any logged messages.

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Settings;
+
 class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 
@@ -25,7 +27,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 	function test_settings_are_tracked_by_woo_tracker_if_opt_in() {
 
-		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+		Settings::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
@@ -40,7 +42,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 		update_option( 'woocommerce_allow_tracking', 'no' );
 
-		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+		Settings::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables the enhanced match setting and syncs this through the Pinterest API.
It covers the following points:

- Set `aem_enabled` when creating a tag
- For all users that are updating to 1.0.11 we will update the tag with the flag enabled (if it's enabled in settings)
- Moves the settings functions to a separate helper class
- When the settings are updated trigger a tag update if enhanced match has been enabled

Closes #429 
Closes #430

### Detailed test instructions:

#### Creating a new tag
1. Create a new Pinterest account or get an account which has 0 tags.
2. Connect the account using the plugin.
3. Visit the store to generate any tag event.
4. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be enabled.
![image](https://user-images.githubusercontent.com/11388669/161978317-41e5b6a6-36ca-4697-b983-4fd978c78a5b.png)

#### Update routine
1. On Pinterest page -> Ads -> Conversions disable the Automatic enhanced match.
2. Temporarily bump the value PINTEREST_FOR_WOOCOMMERCE_VERSION in the main plugin file to 1.0.11.
3. Refresh any admin page.
4. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be enabled.

#### Enable in settings
1. On Pinterest page -> Ads -> Conversions disable the Automatic enhanced match.
2. On the Pinterest > Settings page enable the enhanced match and save the settings.
3. On Pinterest page -> Ads -> Conversions, Automatic enhanced match should be enabled.

*Note that disabling it in settings should not send a request to disable it Pinterest*

### Changelog entry
* Fix - Enable automatic enhanced matching and sync to Pinterest.
