### PR TITLE
Ads User Switching Behavior

### DIFF
--- a/assets/source/catalog-sync/components/OnboardingModals/index.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/index.js
@@ -25,7 +25,7 @@ const OnboardingModals = ( { onCloseModal } ) => {
 	}
 
 	// Ads campaign modal no error.
-	if ( couponRedeemInfo?.error_code === false ) {
+	if ( ! couponRedeemInfo?.error_code ) {
 		return <OnboardingAdsModal onCloseModal={ onCloseModal } />;
 	}
 

--- a/assets/source/catalog-sync/helpers/effects.js
+++ b/assets/source/catalog-sync/helpers/effects.js
@@ -28,3 +28,10 @@ export const useDismissAdsNoticeDispatch = () => {
 	const { adsNoticeDismissed } = useDispatch( USER_INTERACTION_STORE_NAME );
 	return () => adsNoticeDismissed();
 };
+
+export const useResetUserInteractions = () => {
+	const { invalidateResolutionForStore } = useDispatch(
+		USER_INTERACTION_STORE_NAME
+	);
+	return () => invalidateResolutionForStore();
+};

--- a/assets/source/setup-guide/app/helpers/effects.js
+++ b/assets/source/setup-guide/app/helpers/effects.js
@@ -54,3 +54,8 @@ export const useBodyClasses = ( style ) => {
 		};
 	}, [ style ] );
 };
+
+export const useResetSettings = () => {
+	const { invalidateResolution } = useDispatch( SETTINGS_STORE_NAME );
+	return () => invalidateResolution( 'getSettings', [] );
+};

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Pinterest\Billing;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\Notes\MarketingNotifications;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
+use Automattic\WooCommerce\Pinterest\API\UserInteraction;
 
 if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
@@ -710,6 +711,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Flush the whole data option.
 			delete_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			UserInteraction::flush_options();
 
 			// Remove settings that may cause issues if stale on disconnect.
 			self::save_setting( 'account_data', null );

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
+use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Pinterest\AdCredits;
 use Automattic\WooCommerce\Pinterest\Utilities\Utilities;
 use \WP_REST_Server;
@@ -112,6 +113,9 @@ class AdvertiserConnect extends VendorAPI {
 		 * track when the connection to the account was made.
 		 */
 		Utilities::set_account_connection_timestamp();
+
+		// Reset UI state when the new advertiser is connected.
+		UserInteraction::flush_options();
 
 		return array(
 			'connected'   => $response['data']->advertiser_id,

--- a/src/API/UserInteraction.php
+++ b/src/API/UserInteraction.php
@@ -80,4 +80,12 @@ class UserInteraction extends VendorAPI {
 
 		return new WP_Error( \PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_' . self::USER_INTERACTION, esc_html__( 'Unrecognized interaction parameter', 'pinterest-for-woocommerce' ), array( 'status' => 400 ) );
 	}
+
+	/**
+	 * Flush options.
+	 */
+	public static function flush_options() {
+		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_MODAL_DISMISSED );
+		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_NOTICE_DISMISSED );
+	}
 }

--- a/src/API/UserInteraction.php
+++ b/src/API/UserInteraction.php
@@ -85,7 +85,7 @@ class UserInteraction extends VendorAPI {
 	 * Flush options.
 	 */
 	public static function flush_options() {
-		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_MODAL_DISMISSED );
-		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_NOTICE_DISMISSED );
+		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . self::ADS_MODAL_DISMISSED );
+		delete_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . self::ADS_NOTICE_DISMISSED );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #574.

Add user switching behavior

### Screenshots:

### Detailed test instructions:
1. Install a build of this PR and do the onboarding.
2. Dismiss the modal.
3. Disconnect the Pinterest account in the plugin.
4. Connect a new Pinterest account.
5. Modals should be displayed too to the new account.


### Additional details:

### Changelog entry

