### PR TITLE
Skip write to file if products buffer is empty

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -480,6 +480,10 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	private function write_buffers_to_temp_files(): void {
 		foreach ( $this->configurations->get_configurations() as $location => $config ) {
+			if ( '' === $this->buffers[ $location ] ) {
+				continue;
+			}
+
 			$bytes_written = file_put_contents(
 				$config['tmp_file'],
 				$this->buffers[ $location ],

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -9,6 +9,7 @@ use \WC_Unit_Test_Case;
 use \WC_Product_Variable;
 
 use Automattic\WooCommerce\Pinterest\Logger;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\ProductsXmlFeed;
 use Automattic\WooCommerce\Pinterest\Product\GoogleCategorySearch;
 use Automattic\WooCommerce\Pinterest\Product\GoogleProductTaxonomy;
@@ -631,6 +632,63 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$xml = $method->invoke( null, $product, '' );
 		// Google product category attribute was set, we should see it in the output.
 		$this->assertEquals( '<g:google_product_category>Arts &amp; Entertainment &gt; Hobbies &amp; Creative Arts &gt; Arts &amp; Crafts &gt; Art &amp; Craft Kits &gt; Jewelry Making Kits</g:google_product_category>' . PHP_EOL, $xml );
+	}
+
+	/**
+	 * @group feed
+	 *
+	 * Test that the feed is writable.
+	 */
+	public function testFeedWritable() {
+		// Create simple product.
+		$product = WC_Helper_Product::create_simple_product();
+
+		// We need header and footer so we can process XML directly.
+		$xml  = ProductsXmlFeed::get_xml_header();
+		$xml .= ProductsXmlFeed::get_xml_item( $product, 'US' );
+		$xml .= ProductsXmlFeed::get_xml_footer();
+
+		$configurations = LocalFeedConfigs::get_instance();
+
+		$config = $configurations->get_configurations()[0];
+
+		$bytes_written = file_put_contents(
+			$config['tmp_file'],
+			ProductsXmlFeed::get_xml_header()
+		);
+
+		$this->assertNotEmpty( $bytes_written );
+	}
+
+	/**
+	 * @group feed
+	 *
+	 * Test that the feed is writable when there are no eligible products.
+	 */
+	public function testFeedWritableNiEligibleProducts() {
+		// Create product with zero price.
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 0,
+			)
+		);
+
+		// We need header and footer so we can process XML directly.
+		$xml  = ProductsXmlFeed::get_xml_header();
+		$xml .= ProductsXmlFeed::get_xml_item( $product, 'US' );
+		$xml .= ProductsXmlFeed::get_xml_footer();
+
+		$configurations = LocalFeedConfigs::get_instance();
+
+		$config = $configurations->get_configurations()[0];
+
+		$bytes_written = file_put_contents(
+			$config['tmp_file'],
+			ProductsXmlFeed::get_xml_header()
+		);
+
+		$this->assertNotEmpty( $bytes_written );
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -654,41 +654,10 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		$bytes_written = file_put_contents(
 			$config['tmp_file'],
-			ProductsXmlFeed::get_xml_header()
+			$xml
 		);
 
-		$this->assertNotEmpty( $bytes_written );
-	}
-
-	/**
-	 * @group feed
-	 *
-	 * Test that the feed is writable when there are no eligible products.
-	 */
-	public function testFeedWritableNiEligibleProducts() {
-		// Create product with zero price.
-		$product = WC_Helper_Product::create_simple_product(
-			true,
-			array(
-				'regular_price' => 0,
-			)
-		);
-
-		// We need header and footer so we can process XML directly.
-		$xml  = ProductsXmlFeed::get_xml_header();
-		$xml .= ProductsXmlFeed::get_xml_item( $product, 'US' );
-		$xml .= ProductsXmlFeed::get_xml_footer();
-
-		$configurations = LocalFeedConfigs::get_instance();
-
-		$config = $configurations->get_configurations()[0];
-
-		$bytes_written = file_put_contents(
-			$config['tmp_file'],
-			ProductsXmlFeed::get_xml_header()
-		);
-
-		$this->assertNotEmpty( $bytes_written );
+		$this->assertTrue( ( bool ) $bytes_written );
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -648,11 +648,9 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$xml .= ProductsXmlFeed::get_xml_item( $product, 'US' );
 		$xml .= ProductsXmlFeed::get_xml_footer();
 
-		$configurations = LocalFeedConfigs::get_instance();
+		$feed_configurations = LocalFeedConfigs::get_instance();
 
-		$configurations = $configurations->get_configurations();
-
-		foreach ( $this->configurations->get_configurations() as $config ) {
+		foreach ( $feed_configurations->get_configurations() as $config ) {
 			$bytes_written = file_put_contents(
 				$config['tmp_file'],
 				$xml

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -650,14 +650,18 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		$configurations = LocalFeedConfigs::get_instance();
 
-		$config = $configurations->get_configurations()[0];
+		$configurations = $configurations->get_configurations();
 
-		$bytes_written = file_put_contents(
-			$config['tmp_file'],
-			$xml
-		);
+		foreach ( $this->configurations->get_configurations() as $config ) {
+			$bytes_written = file_put_contents(
+				$config['tmp_file'],
+				$xml
+			);
 
-		$this->assertTrue( ( bool ) $bytes_written );
+			$this->assertTrue( ( bool ) $bytes_written );
+
+			break;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #448.

Changes added in this PR:
- Skip calling write to file function if the buffer is empty. This prevents the error when `file_put_contents` returns 0 written bytes.

### Screenshots:

### Detailed test instructions:
1. Setup up WooCommerce with only products with out of stock status (for out of stock products the WooCommerce setting 'Hide out of stock items from the catalog' must be enabled) or price 0.
2. Install the Pinterest plugin and do the onboarding.
3. Feed generation should complete without errors but only writing 0 products to the feed.
 
### Additional details:

### Changelog entry

> Fix - Feed generation fails if there is no eligible product
