### PR TITLE
Do not count inactive credits

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -639,13 +639,9 @@ class Base {
 	 * @return mixed
 	 */
 	public static function get_available_discounts( $advertiser_id ) {
-		return self::make_request(
-			"advertisers/{$advertiser_id}/discounts",
-			'GET',
-			array(
-				'active' => true,
-			),
-			'ads'
-		);
+		$request_url = "advertisers/{$advertiser_id}/discounts";
+		$request_url = add_query_arg( 'active', 'true', $request_url );
+
+		return self::make_request( $request_url, 'GET', array(), 'ads' );
 	}
 }

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -639,6 +639,13 @@ class Base {
 	 * @return mixed
 	 */
 	public static function get_available_discounts( $advertiser_id ) {
-		return self::make_request( "advertisers/{$advertiser_id}/discounts", 'GET', array(), 'ads' );
+		return self::make_request(
+			"advertisers/{$advertiser_id}/discounts",
+			'GET',
+			array(
+				'active' => true,
+			),
+			'ads'
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #601

Get only the available active credits.

### Screenshots:

### Detailed test instructions:
1. Install a build of this PR.
2. Do the onboarding with an advertiser with active and inactive credits.
3. The available credits should only contain the active credits.


### Additional details:

### Changelog entry

