### PR TITLE
Improve include and exclude methods

### DIFF
--- a/assets/source/js/admin/pinterest-for-woocommerce-admin.js
+++ b/assets/source/js/admin/pinterest-for-woocommerce-admin.js
@@ -3,11 +3,15 @@
 ( function ( $ ) {
 	'use strict';
 
-	$( document ).on(
-		'woocommerce-product-type-change',
-		'body',
-		function ( event, productType ) {
-			$( '.hide_if_' + productType ).hide();
+	function hideTabs( event, productType ) {
+		$( '.hide_if_' + productType ).hide();
+	}
+
+	$( document ).on( 'woocommerce-product-type-change', 'body', hideTabs );
+
+	$( document ).ready( function () {
+		if ( $( '#product-type' ).length > 0 ) {
+			hideTabs( false, $( '#product-type' ).val() );
 		}
-	);
+	} );
 } )( jQuery );

--- a/assets/source/js/admin/pinterest-for-woocommerce-admin.js
+++ b/assets/source/js/admin/pinterest-for-woocommerce-admin.js
@@ -1,0 +1,12 @@
+/* global jQuery */
+
+( function ( $ ) {
+	'use strict';
+
+	$( document.body ).on(
+		'woocommerce-product-type-change',
+		function ( productType ) {
+			$( '.hide_if_' + productType ).hide();
+		}
+	);
+} )( jQuery );

--- a/assets/source/js/admin/pinterest-for-woocommerce-admin.js
+++ b/assets/source/js/admin/pinterest-for-woocommerce-admin.js
@@ -3,9 +3,10 @@
 ( function ( $ ) {
 	'use strict';
 
-	$( document.body ).on(
+	$( document ).on(
 		'woocommerce-product-type-change',
-		function ( productType ) {
+		'body',
+		function ( event, productType ) {
 			$( '.hide_if_' + productType ).hide();
 		}
 	);

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		 * Initialize class
 		 */
 		public function __construct() {
-			add_action( 'admin_enqueue_scripts', array( $this, 'load_setup_guide_scripts' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_assets' ) );
 			add_action( 'admin_init', array( $this, 'maybe_redirect_to_middleware' ) );
 			add_filter( 'woocommerce_get_registered_extended_tasks', array( $this, 'register_task_list_item' ), 10, 1 );
 			add_filter( 'admin_footer', array( $this, 'load_settings' ) );
@@ -318,6 +318,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 			);
 
 			wp_enqueue_style( $handle );
+		}
+
+		/**
+		 * Enqueues admin related scripts & styles
+		 *
+		 * @return void
+		 */
+		public function load_admin_assets() {
+
+			$assets_path_url = str_replace( array( 'http:', 'https:' ), '', Pinterest_For_Woocommerce()->plugin_url() ) . '/assets/';
+			$ext             = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+			wp_enqueue_script( 'pinterest-for-woocommerce-admin', $assets_path_url . 'js/admin/pinterest-for-woocommerce-admin' . $ext . '.js', array( 'jquery' ), PINTEREST_FOR_WOOCOMMERCE_VERSION, true );
+
+			$this->load_setup_guide_scripts();
 		}
 
 		/**

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -91,14 +91,14 @@ class AttributesTab {
 			function ( string $product_type ) {
 				return "show_if_${product_type}";
 			},
-			$this->get_applicable_product_types()
+			array_keys( $this->get_applicable_product_types() )
 		);
 
 		$hidden_types = array_map(
 			function ( string $product_type ) {
 				return "hide_if_${product_type}";
 			},
-			$this->get_hidden_product_types()
+			array_keys( $this->get_hidden_product_types() )
 		);
 
 		$classes = array_merge( array( 'pinterest' ), $shown_types, $hidden_types );
@@ -182,7 +182,13 @@ class AttributesTab {
 	 * @return array of WooCommerce product types (e.g. 'simple', 'variable', etc.)
 	 */
 	public static function get_applicable_product_types(): array {
-		return apply_filters( 'wc_pinterest_attributes_tab_applicable_product_types', array( 'simple', 'variable' ) );
+		return apply_filters(
+			'wc_pinterest_attributes_tab_applicable_product_types',
+			array(
+				'simple'   => __( 'Simple product', 'pinterest-for-woocommerce' ),
+				'variable' => __( 'Variable product', 'pinterest-for-woocommerce' ),
+			)
+		);
 	}
 
 	/**
@@ -193,7 +199,13 @@ class AttributesTab {
 	 * @return array of WooCommerce product types (e.g. 'subscription', 'variable-subscription', etc.)
 	 */
 	protected function get_hidden_product_types(): array {
-		return apply_filters( 'wc_pinterest_attributes_tab_hidden_product_types', array_diff( array_keys( wc_get_product_types() ), $this->get_applicable_product_types() ) );
+		return apply_filters(
+			'wc_pinterest_attributes_tab_hidden_product_types',
+			array_diff_key(
+				wc_get_product_types(),
+				$this->get_applicable_product_types()
+			)
+		);
 	}
 
 	/**

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -105,7 +105,7 @@ class AttributesTab {
 
 		$tabs['pinterest_attributes'] = array(
 			'label'  => 'Pinterest',
-			'class'  => join( ' ', $classes ),
+			'class'  => $classes,
 			'target' => 'pinterest_attributes',
 		);
 
@@ -193,7 +193,7 @@ class AttributesTab {
 	 * @return array of WooCommerce product types (e.g. 'subscription', 'variable-subscription', etc.)
 	 */
 	protected function get_hidden_product_types(): array {
-		return apply_filters( 'wc_pinterest_attributes_tab_hidden_product_types', array( 'subscription', 'variable-subscription' ) );
+		return apply_filters( 'wc_pinterest_attributes_tab_hidden_product_types', array_diff( array_keys( wc_get_product_types() ), $this->get_applicable_product_types() ) );
 	}
 
 	/**

--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -181,7 +181,7 @@ class AttributesTab {
 	 *
 	 * @return array of WooCommerce product types (e.g. 'simple', 'variable', etc.)
 	 */
-	protected function get_applicable_product_types(): array {
+	public static function get_applicable_product_types(): array {
 		return apply_filters( 'wc_pinterest_attributes_tab_applicable_product_types', array( 'simple', 'variable' ) );
 	}
 

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -49,6 +49,11 @@ class VariationsAttributes {
 	 * Register a service.
 	 */
 	public function register(): void {
+
+		if ( ! in_array( 'variable', AttributesTab::get_applicable_product_types(), true ) ) {
+			return;
+		}
+
 		// Priority 90 to render after regular variation attributes.
 		add_action(
 			'woocommerce_product_after_variable_attributes',

--- a/src/Admin/Product/Attributes/VariationsAttributes.php
+++ b/src/Admin/Product/Attributes/VariationsAttributes.php
@@ -50,7 +50,7 @@ class VariationsAttributes {
 	 */
 	public function register(): void {
 
-		if ( ! in_array( 'variable', AttributesTab::get_applicable_product_types(), true ) ) {
+		if ( ! array_key_exists( 'variable', AttributesTab::get_applicable_product_types() ) ) {
 			return;
 		}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -222,13 +222,8 @@ class FeedGenerator extends AbstractChainedJob {
 			// Get included product types.
 			$included_product_types = self::get_supported_product_types();
 
-			// Get excluded product types.
-			$excluded_product_types = self::get_unsupported_product_types();
-
-			$types = array_diff( $included_product_types, $excluded_product_types );
-
 			$products_query_args = array(
-				'type'       => $types,
+				'type'       => $included_product_types,
 				'include'    => $items,
 				'visibility' => 'catalog',
 				'orderby'    => 'none',
@@ -553,25 +548,6 @@ class FeedGenerator extends AbstractChainedJob {
 				'simple',
 				'external',
 				'variation',
-			)
-		);
-	}
-
-	/**
-	 * Return the list of hidden product types.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return array
-	 */
-	private function get_unsupported_product_types(): array {
-		return (array) apply_filters(
-			'pinterest_for_woocommerce_excluded_product_types',
-			array(
-				'grouped',
-				'variable',
-				'subscription',
-				'variable-subscription',
 			)
 		);
 	}

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -549,7 +549,6 @@ class FeedGenerator extends AbstractChainedJob {
 			'pinterest_for_woocommerce_included_product_types',
 			array(
 				'simple',
-				'external',
 				'variation',
 			)
 		);

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -220,7 +220,10 @@ class FeedGenerator extends AbstractChainedJob {
 	protected function process_items( array $items, array $args ) {
 		try {
 			// Get included product types.
-			$included_product_types = self::get_supported_product_types();
+			$included_product_types = array_diff(
+				self::get_supported_product_types(),
+				self::get_excluded_product_types(),
+			);
 
 			$products_query_args = array(
 				'type'       => $included_product_types,
@@ -548,6 +551,25 @@ class FeedGenerator extends AbstractChainedJob {
 				'simple',
 				'external',
 				'variation',
+			)
+		);
+	}
+
+	/**
+	 * Return the list of excluded product types.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array
+	 */
+	private function get_excluded_product_types(): array {
+		return (array) apply_filters(
+			'pinterest_for_woocommerce_excluded_product_types',
+			array(
+				'grouped',
+				'variable',
+				'subscription',
+				'variable-subscription',
 			)
 		);
 	}

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -221,7 +221,7 @@ class FeedGenerator extends AbstractChainedJob {
 		try {
 			// Get included product types.
 			$included_product_types = array_diff(
-				self::get_supported_product_types(),
+				self::get_included_product_types(),
 				self::get_excluded_product_types(),
 			);
 
@@ -544,7 +544,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @return array
 	 */
-	private function get_supported_product_types(): array {
+	private function get_included_product_types(): array {
 		return (array) apply_filters(
 			'pinterest_for_woocommerce_included_product_types',
 			array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Closes #372
Closes #543 

This PR follows up the PR #468.
As [discussed here](https://github.com/woocommerce/pinterest-for-woocommerce/pull/468#issuecomment-1150902058), the plugin will sync only the supported products, which can be filtered for customization by the customer.

### Screenshots:


### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. The feed should contain by default only the following product types: 'simple', 'external' and 'variation'.
3. The included product types can be filtered using: `pinterest_for_woocommerce_included_product_types`.
4. Default product types for which Google Category and Condition is displayed are 'simple' and 'variable', it won't be displayed for the rest of product types by default.
5. The product types for which Pinterest Google Condition tab is displayed can be edited using the following filters: `wc_pinterest_attributes_tab_applicable_product_types` and `wc_pinterest_attributes_tab_hidden_product_types`.

### Additional details:

### Changelog entry

>
