### PR TITLE
Ads credits post onboarding redeem action.

### DIFF
--- a/assets/source/catalog-sync/components/OnboardingModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModal.js
@@ -15,7 +15,7 @@ import {
  */
 import { useSettingsSelect } from '../../setup-guide/app/helpers/effects';
 
-const OnboardingModalText = ( { isBillingSetup, didRedeemCredits } ) => {
+const OnboardingModalText = ( { isBillingSetup } ) => {
 	if ( ! isBillingSetup ) {
 		return (
 			<Text variant="body">
@@ -33,30 +33,18 @@ const OnboardingModalText = ( { isBillingSetup, didRedeemCredits } ) => {
 		);
 	}
 
-	if ( isBillingSetup && ! didRedeemCredits ) {
-		return (
-			<Text variant="body">
-				{ __(
-					'You are eligible for $125 of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
-					'pinterest-for-woocommerce'
-				) }
-				<strong>
-					{ __(
-						'spend $15 on Pinterest ads.',
-						'pinterest-for-woocommerce'
-					) }
-				</strong>
-			</Text>
-		);
-	}
-
-	// This means that billing is setup and credits redeemed.
 	return (
 		<Text variant="body">
 			{ __(
-				'$125 of ad credits has been added to your Pinterest adds account. To use credits, head over to Pinterest Ads Manager to create a new ad campaign.',
+				'You are eligible for $125 of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
 				'pinterest-for-woocommerce'
 			) }
+			<strong>
+				{ __(
+					'spend $15 on Pinterest ads.',
+					'pinterest-for-woocommerce'
+				) }
+			</strong>
 		</Text>
 	);
 };
@@ -72,7 +60,6 @@ const OnboardingModalText = ( { isBillingSetup, didRedeemCredits } ) => {
 const OnboardingModal = ( { onCloseModal } ) => {
 	const appSettings = useSettingsSelect();
 	const isBillingSetup = appSettings?.account_data?.is_billing_setup;
-	const didRedeemCredits = appSettings?.account_data?.did_redeem_credits;
 
 	return (
 		<Modal
@@ -100,12 +87,7 @@ const OnboardingModal = ( { onCloseModal } ) => {
 					'pinterest-for-woocommerce'
 				) }
 			</Text>
-			{
-				<OnboardingModalText
-					isBillingSetup={ isBillingSetup }
-					isRedeemCredit={ didRedeemCredits }
-				/>
-			}
+			<OnboardingModalText isBillingSetup={ isBillingSetup } />
 			<Text variant="caption">
 				{ __(
 					'*Ad credits may take up to 24 hours to be credited to account.',

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -929,7 +929,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public static function get_redeem_credits_info_from_account_data() {
 			$account_data = self::get_setting( 'account_data' );
 
-			return (bool) $account_data['did_redeem_credits'];
+			return (bool) $account_data['did_redeem_credits'] ?? false;
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -919,7 +919,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$offer_code   = AdCreditsCoupons::get_coupon_for_merchant();
 
 			// Redeem the coupon.
-			$redeem_status = AdCredits::redeem_credits( $offer_code );
+			$error         = false;
+			$redeem_status = AdCredits::redeem_credits( $offer_code, $error );
 
 			$redeem_information = array(
 				'redeem_status' => $redeem_status,
@@ -927,7 +928,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				'advertiser_id' => Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' ),
 				'username'      => $account_data['username'],
 				'id'            => $account_data['id'],
-				'error'         => false,
+				'error'         => $error,
 			);
 
 			$account_data['did_redeem_credits'] = $redeem_information;

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -867,7 +867,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				 * The billing is tied to advertiser.
 				 */
 				$data['is_billing_setup']   = false;
-				$data['did_redeem_credits'] = false;
+				$data['coupon_redeem_info'] = array( 'redeem_status' => false );
 
 				Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
 				return $data;
@@ -931,7 +931,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				'error'         => $error,
 			);
 
-			$account_data['did_redeem_credits'] = $redeem_information;
+			$account_data['coupon_redeem_info'] = $redeem_information;
 			self::save_setting( 'account_data', $account_data );
 		}
 
@@ -945,7 +945,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public static function check_if_coupon_was_redeemed() {
 			$account_data = self::get_setting( 'account_data' );
 
-			return is_array( $account_data['did_redeem_credits'] ) ? $account_data['did_redeem_credits']['redeem_status'] : false;
+			return is_array( $account_data['coupon_redeem_info'] ) ? $account_data['coupon_redeem_info']['redeem_status'] : false;
 		}
 
 		/**

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
+use Automattic\WooCommerce\Pinterest\AdCredits;
 use Automattic\WooCommerce\Pinterest\Utilities\Utilities;
 use \WP_REST_Server;
 use \WP_REST_Request;
@@ -102,6 +103,9 @@ class AdvertiserConnect extends VendorAPI {
 
 		// At this stage we can check if the connected advertiser has billing setup.
 		Pinterest_For_Woocommerce()::add_billing_setup_info_to_account_data();
+
+		// Try to claim coupons if they are available for the merchant.
+		AdCredits::handle_redeem_credit();
 
 		/*
 		 * This is the last step of the connection process. We can use this moment to

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -37,7 +37,7 @@ class AdCredits {
 	 * @since x.x.x
 	 */
 	public static function schedule_event() {
-		add_action( Heartbeat::DAILY, array( __CLASS__, 'handle_redeem_credit' ), 20 );
+		add_action( Heartbeat::DAILY, array( static::class, 'handle_redeem_credit' ), 20 );
 	}
 
 	/**
@@ -47,7 +47,7 @@ class AdCredits {
 	 *
 	 * @return mixed
 	 */
-	public function handle_redeem_credit() {
+	public static function handle_redeem_credit() {
 
 		if ( ! Pinterest_For_Woocommerce()::get_billing_setup_info_from_account_data() ) {
 			// Do not redeem credits if the billing is not setup.

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -24,12 +24,6 @@ class AdCredits {
 
 	const ADS_CREDIT_CAMPAIGN_TRANSIENT = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-ads-credit-campaign-transient';
 	const ADS_CREDIT_CAMPAIGN_OPTION    = 'ads_campaign_is_active';
-	/**
-	 * Hardcoded offer code as an initial approach.
-	 * TODO: Add the rest of offer codes or perhaps moving the logic to a separate class, where we can get codes by country, etc.
-	 */
-	const OFFER_CODE = 'TESTING_WOO_FUTURE';
-
 
 	/**
 	 * Initialize Ad Credits actions and Action Scheduler hooks.
@@ -74,11 +68,12 @@ class AdCredits {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param string $offer_code Coupon string.
+	 * @param string  $offer_code Coupon string.
+	 * @param integer $error reference parameter for error number.
 	 *
 	 * @return bool Weather the coupon was successfully redeemed or not.
 	 */
-	public static function redeem_credits( $offer_code ) {
+	public static function redeem_credits( $offer_code, &$error = null ) {
 
 		if ( ! Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' ) ) {
 			// Advertiser not connected, we can't check if credits were redeemed.
@@ -109,8 +104,9 @@ class AdCredits {
 
 			$offer_code_credits_data = $redeem_credits_data[ $offer_code ];
 
-			if ( ! $offer_code_credits_data->success && 2322 !== $offer_code_credits_data->error_code ) {
+			if ( ! $offer_code_credits_data->success ) {
 				Logger::log( $offer_code_credits_data->failure_reason, 'error' );
+				$error = $offer_code_credits_data->error_code;
 				return false;
 			}
 

--- a/src/AdCreditsCoupons.php
+++ b/src/AdCreditsCoupons.php
@@ -64,11 +64,13 @@ class AdCreditsCoupons {
 	);
 
 	/**
-	 * Check if there is a valid coupon for the user currency.
+	 * Get a valid coupon for merchant.
 	 *
-	 * @return string|false Coupon string or false if no coupon was found.
+	 * @since x.x.x
+	 *
+	 * @return string|false Coupon string of false if no coupon was found.
 	 */
-	public static function has_valid_coupon_for_merchant() {
+	public static function get_coupon_for_merchant() {
 		$currency = get_woocommerce_currency();
 		$coupons  = self::$currency_coupons_map[ $currency ] ?? array();
 		if ( empty( $coupons ) ) {
@@ -77,4 +79,14 @@ class AdCreditsCoupons {
 
 		return reset( $coupons );
 	}
+
+	/**
+	 * Check if there is a valid coupon for the user currency.
+	 *
+	 * @return bool Wether there is a valid coupon for the merchant.
+	 */
+	public static function has_valid_coupon_for_merchant() {
+		return self::get_coupon_for_merchant() !== false;
+	}
+
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #570 .

### Screenshots:

![image](https://user-images.githubusercontent.com/17271089/193439976-81ee434e-8ca8-4417-8e33-c4f9f6259ad4.png)


<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Start and finish the onboarding wizard.
2. Check the last XHR request to settings 
3. The `account_data


### Additional details:

In addition I have noticed that one of the flows is no longer in the designs so I have removed it:
 [Remove flow that the new design does not use.](https://github.com/woocommerce/pinterest-for-woocommerce/commit/a244d333ffd6bef214067e16302c16259dfac472)

