### PR TITLE
Add action scheduler to min requirements

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -49,9 +49,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * Set the minimum required versions for the plugin.
 		 */
 		const PLUGIN_REQUIREMENTS = array(
-			'php_version' => '7.3',
-			'wp_version'  => '5.6',
-			'wc_version'  => '5.3',
+			'php_version'      => '7.3',
+			'wp_version'       => '5.6',
+			'wc_version'       => '5.3',
+			'action_scheduler' => '3.3.0',
 		);
 
 		/**
@@ -310,6 +311,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
 				$errors[] = esc_html__( 'Pinterest for WooCommerce requires WooCommerce Admin to be enabled.', 'pinterest-for-woocommerce' );
+			}
+
+			if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+				$errors[] = sprintf( esc_html__( 'Pinterest for WooCommerce requires a minimum Action Scheduler package of %s. It can be caused by old version of the WooCommerce extensions.', 'pinterest-for-woocommerce' ), self::PLUGIN_REQUIREMENTS['action_scheduler'] );
 			}
 
 			if ( empty( $errors ) ) {

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -314,6 +314,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			}
 
 			if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+				/* Translators: The minimum Action Scheduler version */
 				$errors[] = sprintf( esc_html__( 'Pinterest for WooCommerce requires a minimum Action Scheduler package of %s. It can be caused by old version of the WooCommerce extensions.', 'pinterest-for-woocommerce' ), self::PLUGIN_REQUIREMENTS['action_scheduler'] );
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #443.

The plugin requires a version of Action Scheduler package >= 3.3.0. If for some reason, a plugin loads an older version of the package, the plugin will throw fatal error.

The changes on this PR include:
- Add the action scheduler v3.3.0 as a min requirement.

### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/163465689-24ce73d3-82c3-4906-a98c-6879f0f66197.png)

### Detailed test instructions:
1. Install the Pinterest for WooCommerce plugin along with WooCommerce.
2. Install a Woo extension that uses an old version of the action scheduler package, such as WooCommerce Smart Coupons v4.8.0.
3. Manually edit the file woocommerce -> `class-woocommerce` and remove the action scheduler loader (forcing the action scheduler on Smart Coupons plugin).
4. The plugin should throw an error since action scheduler min requirement is not fulfilled (check screenshot).

### Additional details:

### Changelog entry

> Add - Add action scheduler as a minimum plugin requirement.
