### PR TITLE
Add Japan to the list of countries

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -41,6 +41,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 				'HU', // Hungary.
 				'IE', // Ireland.
 				'IT', // Italy.
+				'JP', // Japan.
 				'LU', // Luxembourg.
 				'MT', // Malta.
 				'MX', // Mexico.


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Add Japan to ads supported countries.

Closes #461.

### Detailed test instructions:

1. Go to the General tab of WC Settings. Change the "Country / State" option to Japan
2. Go to the landing page: /wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding
3. The no supported country warning notice should not appear.

### Changelog entry

> Add - Japan to ads supported countries.
