### PR TITLE
Cast settings to array to prevent fatal errors

### DIFF
--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -71,7 +71,7 @@ class TrackerSnapshot {
 	 */
 	protected static function parse_settings(): array {
 
-		$settings = Pinterest_For_Woocommerce::get_settings( true );
+		$settings = (array) Pinterest_For_Woocommerce()::get_settings( true );
 
 		$tracked_settings = array(
 			'track_conversions',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #594.

Cast the settings to array to prevent fatal errors on `TrackerSnapshot` class.

### Screenshots:


### Detailed test instructions:

### Additional details:

### Changelog entry

