### PR TITLE
Fix/539 strip html rich pins

### DIFF
--- a/src/PluginHelper.php
+++ b/src/PluginHelper.php
@@ -79,4 +79,33 @@ trait PluginHelper {
 		return count( $page_parameters ) === count( array_intersect_assoc( $_GET, $page_parameters ) ); // phpcs:disable WordPress.Security.NonceVerification.Recommended
 	}
 
+	/**
+	 * Strip HTML tags from the given string.
+	 * This is intended to be used with the description field on the feed and the Rich Pins.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $string           String with HTML tags.
+	 * @param bool   $apply_shortcodes Whether to apply shortcodes or not.
+	 *
+	 * @return string
+	 */
+	protected static function strip_tags_from_string( $string, $apply_shortcodes = false ) {
+
+		if ( $apply_shortcodes ) {
+			// Apply active shortcodes.
+			$string = do_shortcode( $string );
+		} else {
+			// Strip out active shortcodes.
+			$string = strip_shortcodes( $string );
+		}
+
+		// Strip HTML tags from description.
+		$string = wp_strip_all_tags( $string );
+
+		// Strip [&hellip] character from description.
+		$string = str_replace( '[&hellip;]', '...', $string );
+
+		return $string;
+	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProductsXmlFeed {
 
+	use PluginHelper;
+
 	/**
 	 * The default data structure of the Item to be printed in the XML feed.
 	 *
@@ -256,19 +258,8 @@ class ProductsXmlFeed {
 		 * @param WC_Product $product          WooCommerce product object.
 		 */
 		$apply_shortcodes = apply_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes', false, $product );
-		if ( $apply_shortcodes ) {
-			// Apply active shortcodes.
-			$description = do_shortcode( $description );
-		} else {
-			// Strip out active shortcodes.
-			$description = strip_shortcodes( $description );
-		}
 
-		// Strip HTML tags from description.
-		$description = wp_strip_all_tags( $description );
-
-		// Strip [&hellip] character from description.
-		$description = str_replace( '[&hellip;]', '...', $description );
+		$description = self::strip_tags_from_string( $description, $apply_shortcodes );
 
 		// Limit the number of characters in the description to 10000.
 		if ( strlen( $description ) > self::DESCRIPTION_SIZE_CHARS_LIMIT ) {

--- a/src/RichPins.php
+++ b/src/RichPins.php
@@ -17,6 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class RichPins {
 
+	use PluginHelper;
+
 	/**
 	 * Output Pinterest Rich Pins metatags based on post_type and site setup.
 	 *
@@ -171,6 +173,17 @@ class RichPins {
 			if ( empty( $description ) ) {
 				$description = $product->get_description();
 			}
+
+			/**
+			 * Filters whether the shortcodes should be applied for product descriptions on the rich pins or be stripped out.
+			 *
+			 * @param bool       $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
+			 * @param WC_Product $product          WooCommerce product object.
+			 */
+			$apply_shortcodes = apply_filters( 'pinterest_for_woocommerce_rich_pins_product_description_apply_shortcodes', false, $product );
+
+			$description = self::strip_tags_from_string( $description, $apply_shortcodes );
+
 			$tags['og:description'] = $description;
 		}
 
@@ -211,8 +224,20 @@ class RichPins {
 			return $tags;
 		}
 
+		$description = get_the_excerpt();
+
+		/**
+		 * Filters whether the shortcodes should be applied for product descriptions on the rich pins or be stripped out.
+		 *
+		 * @param bool $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
+		 * @param int  The post id.
+		 */
+		$apply_shortcodes = apply_filters( 'pinterest_for_woocommerce_rich_pins_post_description_apply_shortcodes', false, get_the_ID() );
+
+		$description = self::strip_tags_from_string( $description, $apply_shortcodes );
+
 		// mandatory tags.
-		$tags['og:description'] = get_the_excerpt();
+		$tags['og:description'] = $description;
 
 		// tags enabled by setup.
 		if ( ! empty( $args['posts']['enable_publish_time'] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #539 .

The HTML from the `og:description` field on Rich Pins should be stripped.

### Screenshots:


### Detailed test instructions:

1. Install a build version of this PR and do the onboarding.
2. Make sure that the option `Add Rich Pins for Products` is set on the plugin.
3. Create a product with some HTML and shortcodes in the short description.
4. Visit the product page and check the head element: `<meta property="og:description" content="...">`.
6. The meta element should no contain any HTML or shortcode (shortcodes are stripped by default).
7. The shortcodes can be enabled using the following filters:
- On products: `pinterest_for_woocommerce_rich_pins_product_description_apply_shortcodes`
- On posts: `pinterest_for_woocommerce_rich_pins_post_description_apply_shortcodes`

### Additional details:

### Changelog entry

> Fix - Strip HTML from the Rich Pins description field.
