### PR TITLE
Sum up all available active coupons.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -280,6 +280,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Init marketing notifications.
 			add_action( Heartbeat::DAILY, array( $this, 'init_marketing_notifications' ) );
 
+			// Check available coupons and credits.
+			add_action( Heartbeat::HOURLY, array( $this, 'check_available_coupons_and_credits' ) );
+
 		}
 
 
@@ -979,10 +982,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public static function add_available_credits_info_to_account_data() {
 			$account_data = self::get_setting( 'account_data' );
 
-			// Check for available discounts.
-			$account_data['available_discounts'] = AdCredits::process_available_discounts();
-
-			self::save_setting( 'account_data', $account_data );
+			try {
+				// Check for available discounts.
+				$account_data['available_discounts'] = AdCredits::process_available_discounts();
+				self::save_setting( 'account_data', $account_data );
+			} catch ( Exception $e ) {
+				return;
+			}
 		}
 
 		/**
@@ -1120,6 +1126,16 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			}
 		}
 
+		/**
+		 * Trigger coupons check.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public function check_available_coupons_and_credits() {
+			Pinterest_For_Woocommerce()::add_available_credits_info_to_account_data();
+		}
 
 		/**
 		 * Checks if setup is completed and all requirements are set.

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -248,15 +248,26 @@ class AdCredits {
 
 		$discounts = (array) $result['data'];
 
+		$coupon = AdCreditsCoupons::get_coupon_for_merchant();
+
 		$found_discounts = array();
 		if ( array_key_exists( self::ADS_CREDIT_FUTURE_DISCOUNT, $discounts ) ) {
-			$found_discounts['future_discount'] = true;
+			foreach ( $discounts[ self::ADS_CREDIT_FUTURE_DISCOUNT ] as $future_discount ) {
+				$discount_information = (array) $future_discount;
+				if ( $discount_information['offer_code'] === $coupon ) {
+					$found_discounts['future_discount'] = true;
+				}
+			}
 		}
 
+		$remaining_discount_value = 0;
 		if ( array_key_exists( self::ADS_CREDIT_MARKETING_OFFER, $discounts ) ) {
-			// We only look at the first available field. For now we have no plans to handle more fields.
-			$discount_information               = (array) reset( $discounts[ self::ADS_CREDIT_MARKETING_OFFER ] );
-			$remaining_discount_value           = ( (float) $discount_information['remaining_discount_in_micro_currency'] ) / 1000000;
+			// Sum all of the available coupons values.
+			foreach ( $discounts[ self::ADS_CREDIT_MARKETING_OFFER ] as $discount ) {
+				$discount_information      = (array) $discount;
+				$remaining_discount_value += ( (float) $discount_information['remaining_discount_in_micro_currency'] ) / 1000000;
+			}
+
 			$found_discounts['marketing_offer'] = array(
 				'remaining_discount' => wc_price( $remaining_discount_value ),
 			);

--- a/src/Heartbeat.php
+++ b/src/Heartbeat.php
@@ -25,7 +25,8 @@ class Heartbeat {
 	/**
 	 * Hook name for daily heartbeat.
 	 */
-	const DAILY = 'pinterest_for_woocommerce_daily_heartbeat';
+	const DAILY  = 'pinterest_for_woocommerce_daily_heartbeat';
+	const HOURLY = 'pinterest_for_woocommerce_hourly_heartbeat';
 
 	/**
 	 * WooCommerce Queue Interface.
@@ -59,6 +60,10 @@ class Heartbeat {
 	public function schedule_events() {
 		if ( null === $this->queue->get_next( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
 			$this->queue->schedule_recurring( time(), DAY_IN_SECONDS, self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		}
+
+		if ( null === $this->queue->get_next( self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+			$this->queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}
 	}
 

--- a/src/Heartbeat.php
+++ b/src/Heartbeat.php
@@ -58,12 +58,12 @@ class Heartbeat {
 	 * @since 1.1.0
 	 */
 	public function schedule_events() {
-		if ( null === $this->queue->get_next( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
-			$this->queue->schedule_recurring( time(), DAY_IN_SECONDS, self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( ! as_has_scheduled_action( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+			as_schedule_recurring_action( time(), DAY_IN_SECONDS, self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}
 
-		if ( null === $this->queue->get_next( self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
-			$this->queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( ! as_has_scheduled_action( self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+			as_schedule_recurring_action( time(), HOUR_IN_SECONDS, self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #608 .

Loop over all coupons:
- Add available credits value.
- Detect future coupon in all of the coupons, don't assume that the first one is correct.
- Bonus: fix action scheduler usage.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Have a user with multiple available coupons
2. Check that the value in UI matches the sum of the coupons.
3. Have a user with future coupons ( non matching the plugin offer ) plugin should not pick it up.
