### PR TITLE
Save settings if new value is different

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -504,6 +504,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return boolean
 		 */
 		public static function save_settings( $settings, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
+
+			if ( self::get_settings( true, $option ) === $settings ) {
+				return true;
+			}
+
 			self::$dirty_settings[ $option ] = true;
 			return update_option( $option, $settings );
 		}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -505,7 +505,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_settings( $settings, $option = PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) {
 
-			if ( self::get_settings( true, $option ) === $settings ) {
+			if ( self::get_settings( false, $option ) === $settings ) {
 				return true;
 			}
 

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -61,9 +61,7 @@ class Options extends VendorAPI {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		$new_settings = $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME );
-
-		if ( Pinterest_For_Woocommerce()::get_settings() !== $new_settings && ! Pinterest_For_Woocommerce()::save_settings( $new_settings ) ) {
+		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -61,7 +61,9 @@ class Options extends VendorAPI {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
+		$new_settings = $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME );
+
+		if ( Pinterest_For_Woocommerce()::get_settings() !== $new_settings && ! Pinterest_For_Woocommerce()::save_settings( $new_settings ) ) {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #477.

The `account_data` setting is updated as part of the domain verification.
The call to `save_settings` after domain verification was throwing error, since old and new values are the same. A verification of old and new values will prevent this error.

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. There should be no error after domain verification.

*Changelog entry once this is ready:* `Fix - Error after domain verification`. The changelog entry below is left empty on purpose.

### Changelog entry

>
