### PR TITLE
Progressive back off for merchant connect

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException as ApiException;
 use \Exception;
+use Pinterest_For_Woocommerce;
 
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -505,11 +506,21 @@ class Base {
 	 * @return mixed
 	 */
 	public static function update_or_create_merchant( $args ) {
-		return self::make_request(
+		// Get the current delay value, defaulting to 10 minutes.
+		$delay = Pinterest_For_Woocommerce::get_data( 'create_merchant_delay' ) ?? 10 * MINUTE_IN_SECONDS;
+
+		$result = self::make_request(
 			'catalogs/partner/connect/',
 			'POST',
 			$args,
+			'',
+			$delay
 		);
+
+		// Double the delay for next time, to ensure the API is called progressively less often.
+		Pinterest_For_Woocommerce::save_data( 'create_merchant_delay', $delay * 2 );
+
+		return $result;
 	}
 
 

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -163,7 +163,7 @@ class Merchants {
 	 *
 	 * This will also use a progressively lengthening delay of the transient value.
 	 *
-	 * @param array $args
+	 * @param array $args Payload array to be sent to the request.
 	 *
 	 * @return array|mixed
 	 */

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -13,9 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Pinterest\API\Base;
-use \Exception;
-use Pinterest_For_Woocommerce;
-use \Throwable;
+use Exception;
+use Throwable;
 
 /**
  * Class Handling registration & generation of the XML product feed.
@@ -141,7 +140,7 @@ class Merchants {
 		);
 
 		// The response only contains the merchant id.
-		$response = self::get_merchant_response( $args );
+		$response = Base::update_or_create_merchant( $args );
 
 		if ( 'success' !== $response['status'] ) {
 			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
@@ -158,30 +157,4 @@ class Merchants {
 		);
 	}
 
-	/**
-	 * Get the (possibly cached) response from attempting to create the merchant.
-	 *
-	 * This will also use a progressively lengthening delay of the transient value.
-	 *
-	 * @param array $args Payload array to be sent to the request.
-	 *
-	 * @return array|mixed
-	 */
-	private static function get_merchant_response( array $args ) {
-		// Get the current delay value, defaulting to 10 minutes.
-		$delay = Pinterest_For_Woocommerce::get_data( 'create_merchant_delay' ) ?? 10 * MINUTE_IN_SECONDS;
-
-		$response = get_transient( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_get_merchant_response' );
-		if ( false === $response ) {
-			$response = Base::update_or_create_merchant( $args );
-
-			// Store the response as a transient using the current delay.
-			set_transient( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_get_merchant_response', $response, $delay );
-
-			// Double the delay, to ensure the API is called progressively less often.
-			Pinterest_For_Woocommerce::save_data( 'create_merchant_delay', $delay * 2 );
-		}
-
-		return $response;
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implement progressive backing off of calling the merchant connect API

Closes #446 .

### Additional details:

This adds a caching mechanism to requests made to the `/catalogs/partner/connect/` endpoint. The cache starts off at 10 minutes, and then will double with every call to the API. 

### Changelog entry

> Tweak - Add progressive back-off for querying the merchant connect API
