### PR TITLE
Redirect user to onboarding page when the plugin is activated

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -274,10 +274,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$view_factory         = new Pinterest\View\PHPViewFactory();
 			$admin                = new Pinterest\Admin\Admin( $view_factory );
 			$attributes_tab       = new Pinterest\Admin\Product\Attributes\AttributesTab( $admin );
+			$activation_redirect  = new Pinterest\Admin\ActivationRedirect();
 			$variation_attributes = new Pinterest\Admin\Product\Attributes\VariationsAttributes( $admin );
 
 			$admin->register();
 			$attributes_tab->register();
+			$activation_redirect->register();
 			$variation_attributes->register();
 		}
 

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -116,8 +116,7 @@ Pinterest_For_Woocommerce();
 register_activation_hook(
 	__FILE__,
 	function () {
-		// Initialize update engine on activation. This prevents update procedures from running on first activation.
-		( new Automattic\WooCommerce\Pinterest\PluginUpdate() )->update_plugin_update_version_option();
+		( new Automattic\WooCommerce\Pinterest\PluginActivate() )->activate();
 	}
 );
 

--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -26,7 +26,7 @@ class ActivationRedirect {
 	 *
 	 * @since  x.x.x
 	 */
-	protected const REDIRECT_SETTING = 'redirect_to_onboarding';
+	protected const DID_REDIRECT_SETTING = 'did_redirect_to_onboarding';
 
 	/**
 	 * Initiate class.
@@ -46,34 +46,32 @@ class ActivationRedirect {
 	 * Checks if merchant should be redirected to the onboarding page.
 	 *
 	 * @since  x.x.x
-	 * @return bool True if the redirection should have happened
 	 */
-	public function maybe_redirect_to_onboarding(): bool {
+	protected function maybe_redirect_to_onboarding() {
 		if ( wp_doing_ajax() ) {
-			return false;
+			return;
 		}
 
 		// If we have redirected before do not attempt to redirect again.
-		if ( ! $this->redirect_setting() ) {
-			return false;
+		if ( ! $this->did_redirect_setting() ) {
+			return;
 		}
 
 		// Do not redirect if setup is already complete.
 		if ( Pinterest_For_Woocommerce()::is_setup_complete() ) {
-			$this->update_redirect_setting( false );
-			return false;
+			$this->update_did_redirect_setting( false );
+			return;
 		}
 
 		// Do not redirect if we already are in the Get Started page.
-		if ( $this->is_onboarding_page() && $this->redirect_setting() ) {
-			$this->update_redirect_setting( false );
-			return false;
+		if ( $this->is_onboarding_page() && $this->did_redirect_setting() ) {
+			$this->update_did_redirect_setting( false );
+			return;
 		}
 
 		// Redirect if setup is not complete.
 		$this->redirect_to_onboarding_page();
 
-		return true;
 	}
 
 	/**
@@ -89,7 +87,7 @@ class ActivationRedirect {
 			return;
 		}
 
-		$this->update_redirect_setting( true );
+		$this->update_did_redirect_setting( true );
 
 		wp_safe_redirect( admin_url( add_query_arg( $this->onboarding_page_parameters(), 'admin.php' ) ) );
 		exit();
@@ -108,18 +106,18 @@ class ActivationRedirect {
 			// ...or with a bulk action.
 			|| isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) // phpcs:ignore WordPress.Security.NonceVerification
 		) {
-			$this->update_redirect_setting( true );
+			$this->update_did_redirect_setting( true );
 		}
 	}
 
 	/**
 	 * Update the redirect setting.
 	 *
-	 * @param bool $redirect_setting The new value.
+	 * @param bool $did_redirect The new value.
 	 * @since x.x.x
 	 */
-	protected function update_redirect_setting( $redirect_setting ): void {
-		Pinterest_For_Woocommerce()->save_setting( self::REDIRECT_SETTING, $redirect_setting );
+	protected function update_did_redirect_setting( $did_redirect ): void {
+		Pinterest_For_Woocommerce()->save_setting( self::DID_REDIRECT_SETTING, $did_redirect );
 	}
 
 	/**
@@ -128,8 +126,7 @@ class ActivationRedirect {
 	 * @since  x.x.x
 	 * @return bool
 	 */
-	protected function redirect_setting(): bool {
-		$redirect_setting = Pinterest_For_Woocommerce()->get_setting( self::REDIRECT_SETTING );
-		return isset( $redirect_setting ) ? (bool) $redirect_setting : false;
+	protected function did_redirect_setting(): bool {
+		return (bool) Pinterest_For_Woocommerce()->get_setting( self::DID_REDIRECT_SETTING );
 	}
 }

--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -3,7 +3,7 @@
  * Helper class for handling the redirection to the onboarding page.
  *
  * @package Automattic\WooCommerce\Pinterest\Admin
- * @since   X.X.X
+ * @since   x.x.x
  */
 
 namespace Automattic\WooCommerce\Pinterest\Admin;
@@ -24,14 +24,14 @@ class ActivationRedirect {
 	/**
 	 * The setting for redirect to onboarding.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 */
 	protected const REDIRECT_SETTING = 'redirect_to_onboarding';
 
 	/**
 	 * Initiate class.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 */
 	public function register() {
 		add_action(
@@ -45,7 +45,7 @@ class ActivationRedirect {
 	/**
 	 * Checks if merchant should be redirected to the onboarding page.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 * @return bool True if the redirection should have happened
 	 */
 	public function maybe_redirect_to_onboarding(): bool {
@@ -80,7 +80,7 @@ class ActivationRedirect {
 	 * Utility function to immediately redirect to the main "Get Started" onboarding page.
 	 * Note that this function immediately ends the execution.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 * @return void
 	 */
 	protected function redirect_to_onboarding_page(): void {
@@ -98,7 +98,7 @@ class ActivationRedirect {
 	/**
 	 * Maybe update the redirect option.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 */
 	public function maybe_update_redirect_option(): void {
 
@@ -116,7 +116,7 @@ class ActivationRedirect {
 	 * Update the redirect setting.
 	 *
 	 * @param bool $redirect_setting The new value.
-	 * @since X.X.X
+	 * @since x.x.x
 	 */
 	protected function update_redirect_setting( $redirect_setting ): void {
 		Pinterest_For_Woocommerce()->save_setting( self::REDIRECT_SETTING, $redirect_setting );
@@ -125,7 +125,7 @@ class ActivationRedirect {
 	/**
 	 * Get the redirect setting.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 * @return bool
 	 */
 	protected function redirect_setting(): bool {

--- a/src/Admin/ActivationRedirect.php
+++ b/src/Admin/ActivationRedirect.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Helper class for handling the redirection to the onboarding page.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Admin
+ * @since   X.X.X
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Admin;
+
+use Automattic\WooCommerce\Pinterest\PluginHelper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class ActivationRedirect
+ */
+class ActivationRedirect {
+
+	use PluginHelper;
+
+	/**
+	 * The setting for redirect to onboarding.
+	 *
+	 * @since  X.X.X
+	 */
+	protected const REDIRECT_SETTING = 'redirect_to_onboarding';
+
+	/**
+	 * Initiate class.
+	 *
+	 * @since  X.X.X
+	 */
+	public function register() {
+		add_action(
+			'admin_init',
+			function () {
+				$this->maybe_redirect_to_onboarding();
+			}
+		);
+	}
+
+	/**
+	 * Checks if merchant should be redirected to the onboarding page.
+	 *
+	 * @since  X.X.X
+	 * @return bool True if the redirection should have happened
+	 */
+	public function maybe_redirect_to_onboarding(): bool {
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
+
+		// If we have redirected before do not attempt to redirect again.
+		if ( ! $this->redirect_setting() ) {
+			return false;
+		}
+
+		// Do not redirect if setup is already complete.
+		if ( Pinterest_For_Woocommerce()::is_setup_complete() ) {
+			$this->update_redirect_setting( false );
+			return false;
+		}
+
+		// Do not redirect if we already are in the Get Started page.
+		if ( $this->is_onboarding_page() && $this->redirect_setting() ) {
+			$this->update_redirect_setting( false );
+			return false;
+		}
+
+		// Redirect if setup is not complete.
+		$this->redirect_to_onboarding_page();
+
+		return true;
+	}
+
+	/**
+	 * Utility function to immediately redirect to the main "Get Started" onboarding page.
+	 * Note that this function immediately ends the execution.
+	 *
+	 * @since  X.X.X
+	 * @return void
+	 */
+	protected function redirect_to_onboarding_page(): void {
+		// If we are already on the onboarding page, do nothing.
+		if ( $this->is_onboarding_page() ) {
+			return;
+		}
+
+		$this->update_redirect_setting( true );
+
+		wp_safe_redirect( admin_url( add_query_arg( $this->onboarding_page_parameters(), 'admin.php' ) ) );
+		exit();
+	}
+
+	/**
+	 * Maybe update the redirect option.
+	 *
+	 * @since  X.X.X
+	 */
+	public function maybe_update_redirect_option(): void {
+
+		if (
+			// Only redirect to onboarding when activated on its own.
+			isset( $_GET['action'] ) && 'activate' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification
+			// ...or with a bulk action.
+			|| isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) // phpcs:ignore WordPress.Security.NonceVerification
+		) {
+			$this->update_redirect_setting( true );
+		}
+	}
+
+	/**
+	 * Update the redirect setting.
+	 *
+	 * @param bool $redirect_setting The new value.
+	 * @since X.X.X
+	 */
+	protected function update_redirect_setting( $redirect_setting ): void {
+		Pinterest_For_Woocommerce()->save_setting( self::REDIRECT_SETTING, $redirect_setting );
+	}
+
+	/**
+	 * Get the redirect setting.
+	 *
+	 * @since  X.X.X
+	 * @return bool
+	 */
+	protected function redirect_setting(): bool {
+		$redirect_setting = Pinterest_For_Woocommerce()->get_setting( self::REDIRECT_SETTING );
+		return isset( $redirect_setting ) ? (bool) $redirect_setting : false;
+	}
+}

--- a/src/PluginActivate.php
+++ b/src/PluginActivate.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Helper class for handling the activation hook.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ * @since   X.X.X
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Automattic\WooCommerce\Pinterest\Admin\ActivationRedirect;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class PluginActivate
+ */
+class PluginActivate {
+
+	/**
+	 * Activation hook
+	 *
+	 * @since X.X.X
+	 */
+	public function activate(): void {
+
+		// Init the update class.
+		$this->init_plugin_update();
+
+		// Maybe update the redirect option.
+		( new ActivationRedirect() )->maybe_update_redirect_option();
+	}
+
+	/**
+	 * Initialize the update helper class.
+	 *
+	 * @since  X.X.X
+	 */
+	protected function init_plugin_update(): void {
+		( new PluginUpdate() )->update_plugin_update_version_option();
+	}
+
+}

--- a/src/PluginActivate.php
+++ b/src/PluginActivate.php
@@ -3,7 +3,7 @@
  * Helper class for handling the activation hook.
  *
  * @package Automattic\WooCommerce\Pinterest
- * @since   X.X.X
+ * @since   x.x.x
  */
 
 namespace Automattic\WooCommerce\Pinterest;
@@ -22,7 +22,7 @@ class PluginActivate {
 	/**
 	 * Activation hook
 	 *
-	 * @since X.X.X
+	 * @since x.x.x
 	 */
 	public function activate(): void {
 
@@ -36,7 +36,7 @@ class PluginActivate {
 	/**
 	 * Initialize the update helper class.
 	 *
-	 * @since  X.X.X
+	 * @since  x.x.x
 	 */
 	protected function init_plugin_update(): void {
 		( new PluginUpdate() )->update_plugin_update_version_option();

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -54,4 +54,31 @@ trait PluginHelper {
 		return defined( 'WP_DEBUG' ) && WP_DEBUG;
 	}
 
+	/**
+	 * Helper method to return the onboarding page parameters.
+	 *
+	 * @return array The onboarding page parameters.
+	 */
+	protected function onboarding_page_parameters(): array {
+
+		return array(
+			'page' => 'wc-admin',
+			'path' => '/pinterest/onboarding',
+		);
+	}
+
+	/**
+	 * Check wether if the current page is the Get Started page.
+	 *
+	 * @return bool Wether the current page is the Get Started page.
+	 */
+	protected function is_onboarding_page(): bool {
+
+		if ( count( $this->onboarding_page_parameters() ) === count( array_intersect_assoc( $_GET, $this->onboarding_page_parameters() ) ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return false;
+	}
+
 }

--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -74,11 +74,9 @@ trait PluginHelper {
 	 */
 	protected function is_onboarding_page(): bool {
 
-		if ( count( $this->onboarding_page_parameters() ) === count( array_intersect_assoc( $_GET, $this->onboarding_page_parameters() ) ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			return true;
-		}
+		$page_parameters = $this->onboarding_page_parameters();
 
-		return false;
+		return count( $page_parameters ) === count( array_intersect_assoc( $_GET, $page_parameters ) ); // phpcs:disable WordPress.Security.NonceVerification.Recommended
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #420.

Redirect the user to the onboarding page when the plugin is activated on a fresh install.

### Screenshots:

![Screenshot_20220524_231207](https://user-images.githubusercontent.com/40774170/170172010-fe05a166-4e5a-4cd5-af1e-78736f7188c2.png)

### Detailed test instructions:
1. Install Woocommerce plugin and activate.
2. Install the Pinterest for Woocommerce plugin and activate.
3. The user should be redirected to the Get started page automatically. 


### Additional details:

### Changelog entry

> Add - The user will be redirected to the Get started page on first activation.
