### PR TITLE
Check billing status during account connection.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Pinterest as Pinterest;
+use Automattic\WooCommerce\Pinterest\Billing;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\Notes\MarketingNotifications;
 
@@ -850,6 +851,20 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			return array();
 
+		}
+
+		/**
+		 * Add billing setup information to the account data option.
+		 * Using this function makes sense only when we have a connected advertiser.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public static function add_billing_setup_info_to_account_data() {
+			$account_data                     = self::get_setting( 'account_data' );
+			$account_data['is_billing_setup'] = Billing::has_billing_set_up();
+			self::save_setting( 'account_data', $account_data );
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -835,6 +835,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					)
 				);
 
+				/*
+				 * For now we assume that the billing is not setup.
+				 * We will be able to check that only when the advertiser will be connected.
+				 * The billing is tied to advertiser.
+				 */
+				$data['is_billing_setup'] = false;
+
 				Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
 				return $data;
 			}

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -100,6 +100,9 @@ class AdvertiserConnect extends VendorAPI {
 
 		Pinterest_For_Woocommerce()::save_data( 'is_advertiser_connected', true );
 
+		// At this stage we can check if the connected advertiser has billing setup.
+		Pinterest_For_Woocommerce()::add_billing_setup_info_to_account_data();
+
 		/*
 		 * This is the last step of the connection process. We can use this moment to
 		 * track when the connection to the account was made.

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -135,6 +135,9 @@ class AdvertiserConnect extends VendorAPI {
 			}
 
 			Pinterest_For_Woocommerce()::save_data( 'is_advertiser_connected', false );
+
+			// Advertiser disconnected, clear the billing status information in the account data.
+			Pinterest_For_Woocommerce()::add_billing_setup_info_to_account_data();
 		} catch ( \Exception $e ) {
 
 			throw new \Exception( esc_html__( 'The advertiser could not be disconnected from Pinterest.', 'pinterest-for-woocommerce' ), 400 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Check connected advertiser billing status. Since the billing status is connected to the advertiser id we can only do that after advertiser gets connected. We also clear the status after advertiser disconnection.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect to pinters.
2. Check the `pinterest_for_woocommerce` option in wp_options.
3. There should be `is_billing_setup`field in that option:
 a) with value `0` when the advertiser has no billing setup
 b) with value `1` when the advertiser has billing setup ( I think that internal billing also works )


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Billing status check during advertiser conncetion.
