### PR TITLE
Remove subscription products support

### DIFF
--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -188,6 +188,8 @@ class AttributesTab {
 	/**
 	 * Return an array of WooCommerce product types that the Pinterest tab cannot be displayed for.
 	 *
+	 * @since x.x.x
+	 *
 	 * @return array of WooCommerce product types (e.g. 'subscription', 'variable-subscription', etc.)
 	 */
 	protected function get_hidden_product_types(): array {

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -94,7 +94,14 @@ class AttributesTab {
 			$this->get_applicable_product_types()
 		);
 
-		$classes = array_merge( array( 'pinterest' ), $shown_types );
+		$hidden_types = array_map(
+			function ( string $product_type ) {
+				return "hide_if_${product_type}";
+			},
+			$this->get_hidden_product_types()
+		);
+
+		$classes = array_merge( array( 'pinterest' ), $shown_types, $hidden_types );
 
 		$tabs['pinterest_attributes'] = array(
 			'label'  => 'Pinterest',
@@ -176,6 +183,15 @@ class AttributesTab {
 	 */
 	protected function get_applicable_product_types(): array {
 		return apply_filters( 'wc_pinterest_attributes_tab_applicable_product_types', array( 'simple', 'variable' ) );
+	}
+
+	/**
+	 * Return an array of WooCommerce product types that the Pinterest tab cannot be displayed for.
+	 *
+	 * @return array of WooCommerce product types (e.g. 'subscription', 'variable-subscription', etc.)
+	 */
+	protected function get_hidden_product_types(): array {
+		return apply_filters( 'wc_pinterest_attributes_tab_hidden_product_types', array( 'subscription', 'variable-subscription' ) );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -252,6 +252,15 @@ class FeedGenerator extends AbstractChainedJob {
 				'limit'      => $this->get_batch_size(),
 			);
 
+			// Exclude variation subscriptions.
+			$products_query_args['parent_exclude'] = wc_get_products(
+				array(
+					'type'   => 'variable-subscription',
+					'limit'  => -1,
+					'return' => 'ids',
+				)
+			);
+
 			// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set.
 			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 				$products_query_args['stock_status'] = 'instock';

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -237,6 +237,8 @@ class FeedGenerator extends AbstractChainedJob {
 				array(
 					'grouped',
 					'variable',
+					'subscription',
+					'variable-subscription',
 				)
 			);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the support for subscription products as discussed [here](https://github.com/woocommerce/pinterest-for-woocommerce/issues/372)
- Exclude subscription products from the feed.
- Hide Pinterest attributes tab on subscription products.

### Screenshots:

![Screenshot_20220524_153811](https://user-images.githubusercontent.com/40774170/170118484-023cf2a7-ad77-439b-a351-bf0e0261fb63.png)

### Detailed test instructions:

1. Install the plugin and do the onboarding.
2. Add one/many subscription products.
3. Subscription products should be excluded from the feed.
4. Pinterest attribute tab should be hidden on subscription products.


### Additional details:

### Changelog entry
