### PR TITLE
Remove from PHP test matrix WP 5.6 and 5.7, add 5.9

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4]
-        wp-version: [5.8, latest]
+        wp-version: [5.8, 5.9, latest]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4]
-        wp-version: [5.6, 5.7, 5.8, latest]
+        wp-version: [5.8, latest]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Info

Current PHP tests are failing. The reason for that is the latest version of WooCommerce.
We only test with the latests, to be precise we test with trunk. The latest version 6.9 does not support the WP versions before WP 5.8. The 5.8 is the first version that adds the `_wp_to_kebab_case` function required by blocks plugin in the latest WooCommerce.

It would be nice to find a way to test with older than trunk versions of WooCommerce.

1. All CI tests should pass.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Remove from PHP test matrix WP 5.6 and 5.7, add 5.9
