### PR TITLE
Hide ads related elements if ads credits is not available

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -82,7 +82,7 @@ Clicking on an external documentation link.
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
-- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L47) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L48) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 - [TermsAndConditionsModal]( assets/source/setup-guide/app/components/TermsAndConditionsModal.js#L24)
     - with `{ link_id: 'terms-of-service', context: 'ads-credits-terms-and-conditions' }`
 	- with `{ link_id: 'privacy-policy', context: 'ads-credits-terms-and-conditions' }`
@@ -101,7 +101,7 @@ Triggered when a site is successfully verified.
 #### Emitters
 - [`ClaimWebsite`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L99)
 
-### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L222)
+### [`wcadmin_pfw_get_started_faq`](assets/source/setup-guide/app/views/LandingPageApp.js#L310)
 Clicking on getting started page faq item to collapse or expand it.
 #### Properties
 | name | type | description |
@@ -109,7 +109,7 @@ Clicking on getting started page faq item to collapse or expand it.
 `action` | `string` | `'expand' \| 'collapse'` What action was initiated.
 `question_id` | `string` | Identifier of the clicked question.
 #### Emitters
-- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#L241) whenever the FAQ is toggled.
+- [`FaqQuestion`](assets/source/setup-guide/app/views/LandingPageApp.js#326) whenever the FAQ is toggled.
 
 ### [`wcadmin_pfw_get_started_notice_link_click`](assets/source/setup-guide/app/helpers/documentation-link-props.js#L16)
 Clicking on the link inside the notice.
@@ -133,7 +133,7 @@ Closing a modal.
 `action` | `string` | `confirm` - When the final "Yes, I'm sure" button is clicked. <br> `dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
 #### Emitters
 - [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L82) with `{ name: 'account-disconnection', … }`
-- [`LandingPageApp.AdsCreditSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L136) with `{ name: 'ads-credits-terms-and-conditions', … } `
+- [`LandingPageApp.AdsCreditSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L140) with `{ name: 'ads-credits-terms-and-conditions', … } `
 - [`CatalogSync`](assets/source/catalog-sync/App.js#L37) with `{ name: 'ads-credits-onboarding', … } `
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L60 ) with `{ name: 'ads-credits-terms-and-conditions', … } `
 
@@ -146,7 +146,7 @@ Opening a modal.
 `context` | `string` | `'settings' \| 'wizard' \| 'landing-page' \| 'catalog-sync'` In which context it was used?
 #### Emitters
 - [`AccountConnection`](assets/source/setup-guide/app/components/Account/Connection.js#L82) with `{ name: 'account-disconnection', … }`
-- [`LandingPageApp.AdsCreditSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L135) with `{ name: 'ads-credits-terms-and-conditions', … } `
+- [`LandingPageApp.AdsCreditSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L140) with `{ name: 'ads-credits-terms-and-conditions', … } `
 - [`CatalogSync`](assets/source/catalog-sync/App.js#L38) with `{ name: 'ads-credits-onboarding', … } `
 - [`SetupAccount`](assets/source/setup-guide/app/steps/SetupAccount.js#L59 ) with `{ name: 'ads-credits-terms-and-conditions', … } `
 
@@ -167,7 +167,7 @@ Clicking on "… Save changes" button.
 #### Emitters
 - [`SaveSettingsButton`](assets/source/setup-guide/app/components/SaveSettingsButton.js#L42) with `{ context: view, … }`
 
-### [`wcadmin_pfw_setup`](assets/source/setup-guide/app/views/LandingPageApp.js#L28)
+### [`wcadmin_pfw_setup`](assets/source/setup-guide/app/views/LandingPageApp.js#L38)
 Triggered on events during setup,
 like starting, ending, or navigating between steps.
 #### Properties
@@ -179,7 +179,7 @@ like starting, ending, or navigating between steps.
 - [`SetupTracking`](assets/source/setup-guide/app/steps/SetupTracking.js#L54)
 	- with `{ target: 'complete', trigger: 'setup-tracking-complete' }` when "Complete setup" button is clicked.
 	- with `{ target: 'fetch-tags' | 'fetch-advertisers', trigger: 'setup-tracking-try-again' }` when "Try again" button is clicked.
-- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L47) with `{ target: 'onboarding', trigger: 'get-started' }` when "Get started" button is clicked for incomplete setup.
+- [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L53) with `{ target: 'onboarding', trigger: 'get-started' }` when "Get started" button is clicked for incomplete setup.
 - [`WizardApp`](assets/source/setup-guide/app/views/WizardApp.js#L37)
 	- with `{ target: 'setup-account' | 'claim-website' | 'setup-tracking', trigger: 'wizard-stepper' }` when wizard's header step is clicked.
 	- with `{ target: 'claim-website' , trigger: 'setup-account-continue' }` when continue button is clicked.

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -78,8 +78,6 @@ const SetupAccount = ( {
 		wcSettings.pinterest_for_woocommerce.businessAccounts
 	);
 
-	const { isAdsSupportedCountry } = wcSettings.pinterest_for_woocommerce;
-
 	const [
 		isTermsAndConditionsModalOpen,
 		setIsTermsAndConditionsModalOpen,

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -78,6 +78,8 @@ const SetupAccount = ( {
 		wcSettings.pinterest_for_woocommerce.businessAccounts
 	);
 
+	const { isAdsSupportedCountry } = wcSettings.pinterest_for_woocommerce;
+
 	const [
 		isTermsAndConditionsModalOpen,
 		setIsTermsAndConditionsModalOpen,
@@ -200,47 +202,46 @@ const SetupAccount = ( {
 							}
 						) }
 					/>
-					{ view === 'wizard' &&
-						appSettings?.ads_campaign_is_active && (
-							<>
-								<CardDivider
-									className={
-										'woocommerce-setup-guide__ad-credits__divider'
-									}
-								/>
-								<Flex
-									className={
-										'woocommerce-setup-guide__ad-credits'
-									}
-								>
-									<FlexBlock className="image-block">
-										<Icon icon={ GiftIcon } />
-									</FlexBlock>
-									<FlexBlock className="content-block">
-										<Text variant="body">
-											{ createInterpolateElement(
-												__(
-													'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
-													'pinterest-for-woocommerce'
+					{ view === 'wizard' && isAdsSupportedCountry && (
+						<>
+							<CardDivider
+								className={
+									'woocommerce-setup-guide__ad-credits__divider'
+								}
+							/>
+							<Flex
+								className={
+									'woocommerce-setup-guide__ad-credits'
+								}
+							>
+								<FlexBlock className="image-block">
+									<Icon icon={ GiftIcon } />
+								</FlexBlock>
+								<FlexBlock className="content-block">
+									<Text variant="body">
+										{ createInterpolateElement(
+											__(
+												'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
+												'pinterest-for-woocommerce'
+											),
+											{
+												a: (
+													// Disabling no-content rule - content is interpolated from above string
+													// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
+													<a
+														href={ '#' }
+														onClick={
+															openTermsAndConditionsModal
+														}
+													/>
 												),
-												{
-													a: (
-														// Disabling no-content rule - content is interpolated from above string
-														// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
-														<a
-															href={ '#' }
-															onClick={
-																openTermsAndConditionsModal
-															}
-														/>
-													),
-												}
-											) }
-										</Text>
-									</FlexBlock>
-								</Flex>
-							</>
-						) }
+											}
+										) }
+									</Text>
+								</FlexBlock>
+							</Flex>
+						</>
+					) }
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -200,46 +200,47 @@ const SetupAccount = ( {
 							}
 						) }
 					/>
-					{ view === 'wizard' && (
-						<>
-							<CardDivider
-								className={
-									'woocommerce-setup-guide__ad-credits__divider'
-								}
-							/>
-							<Flex
-								className={
-									'woocommerce-setup-guide__ad-credits'
-								}
-							>
-								<FlexBlock className="image-block">
-									<Icon icon={ GiftIcon } />
-								</FlexBlock>
-								<FlexBlock className="content-block">
-									<Text variant="body">
-										{ createInterpolateElement(
-											__(
-												'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
-												'pinterest-for-woocommerce'
-											),
-											{
-												a: (
-													// Disabling no-content rule - content is interpolated from above string
-													// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
-													<a
-														href={ '#' }
-														onClick={
-															openTermsAndConditionsModal
-														}
-													/>
+					{ view === 'wizard' &&
+						appSettings?.ads_campaign_is_active && (
+							<>
+								<CardDivider
+									className={
+										'woocommerce-setup-guide__ad-credits__divider'
+									}
+								/>
+								<Flex
+									className={
+										'woocommerce-setup-guide__ad-credits'
+									}
+								>
+									<FlexBlock className="image-block">
+										<Icon icon={ GiftIcon } />
+									</FlexBlock>
+									<FlexBlock className="content-block">
+										<Text variant="body">
+											{ createInterpolateElement(
+												__(
+													'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
+													'pinterest-for-woocommerce'
 												),
-											}
-										) }
-									</Text>
-								</FlexBlock>
-							</Flex>
-						</>
-					) }
+												{
+													a: (
+														// Disabling no-content rule - content is interpolated from above string
+														// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
+														<a
+															href={ '#' }
+															onClick={
+																openTermsAndConditionsModal
+															}
+														/>
+													),
+												}
+											) }
+										</Text>
+									</FlexBlock>
+								</Flex>
+							</>
+						) }
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>

--- a/assets/source/setup-guide/app/steps/SetupAccount.js
+++ b/assets/source/setup-guide/app/steps/SetupAccount.js
@@ -202,46 +202,47 @@ const SetupAccount = ( {
 							}
 						) }
 					/>
-					{ view === 'wizard' && isAdsSupportedCountry && (
-						<>
-							<CardDivider
-								className={
-									'woocommerce-setup-guide__ad-credits__divider'
-								}
-							/>
-							<Flex
-								className={
-									'woocommerce-setup-guide__ad-credits'
-								}
-							>
-								<FlexBlock className="image-block">
-									<Icon icon={ GiftIcon } />
-								</FlexBlock>
-								<FlexBlock className="content-block">
-									<Text variant="body">
-										{ createInterpolateElement(
-											__(
-												'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
-												'pinterest-for-woocommerce'
-											),
-											{
-												a: (
-													// Disabling no-content rule - content is interpolated from above string
-													// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
-													<a
-														href={ '#' }
-														onClick={
-															openTermsAndConditionsModal
-														}
-													/>
+					{ view === 'wizard' &&
+						appSettings?.ads_campaign_is_active && (
+							<>
+								<CardDivider
+									className={
+										'woocommerce-setup-guide__ad-credits__divider'
+									}
+								/>
+								<Flex
+									className={
+										'woocommerce-setup-guide__ad-credits'
+									}
+								>
+									<FlexBlock className="image-block">
+										<Icon icon={ GiftIcon } />
+									</FlexBlock>
+									<FlexBlock className="content-block">
+										<Text variant="body">
+											{ createInterpolateElement(
+												__(
+													'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Terms and conditions</a> apply.',
+													'pinterest-for-woocommerce'
 												),
-											}
-										) }
-									</Text>
-								</FlexBlock>
-							</Flex>
-						</>
-					) }
+												{
+													a: (
+														// Disabling no-content rule - content is interpolated from above string
+														// eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
+														<a
+															href={ '#' }
+															onClick={
+																openTermsAndConditionsModal
+															}
+														/>
+													),
+												}
+											) }
+										</Text>
+									</FlexBlock>
+								</Flex>
+							</>
+						) }
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -27,6 +27,7 @@ import AdsCreditsTermsAndConditionsModal from '../components/TermsAndConditionsM
 import PrelaunchNotice from '../../../components/prelaunch-notice';
 import documentationLinkProps from '../helpers/documentation-link-props';
 import UnsupportedCountryNotice from '../components/UnsupportedCountryNotice';
+import { useSettingsSelect } from '../helpers/effects';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
 
@@ -356,6 +357,8 @@ const LandingPageApp = () => {
 		<PrelaunchNotice />
 	) : null;
 
+	const adsCampaignIsActive = useSettingsSelect()?.ads_campaign_is_active;
+
 	return (
 		<>
 			{ prelaunchNotice }
@@ -364,7 +367,7 @@ const LandingPageApp = () => {
 					<UnsupportedCountryNotice countryCode={ storeCountry } />
 				) }
 				<WelcomeSection />
-				<AdsCreditSection />
+				{ adsCampaignIsActive && <AdsCreditSection /> }
 				<FeaturesSection />
 				<FaqSection />
 			</div>

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -357,8 +357,6 @@ const LandingPageApp = () => {
 		<PrelaunchNotice />
 	) : null;
 
-	const adsCampaignIsActive = useSettingsSelect()?.ads_campaign_is_active;
-
 	return (
 		<>
 			{ prelaunchNotice }
@@ -367,7 +365,7 @@ const LandingPageApp = () => {
 					<UnsupportedCountryNotice countryCode={ storeCountry } />
 				) }
 				<WelcomeSection />
-				{ adsCampaignIsActive && <AdsCreditSection /> }
+				{ isAdsSupportedCountry && <AdsCreditSection /> }
 				<FeaturesSection />
 				<FaqSection />
 			</div>

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -27,7 +27,6 @@ import AdsCreditsTermsAndConditionsModal from '../components/TermsAndConditionsM
 import PrelaunchNotice from '../../../components/prelaunch-notice';
 import documentationLinkProps from '../helpers/documentation-link-props';
 import UnsupportedCountryNotice from '../components/UnsupportedCountryNotice';
-import { useSettingsSelect } from '../helpers/effects';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
 

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -27,6 +27,7 @@ import AdsCreditsTermsAndConditionsModal from '../components/TermsAndConditionsM
 import PrelaunchNotice from '../../../components/prelaunch-notice';
 import documentationLinkProps from '../helpers/documentation-link-props';
 import UnsupportedCountryNotice from '../components/UnsupportedCountryNotice';
+import { useSettingsSelect } from '../helpers/effects';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
 
@@ -351,6 +352,8 @@ const LandingPageApp = () => {
 		storeCountry,
 	} = wcSettings.pinterest_for_woocommerce;
 
+	const adsCampaignIsActive = useSettingsSelect()?.ads_campaign_is_active;
+
 	// Only show the pre-launch beta notice if the plugin version is a beta.
 	const prelaunchNotice = pluginVersion.includes( 'beta' ) ? (
 		<PrelaunchNotice />
@@ -364,7 +367,7 @@ const LandingPageApp = () => {
 					<UnsupportedCountryNotice countryCode={ storeCountry } />
 				) }
 				<WelcomeSection />
-				{ isAdsSupportedCountry && <AdsCreditSection /> }
+				{ adsCampaignIsActive && <AdsCreditSection /> }
 				<FeaturesSection />
 				<FaqSection />
 			</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #577

Hide Ads features components if the Ads campaign is not available for current merchant.

### Screenshots:

### Detailed test instructions:
1. Install a build of this PR.
2. Connect a merchant with no available ads feature.
3. The ads features components should not be displayed.


### Additional details

### Changelog entry
