### PR TITLE
Add Argentina, Colombia and Chile to supported countries

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -26,11 +26,14 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 		 */
 		public static function get_countries() {
 			return array(
+				'AR', // Argentina.
 				'AU', // Australia.
 				'AT', // Austria.
 				'BE', // Belgium.
 				'BR', // Brazil.
 				'CA', // Canada.
+				'CL', // Chile.
+				'CO', // Colombia.
 				'CY', // Cyprus.
 				'CZ', // Czech Republic.
 				'DK', // Denmark.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add Argentina, Colombia and Chile to the list of supported countries. (https://github.com/woocommerce/pinterest-for-woocommerce/issues/426#issuecomment-1161885670)

### Screenshots:

### Detailed test instructions:

1. Go to the General tab of WC Settings. Change the "Country / State" option to Argentina/Colombia/Chile
2. Go to the landing page: /wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding
3. The no supported country warning notice should not appear.


### Additional details:

### Changelog entry

> Add - Argentina, Colombia and Chile to ads supported countries.
