### PR TITLE
Add ads credit feature gate.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -260,6 +260,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Billing::class, 'schedule_event' ) );
 			add_action( 'init', array( Pinterest\AdCredits::class, 'schedule_event' ) );
 
+			// Verify that the ads_campaign is active or not.
+			add_action( 'admin_init', array( Pinterest\AdCredits::class, 'check_if_ads_campaign_is_active' ) );
+
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -118,33 +118,44 @@ class AdCredits {
 		}
 	}
 
+	/**
+	 * Check if the ads campaign option is enabled in marketing recommendations.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
 	public static function check_if_ads_campaign_is_active() {
 
 		$is_campaign_active = get_transient( self::ADS_CREDIT_CAMPAIGN_TRANSIENT );
 
-		if ( true || false === $is_campaign_active ) {
-			$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.1/recommendations.json' );
-			$recommendations = array();
-
-			if ( ! is_wp_error( $request ) && 200 === $request['response']['code'] ) {
-				$recommendations = json_decode( $request['body'], true );
-			}
-
-			foreach ( $recommendations as $recommendation ) {
-				if ( 'pinterest-for-woocommerce' === $recommendation['product'] ) {
-					$is_campaign_active = $recommendation['show_extension_promotions'] ?? false;
-					break;
-				}
-			}
-			$is_campaign_active = wc_bool_to_string( $is_campaign_active );
-			set_transient(
-				self::ADS_CREDIT_CAMPAIGN_TRANSIENT,
-				wc_bool_to_string( $is_campaign_active ),
-				empty( $recommendations ) ? 15 * MINUTE_IN_SECONDS : 12 * HOUR_IN_SECONDS
-			);
+		// If transient is available then it means that we have already checked.
+		if ( false !== $is_campaign_active ) {
+			return;
 		}
 
-		Pinterest_For_Woocommerce()->save_setting( self::ADS_CREDIT_CAMPAIGN_OPTION, wc_string_to_bool( $is_campaign_active ) );
+		$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
+		$recommendations = array();
+
+		if ( ! is_wp_error( $request ) && 200 === $request['response']['code'] ) {
+			$recommendations = json_decode( $request['body'], true );
+		}
+
+		// Find Pinterest plugin entry and check for promotions key.
+		foreach ( $recommendations as $recommendation ) {
+			if ( 'pinterest-for-woocommerce' === $recommendation['product'] ) {
+				$is_campaign_active = array_key_exists( 'show_extension_promotions', $recommendation ) ? $recommendation['show_extension_promotions'] : false;
+				break;
+			}
+		}
+
+		Pinterest_For_Woocommerce()->save_setting( self::ADS_CREDIT_CAMPAIGN_OPTION, $is_campaign_active );
+
+		set_transient(
+			self::ADS_CREDIT_CAMPAIGN_TRANSIENT,
+			wc_bool_to_string( $is_campaign_active ),
+			empty( $recommendations ) ? 15 * MINUTE_IN_SECONDS : 12 * HOUR_IN_SECONDS
+		);
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements a mechanism that allows to check if the ads campaign is active. This information is obtained from the marketing options json in woocommerce.com ( https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json ). Currently the option is not there but it will be added when the campaign will go live.

Closes #514 .

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open Marketing -> Pinterest 
2. Inspect XHR call to Pinterest settings
3. The response should look like:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/17271089/192518046-5c93343c-c0c3-410a-bbe0-212e55f3678b.png">

Notice the presence of `ads_campaign_is_active` entry.

### Additional details:

This code and option will be used by other parts of the code to determine if ads related UI elements should be shown.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
