### PR TITLE
Fix deprecated warning for API permissions

### DIFF
--- a/assets/source/setup-guide/app/data/settings/actions.js
+++ b/assets/source/setup-guide/app/data/settings/actions.js
@@ -8,7 +8,7 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import TYPES from './action-types';
-import { STORE_NAME, WC_ADMIN_NAMESPACE, OPTIONS_NAME } from './constants';
+import { STORE_NAME, API_ENDPOINT, OPTIONS_NAME } from './constants';
 import { REPORTS_STORE_NAME } from '../../../../catalog-sync/data';
 
 export function receiveSettings( settings ) {
@@ -59,7 +59,7 @@ export function* updateSettings( data, saveToDb = false ) {
 
 	try {
 		const results = yield apiFetch( {
-			path: WC_ADMIN_NAMESPACE + '/options',
+			path: API_ENDPOINT,
 			method: 'POST',
 			data: {
 				[ OPTIONS_NAME ]: settings,

--- a/assets/source/setup-guide/app/data/settings/constants.js
+++ b/assets/source/setup-guide/app/data/settings/constants.js
@@ -1,3 +1,4 @@
 export const STORE_NAME = 'pinterest_for_woocommerce/admin/settings';
-export const WC_ADMIN_NAMESPACE = '/wc-admin';
+export const API_ENDPOINT =
+	wcSettings.pinterest_for_woocommerce.apiRoute + '/settings';
 export const OPTIONS_NAME = wcSettings.pinterest_for_woocommerce.optionsName;

--- a/assets/source/setup-guide/app/data/settings/controls.js
+++ b/assets/source/setup-guide/app/data/settings/controls.js
@@ -7,7 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { WC_ADMIN_NAMESPACE, OPTIONS_NAME } from './constants';
+import { API_ENDPOINT, OPTIONS_NAME } from './constants';
 
 export const fetch = () => {
 	return {
@@ -19,7 +19,7 @@ export const controls = {
 	...dataControls,
 	FETCH() {
 		return new Promise( ( resolve ) => {
-			const url = `${ WC_ADMIN_NAMESPACE }/options?options=${ OPTIONS_NAME }`;
+			const url = `${ API_ENDPOINT }`;
 			apiFetch( { path: url } ).then( ( result ) =>
 				resolve( result[ OPTIONS_NAME ] )
 			);

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -546,6 +546,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			new Pinterest\API\FeedIssues();
 			new Pinterest\API\Tags();
 			new Pinterest\API\HealthCheck();
+			new Pinterest\API\Options();
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -246,9 +246,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
-			// Allow access to our option through the REST API.
-			add_filter( 'woocommerce_rest_api_option_permissions', array( $this, 'add_option_permissions' ), 10, 1 );
-
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'hook_update_settings' ), 10, 2 );
 
@@ -398,21 +395,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public function ajax_url() {
 			return admin_url( 'admin-ajax.php', 'relative' );
-		}
-
-
-		/**
-		 * Allow access to our option through the REST API for a user that can manage the store.
-		 * The UI relies on this option being available through the API.
-		 *
-		 * @param array $permissions The permissions array.
-		 *
-		 * @return array
-		 */
-		public function add_option_permissions( $permissions ) {
-
-			$permissions[ PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ] = current_user_can( 'manage_woocommerce' );
-			return $permissions;
 		}
 
 

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -62,7 +62,7 @@ class Options extends VendorAPI {
 		}
 
 		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
-			return new \WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
+			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * API Options
+ *
+ * @package     Pinterest_For_Woocommerce/API
+ * @version     1.0.0
+ */
+
+namespace Automattic\WooCommerce\Pinterest\API;
+
+use Automattic\WooCommerce\Pinterest\Logger as Logger;
+
+use \WP_REST_Server;
+use \WP_REST_Request;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Endpoint handling Options.
+ */
+class Options extends VendorAPI {
+
+	/**
+	 * Initialize class
+	 */
+	public function __construct() {
+
+		$this->base                        = 'settings';
+		$this->supports_multiple_endpoints = true;
+		$this->endpoint_callbacks_map      = array(
+			'get_settings' => WP_REST_Server::READABLE,
+			'set_settings' => WP_REST_Server::CREATABLE,
+		);
+
+		$this->register_routes();
+	}
+
+
+	/**
+	 * Handle get settings.
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public function get_settings() {
+		return array(
+			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
+		);
+	}
+
+
+	/**
+	 * Handle get settings.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return array|WP_Error
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public function set_settings( WP_REST_Request $request ) {
+		if ( ! $request->has_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) || ! is_array( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
+			return array(
+				'success' => false,
+			);
+		}
+
+		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
+			return array(
+				'success' => false,
+			);
+		}
+
+		return array(
+			'success' => true,
+		);
+	}
+}

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -41,9 +41,7 @@ class Options extends VendorAPI {
 	/**
 	 * Handle get settings.
 	 *
-	 * @return mixed
-	 *
-	 * @throws \Exception PHP Exception.
+	 * @return array
 	 */
 	public function get_settings() {
 		return array(
@@ -53,13 +51,11 @@ class Options extends VendorAPI {
 
 
 	/**
-	 * Handle get settings.
+	 * Handle set settings.
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *
-	 * @return array|WP_Error
-	 *
-	 * @throws \Exception PHP Exception.
+	 * @return array
 	 */
 	public function set_settings( WP_REST_Request $request ) {
 		if ( ! $request->has_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) || ! is_array( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -55,23 +55,19 @@ class Options extends VendorAPI {
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function set_settings( WP_REST_Request $request ) {
 		if ( ! $request->has_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) || ! is_array( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
-			return array(
-				'success' => false,
-			);
+			return new \WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
-			return array(
-				'success' => false,
-			);
+			return new \WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 
 		return array(
-			'success' => true,
+			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => true,
 		);
 	}
 }

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -8,8 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
-use Automattic\WooCommerce\Pinterest\Logger as Logger;
-
+use \WP_Error;
 use \WP_REST_Server;
 use \WP_REST_Request;
 
@@ -59,7 +58,7 @@ class Options extends VendorAPI {
 	 */
 	public function set_settings( WP_REST_Request $request ) {
 		if ( ! $request->has_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) || ! is_array( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
-			return new \WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -66,7 +66,7 @@ class VendorAPI {
 	 *
 	 * @var array
 	 */
-	public $endpoint_callbacks_map;
+	public $endpoint_callbacks_map = array();
 
 	/**
 	 * Returns the namespace.

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -59,14 +59,14 @@ class VendorAPI {
 	 *
 	 * @var bool
 	 */
-	public $supports_multiple_endpoints = false;
+	protected $supports_multiple_endpoints = false;
 
 	/**
 	 * Map with callbacks for each supported method
 	 *
 	 * @var array
 	 */
-	public $endpoint_callbacks_map = array();
+	protected $endpoint_callbacks_map = array();
 
 	/**
 	 * Returns the namespace.
@@ -105,10 +105,11 @@ class VendorAPI {
 	 * @param string $methods The endpoint's methods.
 	 * @param string $endpoint_callback The endpoint's callback.
 	 *
-	 * @since 1.0.11
+	 * @since x.x.x
 	 */
 	public function register_router_single_method( $methods = '', $endpoint_callback = '' ) {
-		$namespace = $this->api_namespace . $this->api_version;
+		$namespace         = $this->api_namespace . $this->api_version;
+		$endpoint_callback = empty( $endpoint_callback ) ? $this->endpoint_callback : $endpoint_callback;
 
 		register_rest_route(
 			$namespace,
@@ -116,7 +117,7 @@ class VendorAPI {
 			array(
 				array(
 					'methods'             => empty( $methods ) ? $this->methods : $methods,
-					'callback'            => array( $this, empty( $endpoint_callback ) ? $this->endpoint_callback : $endpoint_callback ),
+					'callback'            => array( $this, $endpoint_callback ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 			)
@@ -126,7 +127,7 @@ class VendorAPI {
 	/**
 	 * Register endpoint route with multiple methods
 	 *
-	 * @since 1.0.11
+	 * @since x.x.x
 	 */
 	public function register_router_multiple_methods() {
 		foreach ( $this->endpoint_callbacks_map as $callback => $method ) {

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -102,8 +102,8 @@ class VendorAPI {
 	/**
 	 * Register endpoint route with single method
 	 *
-	 * @param string|array $methods The endpoint's methods.
-	 * @param string       $endpoint_callback The endpoint's callback.
+	 * @param string $methods The endpoint's methods.
+	 * @param string $endpoint_callback The endpoint's callback.
 	 *
 	 * @since 1.0.11
 	 */
@@ -115,8 +115,8 @@ class VendorAPI {
 			'/' . $this->base,
 			array(
 				array(
-					'methods'             => $methods ?? $this->methods,
-					'callback'            => $endpoint_callback ?? array( $this, $this->endpoint_callback ),
+					'methods'             => empty( $methods ) ? $this->methods : $methods,
+					'callback'            => array( $this, empty( $endpoint_callback ) ? $this->endpoint_callback : $endpoint_callback ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 			)

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -102,6 +102,9 @@ class VendorAPI {
 	/**
 	 * Register endpoint route with single method
 	 *
+	 * @param string|array $methods The endpoint's methods.
+	 * @param string       $endpoint_callback The endpoint's callback.
+	 *
 	 * @since 1.0.11
 	 */
 	public function register_router_single_method( $methods = '', $endpoint_callback = '' ) {

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -55,6 +55,20 @@ class VendorAPI {
 	public $endpoint_callback;
 
 	/**
+	 * Specify if the endpoint supports multiple methods
+	 *
+	 * @var bool
+	 */
+	public $supports_multiple_endpoints = false;
+
+	/**
+	 * Map with callbacks for each supported method
+	 *
+	 * @var array
+	 */
+	public $endpoint_callbacks_map;
+
+	/**
 	 * Returns the namespace.
 	 *
 	 * @return string
@@ -78,7 +92,19 @@ class VendorAPI {
 	 * @since 1.0.0
 	 */
 	public function register_routes() {
+		if ( $this->supports_multiple_endpoints ) {
+			$this->register_router_multiple_methods();
+		} else {
+			$this->register_router_single_method();
+		}
+	}
 
+	/**
+	 * Register endpoint route with single method
+	 *
+	 * @since 1.0.11
+	 */
+	public function register_router_single_method() {
 		$namespace = $this->api_namespace . $this->api_version;
 
 		register_rest_route(
@@ -91,6 +117,31 @@ class VendorAPI {
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 			)
+		);
+	}
+
+	/**
+	 * Register endpoint route with multiple methods
+	 *
+	 * @since 1.0.11
+	 */
+	public function register_router_multiple_methods() {
+		$namespace = $this->api_namespace . $this->api_version;
+
+		$route_args = array();
+
+		foreach ( $this->endpoint_callbacks_map as $callback => $method ) {
+			$route_args[] = array(
+				'methods'             => $method,
+				'callback'            => array( $this, $callback ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			);
+		}
+
+		register_rest_route(
+			$namespace,
+			'/' . $this->base,
+			$route_args
 		);
 	}
 

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -104,7 +104,7 @@ class VendorAPI {
 	 *
 	 * @since 1.0.11
 	 */
-	public function register_router_single_method() {
+	public function register_router_single_method( $methods = '', $endpoint_callback = '' ) {
 		$namespace = $this->api_namespace . $this->api_version;
 
 		register_rest_route(
@@ -112,8 +112,8 @@ class VendorAPI {
 			'/' . $this->base,
 			array(
 				array(
-					'methods'             => $this->methods,
-					'callback'            => array( $this, $this->endpoint_callback ),
+					'methods'             => $methods ?? $this->methods,
+					'callback'            => $endpoint_callback ?? array( $this, $this->endpoint_callback ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 			)
@@ -126,23 +126,9 @@ class VendorAPI {
 	 * @since 1.0.11
 	 */
 	public function register_router_multiple_methods() {
-		$namespace = $this->api_namespace . $this->api_version;
-
-		$route_args = array();
-
 		foreach ( $this->endpoint_callbacks_map as $callback => $method ) {
-			$route_args[] = array(
-				'methods'             => $method,
-				'callback'            => array( $this, $callback ),
-				'permission_callback' => array( $this, 'permissions_check' ),
-			);
+			$this->register_router_single_method( $method, $callback );
 		}
-
-		register_rest_route(
-			$namespace,
-			'/' . $this->base,
-			$route_args
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Closes #416.
Closes #423.

A new endpoint was created to handle the settings of the plugin, in order to avoid extending the `wc-admin` option.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
1. Enable debug logging with WP_DEBUG_LOG.
2. Visit the settings page and update some option.
3. There should be no deprecated warning on logs.


### Additional details:
### Changelog entry

> Add - Route to handle the plugin's settings.
