### PR TITLE
Revert "Sync enhanced match support with Pinterest"

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -113,7 +113,7 @@ const SetupPins = ( {} ) => {
 										help={
 											<HelpTooltip
 												text={ __(
-													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled. Changes on this option are synched with the Pinterest conversion tag.',
+													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled.',
 													'pinterest-for-woocommerce'
 												) }
 											/>

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_filter( 'woocommerce_rest_api_option_permissions', array( $this, 'add_option_permissions' ), 10, 1 );
 
 			// Disconnect advertiser if advertiser or tag change.
-			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'hook_update_settings' ), 10, 2 );
+			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
 		}
 
@@ -678,29 +678,16 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 
 		/**
-		 * Trigger methods for specific changes on the `pinterest_for_woocommerce` option.
-		 *
-		 * @param array $old_value The old value of the option.
-		 * @param array $new_value The new value of the option.
-		 */
-		public static function hook_update_settings( $old_value, $new_value ) {
-
-			if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
-				return;
-			}
-
-			self::maybe_disconnect_advertiser( $old_value, $new_value );
-			self::maybe_sync_enhanced_match_support( $old_value, $new_value );
-		}
-
-
-		/**
 		 * Disconnect advertiser from the platform if advertiser or tag change.
 		 *
 		 * @param array $old_value The old value of the option.
 		 * @param array $new_value The new value of the option.
 		 */
-		private static function maybe_disconnect_advertiser( $old_value, $new_value ) {
+		public static function maybe_disconnect_advertiser( $old_value, $new_value ) {
+
+			if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
+				return;
+			}
 
 			if (
 				! isset( $old_value['tracking_advertiser'] ) ||
@@ -722,52 +709,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 					Pinterest\Logger::log( esc_html__( 'There was an error disconnecting the Advertiser. Please try again.', 'pinterest-for-woocommerce' ) );
 				}
-			}
-		}
-
-
-		/**
-		 * Sync the Enhanced Match Support setting with Pinterest.
-		 *
-		 * @param array $old_value The old value of the option.
-		 * @param array $new_value The new value of the option.
-		 */
-		private static function maybe_sync_enhanced_match_support( $old_value, $new_value ) {
-
-			if ( ! isset( $old_value['enhanced_match_support'], $new_value['enhanced_match_support'] ) ) {
-				return;
-			}
-
-			$tracking_tag = self::get_setting( 'tracking_tag' );
-			if ( ! $tracking_tag ) {
-				return;
-			}
-
-			// Sync setting with Pinterest if old value is different than new ones.
-			if ( $old_value['enhanced_match_support'] !== $new_value['enhanced_match_support'] ) {
-				self::update_tag_config( $tracking_tag, $new_value['enhanced_match_support'] );
-			}
-		}
-
-		/**
-		 * Update the tag on Pinterest.
-		 *
-		 * @param string $tracking_tag The connected tag.
-		 * @param bool   $enhanced_match_support The value of the enhanced_math_support option.
-		 */
-		public static function update_tag_config( $tracking_tag, $enhanced_match_support ) {
-			try {
-				Pinterest\API\Base::update_tag(
-					$tracking_tag,
-					array(
-						'aem_enabled' => $enhanced_match_support,
-					)
-				);
-
-			} catch ( \Exception $e ) {
-
-				/* Translators: The error message */
-				Pinterest\Logger::log( sprintf( esc_html__( 'There was an error updating the tag parameters.: %s', 'pinterest-for-woocommerce' ), $e->getMessage() ), 'error' );
 			}
 		}
 

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -64,9 +64,6 @@ class AdvertiserConnect extends VendorAPI {
 				);
 			}
 
-			// Sync the enhanced match support option (force syncing in users that already had an existing tag).
-			Pinterest_For_Woocommerce()::update_tag_config( $tag_id, Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) );
-
 			// Connect new advertiser and tag.
 			return self::connect_advertiser_and_tag( $advertiser_id, $tag_id );
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException as ApiException;
 use \Exception;
 
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -99,7 +100,7 @@ class Base {
 				'args'   => $payload,
 			);
 
-			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
+			if ( 'ads/' === $api && 'POST' === $method ) {
 				// Force json content-type header and json encode payload.
 				$request['headers']['Content-Type'] = 'application/json';
 
@@ -417,35 +418,8 @@ class Base {
 			"advertisers/{$advertiser_id}/conversion_tags",
 			'POST',
 			array(
-				'name'        => $tag_name,
-				'aem_enabled' => (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ),
+				'name' => $tag_name,
 			),
-			'ads'
-		);
-	}
-
-
-	/**
-	 * Update the parameters of an existing tag.
-	 *
-	 * @param string $tag_id The tag_id for which we want to update the parameters.
-	 * @param array  $params The parameters to update.
-	 *
-	 * @return mixed
-	 */
-	public static function update_tag( $tag_id, $params = array() ) {
-		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
-
-		if ( ! $advertiser_id || empty( $params ) ) {
-			return false;
-		}
-
-		$params['id'] = (string) $tag_id;
-
-		return self::make_request(
-			"advertisers/{$advertiser_id}/conversion_tags",
-			'PATCH',
-			$params,
 			'ads'
 		);
 	}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -105,7 +105,6 @@ class PluginUpdate {
 		return array(
 			'domain_verification_migration',
 			'feed_generation_migration',
-			'enable_enhanced_match',
 		);
 	}
 
@@ -266,27 +265,5 @@ class PluginUpdate {
 		Pinterest_For_Woocommerce()::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
 		// Update done.
-	}
-
-	/**
-	 * Enable enhanced match for tags which have already been created.
-	 *
-	 * @return void
-	 */
-	protected function enable_enhanced_match(): void {
-		if ( ! $this->version_needs_update( '1.0.11' ) ) {
-			// Already up to date.
-			return;
-		}
-
-		$aem_enabled  = (bool) Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' );
-		$tracking_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag' );
-
-		// Update the setting if we have a connected tag.
-		if ( ! $tracking_tag ) {
-			return;
-		}
-
-		Pinterest_For_Woocommerce()::update_tag_config( $tracking_tag, $aem_enabled );
 	}
 }


### PR DESCRIPTION
Reverts woocommerce/pinterest-for-woocommerce#436

Pending further discussion around this feature, we want to revert it for now.

This PR will need to be reverted later when/if we are ready to include the enhanced match support.

### Changelog entry

> 