### PR TITLE
Decouple check of credits from campaign ads

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -923,7 +923,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$error_message = '';
 			$redeem_status = AdCredits::redeem_credits( $offer_code, $error_code, $error_message );
 
-			$redeem_information = array(
+			$redeem_information                 = array(
 				'redeem_status' => $redeem_status,
 				'offer_code'    => $offer_code,
 				'advertiser_id' => Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' ),
@@ -934,9 +934,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			);
 			$account_data['coupon_redeem_info'] = $redeem_information;
 
+			self::save_setting( 'account_data', $account_data );
+		}
+
+		/**
+		 * Add available credits information to the account data option.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public static function add_available_credits_info_to_account_data() {
+			$account_data = self::get_setting( 'account_data' );
+
 			// Check for available discounts.
-			$available_discounts                 = AdCredits::process_available_discounts();
-			$account_data['available_discounts'] = $available_discounts;
+			$account_data['available_discounts'] = AdCredits::process_available_discounts();
 
 			self::save_setting( 'account_data', $account_data );
 		}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -923,7 +923,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$error_message = '';
 			$redeem_status = AdCredits::redeem_credits( $offer_code, $error_code, $error_message );
 
-			$redeem_information                 = array(
+			$redeem_information = array(
 				'redeem_status' => $redeem_status,
 				'offer_code'    => $offer_code,
 				'advertiser_id' => Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' ),
@@ -932,6 +932,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				'error_id'      => $error_code,
 				'error_message' => $error_message,
 			);
+
 			$account_data['coupon_redeem_info'] = $redeem_information;
 
 			self::save_setting( 'account_data', $account_data );

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -46,6 +46,8 @@ class AdCredits {
 	 */
 	public static function handle_redeem_credit() {
 
+		Pinterest_For_Woocommerce()::add_available_credits_info_to_account_data();
+
 		if ( ! Pinterest_For_Woocommerce()::get_billing_setup_info_from_account_data() ) {
 			// Do not redeem credits if the billing is not setup.
 			return true;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #588.

The available credits are not attached to the ads campaign feature.

### Screenshots:


### Detailed test instructions:
1. Install a build of this PR and do the onboarding.
2. The ads available credits should be displayed even if campaign is not supported.

### Additional details:

### Changelog entry

