### PR TITLE
Fix typo errors on translatable strings

### DIFF
--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -167,7 +167,7 @@ const HealthCheck = () => {
 		pending_initial_configuration: {
 			status: 'warning',
 			message: __(
-				'The feed is being configured. Depending on the number of products this may take a while as the feed needs to be fully generated before its been sent to Pinterest for registration. You can check the status of the generation process in the Catalog tab.',
+				'The feed is being configured. Depending on the number of products this may take a while as the feed needs to be fully generated before it is been sent to Pinterest for registration. You can check the status of the generation process in the Catalog tab.',
 				'pinterest-for-woocommerce'
 			),
 			dismissible: false,
@@ -187,7 +187,7 @@ const HealthCheck = () => {
 				'pinterest-for-woocommerce'
 			),
 			body: __(
-				'If you have a valid reason (such as having corrected the violations that resulted in the disapproval) for appealing a merchant review decision, you can submit an appeal.',
+				'If you have a valid reason for appealing a merchant review decision (such as having corrected the violations that resulted in the disapproval), you can submit an appeal.',
 				'pinterest-for-woocommerce'
 			),
 			reasons: healthStatus.reasons,

--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -167,7 +167,7 @@ const HealthCheck = () => {
 		pending_initial_configuration: {
 			status: 'warning',
 			message: __(
-				'The feed is being configured. Depending on the number of products this may take a while as the feed needs to be fully generated before its been sent to Pinterest for registration. You can check the the status of the generation process in the Catalog tab.',
+				'The feed is being configured. Depending on the number of products this may take a while as the feed needs to be fully generated before its been sent to Pinterest for registration. You can check the status of the generation process in the Catalog tab.',
 				'pinterest-for-woocommerce'
 			),
 			dismissible: false,
@@ -187,7 +187,7 @@ const HealthCheck = () => {
 				'pinterest-for-woocommerce'
 			),
 			body: __(
-				'If you have a valid reason (such as having corrected the violations that resulted in the dissaproval) for appealing a merchant review decision, you can submit an appeal.',
+				'If you have a valid reason (such as having corrected the violations that resulted in the disapproval) for appealing a merchant review decision, you can submit an appeal.',
 				'pinterest-for-woocommerce'
 			),
 			reasons: healthStatus.reasons,

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -71,7 +71,7 @@ class Auth extends VendorAPI {
 	public function redirect_to_settings_page( $served, $result, $request ) {
 
 		if ( 401 === $result->get_status() ) {
-			$error_message = esc_html__( 'Something went wrong with your attempt to authorize this App. Please try agagin.', 'pinterest-for-woocommerce' );
+			$error_message = esc_html__( 'Something went wrong with your attempt to authorize this App. Please try again.', 'pinterest-for-woocommerce' );
 			wp_safe_redirect( add_query_arg( 'error', rawurlencode( $error_message ), $this->get_redirect_url( $request->get_param( 'view' ), true ) ) );
 			exit;
 		}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -174,7 +174,7 @@ class FeedState extends VendorAPI {
 				$status_label = esc_html__( 'Feed generation in progress.', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
 					esc_html(
-						/* Translators: %1$s Time string, %2$s number of products */
+						/* translators: 1: Time string, 2: number of products, 3: opening anchor tag, 4: closing anchor tag */
 						_n(
 							'Last activity: %1$s ago - Wrote %2$s product to %3$sfeed file%4$s.',
 							'Last activity: %1$s ago - Wrote %2$s products to %3$sfeed file%4$s.',
@@ -194,7 +194,7 @@ class FeedState extends VendorAPI {
 				$status_label = esc_html__( 'Up to date', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
 					esc_html(
-						/* Translators: %1$s Time string, %2$s total number of products */
+						/* translators: 1: Time string, 2: total number of products, 3: opening anchor tag, 4: closing anchor tag */
 						_n(
 							'Successfully generated %1$s ago - Wrote %2$s product to %3$sfeed file%4$s',
 							'Successfully generated %1$s ago - Wrote %2$s products to %3$sfeed file%4$s',

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -116,7 +116,7 @@ class FeedState extends VendorAPI {
 							'extra_info'   => wp_kses_post(
 								sprintf(
 									/* Translators: %1$s The URL of the settings page */
-									__( 'Visit the <a href="%1$s">settings</a> page to enabled it.', 'pinterest-for-woocommerce' ),
+									__( 'Visit the <a href="%1$s">settings</a> page to enable it.', 'pinterest-for-woocommerce' ),
 									esc_url(
 										add_query_arg(
 											array(
@@ -173,8 +173,15 @@ class FeedState extends VendorAPI {
 				$status       = 'pending';
 				$status_label = esc_html__( 'Feed generation in progress.', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s number of products */
-					esc_html__( 'Last activity: %1$s ago - Wrote %2$s products to %3$sfeed file%4$s.', 'pinterest-for-woocommerce' ),
+					esc_html(
+						/* Translators: %1$s Time string, %2$s number of products */
+						_n(
+							'Last activity: %1$s ago - Wrote %2$s product to %3$sfeed file%4$s.',
+							'Last activity: %1$s ago - Wrote %2$s products to %3$sfeed file%4$s.',
+							$state['product_count'],
+							'pinterest-for-woocommerce'
+						)
+					),
 					human_time_diff( $state['last_activity'] ),
 					$state['product_count'],
 					sprintf( '<a href="%s" target="_blank">', esc_url( $this->get_feed_url() ) ),
@@ -186,8 +193,15 @@ class FeedState extends VendorAPI {
 				$status       = 'success';
 				$status_label = esc_html__( 'Up to date', 'pinterest-for-woocommerce' );
 				$extra_info   = sprintf(
-					/* Translators: %1$s Time string, %2$s total number of products */
-					esc_html__( 'Successfully generated %1$s ago - Wrote %2$s products to %3$sfeed file%4$s', 'pinterest-for-woocommerce' ),
+					esc_html(
+						/* Translators: %1$s Time string, %2$s total number of products */
+						_n(
+							'Successfully generated %1$s ago - Wrote %2$s product to %3$sfeed file%4$s',
+							'Successfully generated %1$s ago - Wrote %2$s products to %3$sfeed file%4$s',
+							$state['product_count'],
+							'pinterest-for-woocommerce'
+						)
+					),
 					human_time_diff( $state['last_activity'] ),
 					$state['product_count'],
 					sprintf( '<a href="%s" target="_blank">', esc_url( $this->get_feed_url() ) ),

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -81,7 +81,7 @@ class Merchants {
 		}
 
 		if ( ! $merchant || 'success' !== $merchant['status'] || ! $merchant['data'] ) {
-			throw new Exception( __( 'Response error when trying create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
+			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
 		}
 
 		// Update merchant id if it is different from the stored in DB.
@@ -146,7 +146,7 @@ class Merchants {
 		$response = API\Base::update_or_create_merchant( $args );
 
 		if ( 'success' !== $response['status'] ) {
-			throw new Exception( __( 'Response error when trying create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
+			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
 		}
 
 		$registered_feed = Feeds::is_local_feed_registered( $response['data'] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #478.

Fix typo errors on translatable strings:
- 'If you have a valid reason (such as having corrected the violations that resulted in the dissaproval)' --> 'If you have a valid reason (such as having corrected the violations that resulted in the disapproval)'
- 'You can check the the status of the generation process in the Catalog tab.' --> 'You can check the status of the generation process in the Catalog tab.'
- 'Please try agagin.' --> 'Please try again.'
- 'Visit the <a href="%1$s">settings</a> page to enabled it.' --> 'Visit the <a href="%1$s">settings</a> page to enable it.'
- Use of plurals on: 'Last activity: %1$s ago - Wrote %2$s product to %3$sfeed file%4$s.' and 'Successfully generated %1$s ago - Wrote %2$s product to %3$sfeed file%4$s'
- 'Response error when trying create a merchant or update the existing one.' --> 'Response error when trying to create a merchant or update the existing one.'

### Screenshots:

### Detailed test instructions:
1. Check the .pot translatable strings.
2. There should not be any typo errors.


### Additional details:

### Changelog entry

> Fix - Typo errors on translatable strings.
