### PR TITLE
Bump WC & WP compatibility

### DIFF
--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Pinterest\Compat;
@@ -241,13 +242,24 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				Features::is_enabled( 'navigation' );
 		}
 
+		/**
+		 * Compatibility layer for is_admin_page function.
+		 * Needed since WC 6.5.
+		 */
+		private function is_admin_page(): bool {
+			if ( method_exists( PageController::class, 'is_admin_page' ) ) {
+				return PageController::is_admin_page();
+			} else {
+				return class_exists( Loader::class ) && Loader::is_admin_page();
+			}
+		}
 
 		/**
 		 * Load the scripts needed for the setup guide / settings page.
 		 */
 		public function load_setup_guide_scripts() {
 
-			if ( ! class_exists( Loader::class ) || ! Loader::is_admin_page() ) {
+			if ( ! $this->is_admin_page() ) {
 				return;
 			}
 
@@ -316,8 +328,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		public function register_task_list_item( $registered_tasks_list_items ) {
 
 			if (
-				! class_exists( Loader::class ) ||
-				! Loader::is_admin_page() ||
+				! $this->is_admin_page() ||
 				! Compat::should_show_tasks()
 			) {
 				return $registered_tasks_list_items;
@@ -340,7 +351,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		 * @return void
 		 */
 		public function load_settings() {
-			if ( ! class_exists( Loader::class ) || ! class_exists( AssetDataRegistry::class ) || ! Loader::is_admin_page() ) {
+			if ( ! $this->is_admin_page() || ! class_exists( AssetDataRegistry::class ) ) {
 				return;
 			}
 

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -22,11 +22,11 @@
  * Domain Path:       /i18n/languages
  *
  * Requires at least: 5.6
- * Tested up to: 5.9
+ * Tested up to: 6.2
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.3
- * WC tested up to: 6.3
+ * WC tested up to: 6.5
  */
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Use `PageController::is_admin_page` if available,
instead of deprecated `Loader::is_admin_page`,
to support WC 6.5 without a warning.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Quickly smoke test:
1. Plugin installation & activation
2. Account setup
3. Changing settings
4. Disconnecting account
5. `npm i && npm run test:js` (`npm run test:php` doesn't work on my local docker setup)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - WooCommerce 6.5 and WordPress 6.0 compatibility.
