### PR TITLE
Implement better gate feature.

### DIFF
--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -377,7 +377,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
 				'homeUrlToVerify'          => get_home_url(),
 				'storeCountry'             => $store_country,
-				'isAdsSupportedCountry'    => in_array( $store_country, Pinterest_For_Woocommerce_Ads_Supported_Countries::get_countries(), true ),
+				'isAdsSupportedCountry'    => Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country(),
 				'isConnected'              => ! empty( Pinterest_For_Woocommerce()::is_connected() ),
 				'isBusinessConnected'      => ! empty( Pinterest_For_Woocommerce()::is_business_connected() ),
 				'businessAccounts'         => Pinterest_For_Woocommerce()::get_linked_businesses(),

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -62,6 +62,18 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 				'US', // United States (US).
 			);
 		}
+
+		/**
+		 * Check if user selected location is in the list of ads supported countries.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return bool Wether this is ads supported location.
+		 */
+		public static function is_ads_supported_country() {
+			$store_country = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
+			return in_array( $store_country, self::get_countries(), true );
+		}
 	}
 
 endif;

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -141,7 +141,7 @@ class AdCredits {
 		}
 
 		$request_error = false;
-		try {		
+		try {
 			// Check if all conditions are met.
 			if (
 				Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country() &&
@@ -150,7 +150,7 @@ class AdCredits {
 			) {
 				$is_campaign_active = true;
 			}
-		} catch ( Exception $ex) {
+		} catch ( Exception $ex ) {
 			$request_error = true;
 		}
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -9,6 +9,8 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\API\Base;
+use Exception;
+use Pinterest_For_Woocommerce_Ads_Supported_Countries;
 use Throwable;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -119,7 +121,11 @@ class AdCredits {
 	}
 
 	/**
-	 * Check if the ads campaign option is enabled in marketing recommendations.
+	 * Check if the ads campaign is active. In order for that to happen the
+	 * following conditions need to be met:
+	 * 1. Merchant needs to be in ads supported country.
+	 * 2. Merchant needs to have coupon available for his chosen currency.
+	 * 3. Ads Campaign needs to be globally active.
 	 *
 	 * @since x.x.x
 	 *
@@ -134,8 +140,67 @@ class AdCredits {
 			return;
 		}
 
+		$request_error = false;
+		try {		
+			// Check if all conditions are met.
+			if (
+				Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country() &&
+				self::verify_if_coupon_exists_for_merchant() &&
+				self::get_is_campaign_active_from_recommendations()
+			) {
+				$is_campaign_active = true;
+			}
+		} catch ( Exception $ex) {
+			$request_error = true;
+		}
+
+		Pinterest_For_Woocommerce()->save_setting( self::ADS_CREDIT_CAMPAIGN_OPTION, $is_campaign_active );
+
+		/*
+		 * Try again in fifteen minutes in case we had problems fetching
+		 * the campaign status from the server, wait full day otherwise.
+		 */
+		set_transient(
+			self::ADS_CREDIT_CAMPAIGN_TRANSIENT,
+			wc_bool_to_string( $is_campaign_active ),
+			$request_error ? 15 * MINUTE_IN_SECONDS : DAY_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Verify if there is a valid coupon for user currency.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool Wether there is a coupon for merchant available.
+	 */
+	private static function verify_if_coupon_exists_for_merchant() {
+		return ! ( false === AdCreditsCoupons::has_valid_coupon_for_merchant() );
+	}
+
+	/**
+	 * Check if campaign is enabled in the recommendations API from woocommerce.com.
+	 *
+	 * @since x.x.x
+	 *
+	 * @throws Exception API fetch error.
+	 *
+	 * @return bool Wether the campaign is active or not.
+	 */
+	private static function get_is_campaign_active_from_recommendations() {
+
 		$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
 		$recommendations = array();
+
+		if ( is_wp_error( $request ) ) {
+			throw new Exception(
+				sprintf(
+					/* translators: API error message */
+					__( 'Could not fetch ads campaign status due to: %s', 'pinterest-for-woocommerce' ),
+					$request->get_error_message()
+				)
+			);
+		}
 
 		if ( ! is_wp_error( $request ) && 200 === $request['response']['code'] ) {
 			$recommendations = json_decode( $request['body'], true );
@@ -144,18 +209,11 @@ class AdCredits {
 		// Find Pinterest plugin entry and check for promotions key.
 		foreach ( $recommendations as $recommendation ) {
 			if ( 'pinterest-for-woocommerce' === $recommendation['product'] ) {
-				$is_campaign_active = array_key_exists( 'show_extension_promotions', $recommendation ) ? $recommendation['show_extension_promotions'] : false;
-				break;
+				return array_key_exists( 'show_extension_promotions', $recommendation ) ? $recommendation['show_extension_promotions'] : false;
 			}
 		}
 
-		Pinterest_For_Woocommerce()->save_setting( self::ADS_CREDIT_CAMPAIGN_OPTION, $is_campaign_active );
-
-		set_transient(
-			self::ADS_CREDIT_CAMPAIGN_TRANSIENT,
-			wc_bool_to_string( $is_campaign_active ),
-			empty( $recommendations ) ? 15 * MINUTE_IN_SECONDS : 12 * HOUR_IN_SECONDS
-		);
+		return false;
 	}
 
 }


### PR DESCRIPTION
Closes: #572 

This PR extends the gating check with:
- checking if the user is in adds supported country,
- if there is a coupon for merchants currency.

### Testing
Using this branch:
1. Open Mrketing->Pinterest
2. check `ads_campaign_is_active in the settings XHR request return value
3. Modify currency and base location to check if the value is changing 