### PR TITLE
Do not display Save pin button

### DIFF
--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use \Pinterest_For_Woocommerce;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,6 +23,10 @@ class SaveToPinterest {
 	 * Initiate class.
 	 */
 	public static function maybe_init() {
+
+		if ( ! Pinterest_For_Woocommerce::is_setup_complete() ) {
+			return;
+		}
 
 		if ( self::show_pin_button() ) {
 			add_action( 'woocommerce_before_single_product_summary', array( __CLASS__, 'render_product_pin' ) );

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -24,15 +24,13 @@ class SaveToPinterest {
 	 */
 	public static function maybe_init() {
 
-		if ( ! Pinterest_For_Woocommerce::is_setup_complete() ) {
+		if ( ! Pinterest_For_Woocommerce::is_setup_complete() || ! self::show_pin_button() ) {
 			return;
 		}
 
-		if ( self::show_pin_button() ) {
-			add_action( 'woocommerce_before_single_product_summary', array( __CLASS__, 'render_product_pin' ) );
-			add_action( 'woocommerce_before_shop_loop_item', array( __CLASS__, 'render_product_pin' ), 1 );
-			add_filter( 'woocommerce_blocks_product_grid_item_html', array( __CLASS__, 'add_to_wc_blocks' ), 10, 3 );
-		}
+		add_action( 'woocommerce_before_single_product_summary', array( __CLASS__, 'render_product_pin' ) );
+		add_action( 'woocommerce_before_shop_loop_item', array( __CLASS__, 'render_product_pin' ), 1 );
+		add_filter( 'woocommerce_blocks_product_grid_item_html', array( __CLASS__, 'add_to_wc_blocks' ), 10, 3 );
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #511.

Button Save to Pinterest was displayed without finishing the onboarding.

### Screenshots:

### Detailed test instructions:
1. Install the plugin and do the onboarding.
2. Make sure that the Save button setting is enabled.
3. Disconnect the account in the plugin.
4. Visit one of the product's page.
5. Save to Pinterest button should not be displayes.


### Additional details:

### Changelog entry

> Fix - Save Pin button available before finishing onboarding.
