### PR TITLE
Back off mechanism for create merchant

### DIFF
--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -145,7 +145,7 @@ class Merchants {
 		$cache_key = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_request_' . md5( wp_json_encode( $args ) );
 		$cache     = get_transient( $cache_key );
 
-		if ( ! $cache ) {
+		if ( false !== $cache ) {
 			return $cache;
 		}
 

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -153,7 +153,7 @@ class Merchants {
 			// The response only contains the merchant id.
 			$response = Base::update_or_create_merchant( $args );
 		} catch ( Throwable $th ) {
-			$delay = Pinterest_For_Woocommerce()::get_data( 'create_merchant_delay' ) ?? 10 * MINUTE_IN_SECONDS;
+			$delay = Pinterest_For_Woocommerce()::get_data( 'create_merchant_delay' ) ?? MINUTE_IN_SECONDS;
 
 			set_transient( $cache_key, $th->getCode(), $delay );
 

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -110,7 +110,7 @@ class Merchants {
 		$advertiser = reset( $advertisers['data'] ); // All advertisers assigned to a user share the same merchant_id.
 
 		if ( empty( $advertiser->merchant_id ) ) {
-			throw new Exception( __( 'No merchant returned in the advertiser\'s response.', 'pinterest-for-woocommerce' ), 404 );
+			throw new Exception( __( "No merchant returned in the advertiser's response.", 'pinterest-for-woocommerce' ), 404 );
 		}
 
 		return $advertiser->merchant_id;

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -146,7 +146,7 @@ class Merchants {
 		$cache     = get_transient( $cache_key );
 
 		if ( false !== $cache ) {
-			return $cache;
+			throw new Exception( __( 'There was a previous error trying to create or update merchant.', 'pinterest-for-woocommerce' ), (int) $cache );
 		}
 
 		try {
@@ -155,10 +155,10 @@ class Merchants {
 		} catch ( Throwable $th ) {
 			$delay = Pinterest_For_Woocommerce()::get_data( 'create_merchant_delay' ) ?? 10 * MINUTE_IN_SECONDS;
 
-			set_transient( $cache_key, $response, $delay );
+			set_transient( $cache_key, $th->getCode(), $delay );
 
 			// Double the delay.
-			Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', $delay * 2 );
+			Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', max( $delay * 2, 6 * HOUR_IN_SECONDS ) );
 
 			throw new Exception( $th->getMessage(), $th->getCode() );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #446.

Follow up of the PR #512.
Implement progressive backing off of calling the merchant connect API.

### Additional details:
This adds a caching mechanism to requests made to the /catalogs/partner/connect/ endpoint. The cache starts off at 10 minutes, and then will double with every call to the API.

### Changelog entry

> Tweak - Backoff merchant creation in case of failure.
