### PR TITLE
Check if get_pinterest_code mehod exists

### DIFF
--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -95,7 +95,7 @@ class FeedRegistration {
 			throw new Exception( esc_html__( 'Could not register feed.', 'pinterest-for-woocommerce' ) );
 
 		} catch ( Throwable $th ) {
-			if ( 4163 === $th->get_pinterest_code() ) {
+			if ( method_exists( $th, 'get_pinterest_code' ) && 4163 === $th->get_pinterest_code() ) {
 				// Save the error to read it during the Health Check.
 				Pinterest_For_Woocommerce()::save_data( 'merchant_connected_diff_platform', true );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #449.

We need to make sure that `get_pinterest_code()` method exists in the `$th` object.

### Screenshots:

### Detailed test instructions:

### Additional details:

### Changelog entry

> Fix - Fix fatal error if `get_pinterest_code()` doesn't exists on Throwable object
