### PR TITLE
Fix end of line inside single quotes

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -61,7 +61,7 @@ class Tracking {
 	 *
 	 * @var string
 	 */
-	private static $noscript_base_tag = '<!-- Pinterest Pixel Base Code -->\n<noscript>\n  <img height=\"1\" width=\"1\" style=\"display:none;\" alt=\"\" src=\"https://ct.pinterest.com/v3/?tid=' . self::TAG_ID_SLUG . '&noscript=1\" />\n</noscript>\n<!-- End Pinterest Pixel Base Code -->\n';
+	private static $noscript_base_tag = '<!-- Pinterest Pixel Base Code -->' . PHP_EOL . '<noscript>' . PHP_EOL . '  <img height=\"1\" width=\"1\" style=\"display:none;\" alt=\"\" src=\"https://ct.pinterest.com/v3/?tid=' . self::TAG_ID_SLUG . '&noscript=1\" />' . PHP_EOL . '</noscript>' . PHP_EOL . '<!-- End Pinterest Pixel Base Code -->' . PHP_EOL;
 
 	/**
 	 * The user/customer specific key used to store async events that are to be printed the next

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -61,7 +61,7 @@ class Tracking {
 	 *
 	 * @var string
 	 */
-	private static $noscript_base_tag = '<!-- Pinterest Pixel Base Code -->' . PHP_EOL . '<noscript>' . PHP_EOL . '  <img height=\"1\" width=\"1\" style=\"display:none;\" alt=\"\" src=\"https://ct.pinterest.com/v3/?tid=' . self::TAG_ID_SLUG . '&noscript=1\" />' . PHP_EOL . '</noscript>' . PHP_EOL . '<!-- End Pinterest Pixel Base Code -->' . PHP_EOL;
+	private static $noscript_base_tag = '<!-- Pinterest Pixel Base Code --><noscript><img height="1" width="1" style="display:none;" alt="" src="https://ct.pinterest.com/v3/?tid=' . self::TAG_ID_SLUG . '&noscript=1" /></noscript><!-- End Pinterest Pixel Base Code -->';
 
 	/**
 	 * The user/customer specific key used to store async events that are to be printed the next


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is an error rendering the end of lines around the `<noscript>` tag.

### Screenshots:

![pinterest-end-of-line](https://user-images.githubusercontent.com/40774170/176263276-03cddbfc-b173-4a27-9f9c-6f957731f3c6.png)

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. Verify that the Tracking is properly configured.
3. The `\n\n\n` should no appear at the start of the body.


### Additional details:

### Changelog entry

> Fix - Error printing end of line character
