### PR TITLE
Save settings if new value is different

### DIFF
--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -61,7 +61,9 @@ class Options extends VendorAPI {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'Missing option parameters.', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! Pinterest_For_Woocommerce()::save_settings( $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME ) ) ) {
+		$new_settings = $request->get_param( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME );
+
+		if ( Pinterest_For_Woocommerce()::get_settings() !== $new_settings && ! Pinterest_For_Woocommerce()::save_settings( $new_settings ) ) {
 			return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_options_error', esc_html__( 'There was an error saving the settings.', 'pinterest-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #477.

The `account_data` setting is updated as part of the domain verification.
The call to `save_settings` after domain verification was throwing error, since old and new values are the same. A verification of old and new values will prevent this error.

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. There should be no error after domain verification.

### Changelog entry

> Fix - Error after domain verification
