### PR TITLE
Show the correct extra info if product sync is not working

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Pinterest\API;
 use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\FeedRegistration;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\ProductSync;
 use \WP_REST_Server;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -106,28 +107,14 @@ class FeedState extends VendorAPI {
 
 			$result = array();
 
-			if ( ! Pinterest\ProductSync::is_product_sync_enabled() ) {
+			if ( ! ProductSync::is_product_sync_enabled() ) {
 				return array(
 					'workflow' => array(
 						array(
 							'label'        => esc_html__( 'XML feed', 'pinterest-for-woocommerce' ),
 							'status'       => 'error',
 							'status_label' => esc_html__( 'Product sync is disabled.', 'pinterest-for-woocommerce' ),
-							'extra_info'   => wp_kses_post(
-								sprintf(
-									/* Translators: %1$s The URL of the settings page */
-									__( 'Visit the <a href="%1$s">settings</a> page to enable it.', 'pinterest-for-woocommerce' ),
-									esc_url(
-										add_query_arg(
-											array(
-												'page' => 'wc-admin',
-												'path' => '/pinterest/settings',
-											),
-											admin_url( 'admin.php' )
-										)
-									)
-								)
-							),
+							'extra_info'   => wp_kses_post( ProductSync::get_feed_status_extra_info() ),
 						),
 					),
 					'overview' => array(

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -144,6 +144,64 @@ class ProductSync {
 	}
 
 	/**
+	 * Get the proper extra_info for the feed status.
+	 *
+	 * @return string
+	 */
+	public static function get_feed_status_extra_info() {
+
+		if ( self::is_product_sync_enabled() ) {
+			return '';
+		}
+
+		if ( ! Pinterest_For_Woocommerce()::is_domain_verified() ) {
+			return sprintf(
+				/* Translators: %1$s The URL of the connection page */
+				__( 'The domain is not verified, visit the <a href="%1$s">connection</a> page to verify it.', 'pinterest-for-woocommerce' ),
+				esc_url(
+					add_query_arg(
+						array(
+							'page' => 'wc-admin',
+							'path' => '/pinterest/connection',
+						),
+						admin_url( 'admin.php' )
+					)
+				)
+			);
+		}
+
+		if ( ! Pinterest_For_Woocommerce()::is_tracking_configured() ) {
+			return sprintf(
+				/* Translators: %1$s The URL of the connection page */
+				__( 'The tracking conversions is disabled, visit the <a href="%1$s">connection</a> page to enable it.', 'pinterest-for-woocommerce' ),
+				esc_url(
+					add_query_arg(
+						array(
+							'page' => 'wc-admin',
+							'path' => '/pinterest/connection',
+						),
+						admin_url( 'admin.php' )
+					)
+				)
+			);
+		}
+
+		return sprintf(
+			/* Translators: %1$s The URL of the settings page */
+			__( 'Visit the <a href="%1$s">settings</a> page to enable it.', 'pinterest-for-woocommerce' ),
+			esc_url(
+				add_query_arg(
+					array(
+						'page' => 'wc-admin',
+						'path' => '/pinterest/settings',
+					),
+					admin_url( 'admin.php' )
+				)
+			)
+		);
+	}
+
+	/**
 	 * Handles de-registration of the feed.
 	 *
 	 * @return void

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -172,7 +172,7 @@ class ProductSync {
 
 		if ( ! Pinterest_For_Woocommerce()::is_tracking_configured() ) {
 			return sprintf(
-				/* Translators: %1$s The URL of the connection page */
+				/* translators: 1: The URL of the connection page */
 				__( 'The tracking tag is not configured, visit the <a href="%1$s">connection</a> page to configure it.', 'pinterest-for-woocommerce' ),
 				esc_url(
 					add_query_arg(
@@ -187,7 +187,7 @@ class ProductSync {
 		}
 
 		return sprintf(
-			/* Translators: %1$s The URL of the settings page */
+			/* translators: 1: The URL of the settings page */
 			__( 'Visit the <a href="%1$s">settings</a> page to enable it.', 'pinterest-for-woocommerce' ),
 			esc_url(
 				add_query_arg(

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -156,7 +156,7 @@ class ProductSync {
 
 		if ( ! Pinterest_For_Woocommerce()::is_domain_verified() ) {
 			return sprintf(
-				/* Translators: %1$s The URL of the connection page */
+				/* translators: 1: The URL of the connection page */
 				__( 'The domain is not verified, visit the <a href="%1$s">connection</a> page to verify it.', 'pinterest-for-woocommerce' ),
 				esc_url(
 					add_query_arg(

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -173,7 +173,7 @@ class ProductSync {
 		if ( ! Pinterest_For_Woocommerce()::is_tracking_configured() ) {
 			return sprintf(
 				/* Translators: %1$s The URL of the connection page */
-				__( 'The tracking tag is not configured, visit the <a href="%1$s">connection</a> page to enable it.', 'pinterest-for-woocommerce' ),
+				__( 'The tracking tag is not configured, visit the <a href="%1$s">connection</a> page to configure it.', 'pinterest-for-woocommerce' ),
 				esc_url(
 					add_query_arg(
 						array(

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -173,7 +173,7 @@ class ProductSync {
 		if ( ! Pinterest_For_Woocommerce()::is_tracking_configured() ) {
 			return sprintf(
 				/* Translators: %1$s The URL of the connection page */
-				__( 'The tracking conversions is disabled, visit the <a href="%1$s">connection</a> page to enable it.', 'pinterest-for-woocommerce' ),
+				__( 'The tracking tag is not configured, visit the <a href="%1$s">connection</a> page to enable it.', 'pinterest-for-woocommerce' ),
 				esc_url(
 					add_query_arg(
 						array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #415 .

A rollback from v1.0.9 to v1.0.8 and back to v1.0.9 breaks the site verification (since website verification is used since v1.0.9), so the user needs to re-verify the site directly on the connection tab.

The error `Product sync is disabled - Visit the settings page to enable it.` is displayed if:
- The setting Product sync is disabled.
- The domain is not verified.
- The tracking tag is not set.

However, the same error is displayed for any of the previous conditions :point_up: 
Since preventing all the possible errors with after jumping back in the versions can become difficult, it may be preferable to adjust the error message according to which condition is broken.

- Product sync is disabled -> `Product sync is disabled - Visit the settings page to enable it.`
- The domain is not verified -> `Product sync is disabled - The domain is not verified, visit the connection page to enable it.`
- The tracking tag is not set  -> `Product sync is disabled - The tracking tag is nor configured, visit the connection page to configure it.`

### Screenshots:

Previous error:
![image](https://user-images.githubusercontent.com/40774170/159992637-06bd6419-ed20-4a09-a895-b75041b74330.png)

Adjusted error:
![image](https://user-images.githubusercontent.com/40774170/180304351-2afc000c-ed88-4ee2-9df1-635f580c5c52.png)


### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. Rollback to the v1.0.8 and re-verify the site.
3. Update to a version >= 1.0.9.
4. The displayed error should ask to re-verify the site.

### Additional details:

### Changelog entry

> Fix - Display correct error if product sync is broken.
