### PR TITLE
Verify if parent product is valid

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -168,7 +168,7 @@ class ProductsXmlFeed {
 		$xml               = '';
 
 		// Merge with parent's attributes if it's a variation product.
-		if ( $product instanceof WC_Product_Variation ) {
+		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
 			$parent_product    = wc_get_product( $product->get_parent_id() );
 			$parent_attributes = $attribute_manager->get_all_values( $parent_product );
 			$attributes        = array_merge( $parent_attributes, $attributes );

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -168,10 +168,13 @@ class ProductsXmlFeed {
 		$xml               = '';
 
 		// Merge with parent's attributes if it's a variation product.
-		if ( $product instanceof WC_Product_Variation && ! empty( $product->get_parent_id() ) ) {
-			$parent_product    = wc_get_product( $product->get_parent_id() );
-			$parent_attributes = $attribute_manager->get_all_values( $parent_product );
-			$attributes        = array_merge( $parent_attributes, $attributes );
+		if ( $product instanceof WC_Product_Variation ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+
+			if ( $parent_product instanceof WC_Product ) {
+				$parent_attributes = $attribute_manager->get_all_values( $parent_product );
+				$attributes        = array_merge( $parent_attributes, $attributes );
+			}
 		}
 
 		foreach ( $attributes as $name => $value ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Fix orphaned variation products breaking the feed.

Closes #462.

### Screenshots:

Current behavior:
![Screenshot_20220520_122650](https://user-images.githubusercontent.com/40774170/169571572-32c31bf8-e933-444c-bf93-c649bd9d38e0.png)

### Detailed test instructions:

1. Install the plugin and do the onboarding process.
2. Create a variable product with some variations.
3. Edit one of the variations directly on the database and change the parameter post_parent to a different value (>0 and != than parent product ID).
4. The feed should be generated without errors.

### Changelog entry

> Fix - Error on feed generation due to orphaned variations.
