### PR TITLE
Fix/unit tests wc 6.5

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -198,6 +198,13 @@ install_wc() {
     # Install composer for WooCommerce
     cd "${WC_DIR}"
     composer install --ignore-platform-reqs --no-interaction --no-dev
+
+	# Generate feature config for WooCommerce
+	GENERATE_FEATURE_CONFIG=bin/generate-feature-config.php
+	if [ -f $GENERATE_FEATURE_CONFIG ]; then
+	  php $GENERATE_FEATURE_CONFIG
+	fi
+
     cd -
   else
     echo "WooCommerce ($WC_VERSION) already installed."

--- a/tests/Unit/FeedXMLGenerationShippingTest.php
+++ b/tests/Unit/FeedXMLGenerationShippingTest.php
@@ -25,7 +25,7 @@ class Pinterest_Test_Shipping_Feed extends WC_Unit_Test_Case {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		$this->products[] = WC_Helper_Product::create_simple_product(  true, array( "regular_price" => 15 ) );
 	}
 
@@ -34,7 +34,7 @@ class Pinterest_Test_Shipping_Feed extends WC_Unit_Test_Case {
 	 *
 	 * @return void
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		foreach( $this->products as $product ) {
 			$product->delete( true );
 		}

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -683,7 +683,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	/**
 	 * Remove filters and shortcodes.
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 
 		// Remove any added filter.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,11 +75,11 @@ function install_woocommerce() {
 
 	WC_Install::install();
 
-	// Initialize the WC API extensions.
+	// Initialize the WC Admin extension.
 	if ( class_exists( '\Automattic\WooCommerce\Internal\Admin\Install' ) ) {
 		\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
 		\Automattic\WooCommerce\Internal\Admin\Install::create_events();
-	} else {
+	} elseif ( class_exists( '\Automattic\WooCommerce\Admin\Install' ) ) {
 		\Automattic\WooCommerce\Admin\Install::create_tables();
 		\Automattic\WooCommerce\Admin\Install::create_events();
 	}


### PR DESCRIPTION
This ports @mikkamp [fix on GLA](https://github.com/woocommerce/google-listings-and-ads/pull/1498) to this repo.

### Changes proposed in this Pull Request:

This PR fixes the unit tests to allow them to run with WooCommerce 6.5 (first version with WC Admin fully included). The following two fixes are applied:

- Generate a feature config file if the install script is present
- Do not call the WC Admin install class (database tables are created as part of the regular install)

### Detailed test instructions:

1. Now that WC 6.5 is released it will automatically install it for unit tests since we use `latest` 
2. Check that the unit tests successfully run for this PR.

### Changelog entry
* Fix - Unit tests for WooCommerce 6.5