### PR TITLE
Release/1.0.13

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.0.13 - 2022-05-24 =
+* Tweak - WC 6.5 compatibility.
+
 = 1.0.12 - 2022-05-05 =
 * Dev - update trusted plugins in composer.json.
 * Fix - Feed generation fails if there is no eligible product.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 *** Pinterest for WooCommerce Changelog ***
 
 = 1.0.13 - 2022-05-24 =
+* Add - Add action scheduler as a minimum plugin requirement.
+* Add - Japan to ads supported countries.
+* Add - Route to handle the plugin's settings.
+* Fix - Limit the number of additional images to 10.
 * Tweak - WC 6.5 compatibility.
 
 = 1.0.12 - 2022-05-05 =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.0.12
+ * Version:           1.0.13
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.12' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.0.13' ); // WRCS: DEFINED_VERSION.
 
 /**
  * Autoload packages.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 5.9
 Requires PHP: 7.3
-Stable tag: 1.0.12
+Stable tag: 1.0.13
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.0.13 - 2022-05-24 =
+* Tweak - WC 6.5 compatibility.
+
 = 1.0.12 - 2022-05-05 =
 * Dev - update trusted plugins in composer.json.
 * Fix - Feed generation fails if there is no eligible product.

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,10 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 == Changelog ==
 
 = 1.0.13 - 2022-05-24 =
+* Add - Add action scheduler as a minimum plugin requirement.
+* Add - Japan to ads supported countries.
+* Add - Route to handle the plugin's settings.
+* Fix - Limit the number of additional images to 10.
 * Tweak - WC 6.5 compatibility.
 
 = 1.0.12 - 2022-05-05 =

--- a/src/API/VendorAPI.php
+++ b/src/API/VendorAPI.php
@@ -105,7 +105,7 @@ class VendorAPI {
 	 * @param string $methods The endpoint's methods.
 	 * @param string $endpoint_callback The endpoint's callback.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.13
 	 */
 	public function register_router_single_method( $methods = '', $endpoint_callback = '' ) {
 		$namespace         = $this->api_namespace . $this->api_version;
@@ -127,7 +127,7 @@ class VendorAPI {
 	/**
 	 * Register endpoint route with multiple methods
 	 *
-	 * @since x.x.x
+	 * @since 1.0.13
 	 */
 	public function register_router_multiple_methods() {
 		foreach ( $this->endpoint_callbacks_map as $callback => $method ) {


### PR DESCRIPTION
Pinterest For WooCommerce 1.0.13 release PR.

**Changelog**
* Add - Add action scheduler as a minimum plugin requirement.
* Add - Japan to ads supported countries.
* Add - Route to handle the plugin's settings.
* Fix - Limit the number of additional images to 10.
* Tweak - WooCommerce 6.5 and WordPress 6.0 compatibility.

### Changelog entry

>