### PR TITLE
Add additional images limit on feed

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -60,6 +60,13 @@ class ProductsXmlFeed {
 	 */
 	const DESCRIPTION_SIZE_CHARS_LIMIT = 10000;
 
+	/**
+	 * Limit of additional images allowed by Pinterest.
+	 *
+	 * @var int
+	 */
+	const ADDITIONAL_IMAGES_LIMIT = 10;
+
 
 	/**
 	 * Returns the XML header to be printed.
@@ -444,7 +451,7 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '><![CDATA[' . implode( ',', $images ) . ']]></' . $property . '>';
+		return '<' . $property . '><![CDATA[' . implode( ',', array_slice( $images, 0, self::ADDITIONAL_IMAGES_LIMIT ) ) . ']]></' . $property . '>';
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -451,7 +451,10 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '><![CDATA[' . implode( ',', array_slice( $images, 0, self::ADDITIONAL_IMAGES_LIMIT ) ) . ']]></' . $property . '>';
+		$images = array_slice( $images, 0, self::ADDITIONAL_IMAGES_LIMIT );
+		$images = implode( ',', $images );
+
+		return '<' . $property . '><![CDATA[' . $images . ']]></' . $property . '>';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #382.

Pinterest has a limit of 10 additional images per product in the feed. This PR adds that limit on the feed generation.


### Screenshots:

### Detailed test instructions:
1. Add more than 10 additional images to a product.
2. Install and setup the Pinterest plugin.
3. The generated feed should contain only 10 additional images.
4. There should be no error on the Pinterest ingestion.


### Additional details:

### Changelog entry

> Fix - Limit the number of additional images to 10
