### PR TITLE
Ads open T&C modal Links in a new tab.

### DIFF
--- a/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
+++ b/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Link } from '@woocommerce/components';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Modal,
@@ -64,7 +63,8 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 				),
 				{
 					link: (
-						<Link
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- context passed via documentationLinkProps
+						<a
 							{ ...documentationLinkProps( {
 								href: tosHref,
 								linkId: 'terms-of-service',
@@ -81,7 +81,8 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 				),
 				{
 					link: (
-						<Link
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- context passed via documentationLinkProps
+						<a
 							{ ...documentationLinkProps( {
 								href: privacyPolicyHref,
 								linkId: 'privacy-policy',
@@ -98,7 +99,8 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 				),
 				{
 					link: (
-						<Link
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- context passed via documentationLinkProps
+						<a
 							{ ...documentationLinkProps( {
 								href: advertisingServicesAgreementHref,
 								linkId: 'advertising-services-agreement',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #595 .

Use <a/> instead of <Link/> and add `target=_blank`.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check #595 for instructions.
