### PR TITLE
Improve error logs when debug logging is disabled

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -122,8 +122,18 @@ class Base {
 			} else {
 				$pinterest_code = method_exists( $e, 'get_pinterest_code' ) ? '( pinterest code: ' . $e->get_pinterest_code() . ')' : '';
 
-				/* Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message 5: Pinterest code */
-				Logger::log( sprintf( esc_html__( "%1\$s Request: %2\$s\nStatus Code: %3\$s\nAPI response: %4\$s%5\$s", 'pinterest-for-woocommerce' ), $method, $request['url'], $e->getCode(), $e->getMessage(), $pinterest_code ), 'error' );
+				Logger::log(
+					sprintf(
+						/* Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message */
+						esc_html__( "%1\$s Request: %2\$s\nStatus Code: %3\$s\nAPI response: %4\$s", 'pinterest-for-woocommerce' ),
+						$method,
+						$request['url'],
+						$e->getCode(),
+						$e->getMessage(),
+						$pinterest_code
+					),
+					'error'
+				);
 			}
 
 			throw $e;

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -114,13 +114,34 @@ class Base {
 			}
 
 			return $response;
+		} catch ( ApiException $e ) {
+
+			if ( ! empty( Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' ) ) ) {
+				/* Translators: 1: Error message 2: Stack trace */
+				Logger::log( sprintf( "%1\$s\n%2\$s", $e->getMessage(), $e->getTraceAsString() ), 'error' );
+			} else {
+
+				Logger::log(
+					sprintf(
+						/* Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message 5: Pinterest code */
+						esc_html__( "%1\$s Request: %2\$s\nStatus Code: %3\$s\nAPI response: %4\$s\nPinterest Code: %5\$s", 'pinterest-for-woocommerce' ),
+						$method,
+						$request['url'],
+						$e->getCode(),
+						$e->getMessage(),
+						$e->get_pinterest_code(),
+					),
+					'error'
+				);
+			}
+
+			throw $e;
 		} catch ( Exception $e ) {
 
 			if ( ! empty( Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' ) ) ) {
 				/* Translators: 1: Error message 2: Stack trace */
 				Logger::log( sprintf( "%1\$s\n%2\$s", $e->getMessage(), $e->getTraceAsString() ), 'error' );
 			} else {
-				$pinterest_code = method_exists( $e, 'get_pinterest_code' ) ? '( pinterest code: ' . $e->get_pinterest_code() . ')' : '';
 
 				Logger::log(
 					sprintf(
@@ -130,7 +151,6 @@ class Base {
 						$request['url'],
 						$e->getCode(),
 						$e->getMessage(),
-						$pinterest_code
 					),
 					'error'
 				);

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -77,7 +77,8 @@ class Base {
 	 *
 	 * @return array
 	 *
-	 * @throws Exception PHP exception.
+	 * @throws ApiException PHP exception.
+	 * @throws Exception    PHP exception.
 	 */
 	public static function make_request( $endpoint, $method = 'POST', $payload = array(), $api = '', $cache_expiry = false ) {
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -116,7 +116,15 @@ class Base {
 			return $response;
 		} catch ( Exception $e ) {
 
-			Logger::log( $e->getMessage(), 'error' );
+			if ( ! empty( Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' ) ) ) {
+				/* Translators: 1: Error message 2: Stack trace */
+				Logger::log( sprintf( "%1\$s\n%2\$s", $e->getMessage(), $e->getTraceAsString() ), 'error' );
+			} else {
+				$pinterest_code = method_exists( $e, 'get_pinterest_code' ) ? '( pinterest code: ' . $e->get_pinterest_code() . ')' : '';
+
+				/* Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message 5: Pinterest code */
+				Logger::log( sprintf( esc_html__( "%1\$s Request: %2\$s\nStatus Code: %3\$s\nAPI response: %4\$s%5\$s", 'pinterest-for-woocommerce' ), $method, $request['url'], $e->getCode(), $e->getMessage(), $pinterest_code ), 'error' );
+			}
 
 			throw $e;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #187.

Improvements on the log:
- Added the stack trace in verbose/debug mode.
- Added essentials request parameters in normal/production mode (request method, endpoint, error code)


### Screenshots:

**Log in normal/production mode:**
![image](https://user-images.githubusercontent.com/40774170/167141051-dfe81489-4d7e-4bf3-980a-3ab6f017332f.png)

**Fragment of log in verbose/debug mode.**
![image](https://user-images.githubusercontent.com/40774170/167147169-e1344d73-0216-446a-9858-cc9e54ef6f26.png)

### Detailed test instructions:
Get an API error (this error throws when the domain is connected to another Pinterest account)
1. Install the plugin and do the onboarding with a Pinterest account.
2. Logout of the Pinterest account and log into a different one.
3. Do the plugin's onboarding again.
4. An error will appear in logs (explaining that user is already connected to a different Pinterest account)
5. The log for the error should be more clear now (as described above).


### Additional details:

### Changelog entry

> Tweak - Improvements on the error logs.
