### PR TITLE
Add allow-plugins directive to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
 	"config": {
 		"platform": {
 			"php": "7.3.0"
+		},
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"automattic/jetpack-autoloader": true
 		}
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -528,9 +528,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -2211,12 +2208,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2536,5 +2533,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the `composer.json` file to include the `allow-plugins` directive, and update the hash for the `composer.lock` file.

Closes #441.

### Detailed test instructions:

1. Before checking out this PR, run `composer install` with Composer version 2.2+
2. Observe the plugin trust prompts (as outlined in #441)
3. Check out this PR and run `composer install`
4. There should be no prompts for trusting plugins.
5. No package updates should occur compared to the `develop` branch (only the lock file hash has been updated, not any of the dependency versions)

### Changelog entry

> Dev - update trusted plugins in composer.json

