### PR TITLE
Fix issue on prices when price exclude taxes

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -401,11 +401,18 @@ class ProductsXmlFeed {
 	private static function get_property_sale_price( $product, $property ) {
 
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_sale_price' ) ) {
-			$regular_price = $product->get_variation_regular_price();
-			$sale_price    = $product->get_variation_sale_price();
+			$regular_price = $product->get_variation_regular_price( 'min', true );
+			$sale_price    = $product->get_variation_sale_price( 'min', true );
 			$price         = $regular_price > $sale_price ? $sale_price : false;
 		} else {
-			$price = $product->get_sale_price();
+			$sale_price = $product->get_sale_price();
+
+			$price = $sale_price ? wc_get_price_to_display(
+				$product,
+				array(
+					'price' => $sale_price,
+				)
+			) : '';
 		}
 
 		if ( empty( $price ) ) {
@@ -566,7 +573,12 @@ class ProductsXmlFeed {
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
 			$price = $product->get_variation_regular_price( 'min', true );
 		} else {
-			$price = wc_get_price_to_display( $product );
+			$price = wc_get_price_to_display(
+				$product,
+				array(
+					'price' => $product->get_regular_price(),
+				)
+			);
 		}
 
 		return $price;

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -469,6 +469,26 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
 		$xml          = $price_method( $product );
 		$this->assertEquals( '<g:price>15.00USD</g:price>', $xml );
+		
+		
+		// Test if the price excludes taxes.
+		$old_tax_display_option = get_option( 'woocommerce_tax_display_shop' );
+		update_option( 'woocommerce_tax_display_shop', 'excl' );
+
+		$price_decimals_method = ( new ReflectionClass( ProductsXmlFeed::class ) )->getMethod( 'get_currency_decimals' );
+		$price_decimals_method->setAccessible( true );
+		$price_decimals = $price_decimals_method->invoke( null );
+
+		$product_price = wc_get_price_excluding_tax( 
+			$product,
+			array(
+				'price' => $product->get_regular_price(),
+			)
+		);
+		$formatted_price = wc_format_decimal( $product_price, $price_decimals );
+		$this->assertEquals( '<g:price>' . $formatted_price . get_woocommerce_currency() . '</g:price>', $xml );
+
+		update_option( 'woocommerce_tax_display_shop', $old_tax_display_option );
 
 		// Test with another currency.
 		$old_currency = get_woocommerce_currency();
@@ -503,6 +523,26 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		);
 		$xml     = $sale_price_method( $product );
 		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $xml );
+
+
+		// Test if the price excludes taxes.
+		$old_tax_display_option = get_option( 'woocommerce_tax_display_shop' );
+		update_option( 'woocommerce_tax_display_shop', 'excl' );
+
+		$price_decimals_method = ( new ReflectionClass( ProductsXmlFeed::class ) )->getMethod( 'get_currency_decimals' );
+		$price_decimals_method->setAccessible( true );
+		$price_decimals = $price_decimals_method->invoke( null );
+
+		$product_price = wc_get_price_excluding_tax( 
+			$product,
+			array(
+				'price' => $product->get_sale_price(),
+			)
+		);
+		$formatted_price = wc_format_decimal( $product_price, $price_decimals );
+		$this->assertEquals( '<sale_price>' . $formatted_price . get_woocommerce_currency() . '</sale_price>', $xml );
+	
+		update_option( 'woocommerce_tax_display_shop', $old_tax_display_option );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #544.

There was an issue getting the sale price on the feed if prices are displayed excluding taxes.

### Screenshots:

### Detailed test instructions:

1. Set WooCommerce settings: Prices inclusive of taxes (true), display prices on shop, cart and checkout (fExcluding taxes).
2. Install the plugin.
3. Wait for the feed to be generated.
4. The regular and sale prices should be the same that the ones displayed on the shop and cart.


### Additional details:

### Changelog entry

> Fix - Issue with sale price on the feed.
