### PR TITLE
Add redeemed by another ad error case

### DIFF
--- a/assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js
@@ -24,6 +24,7 @@ import { useSettingsSelect } from '../../../setup-guide/app/helpers/effects';
  */
 const OnboardingErrorModal = ( { onCloseModal } ) => {
 	const ALREADY_REDEEMED_ERROR = 2322;
+	const DIFFERENT_ADVERTISER_ALREADY_REDEEMED_ERROR = 2318;
 	const OFFER_EXPIRED_ERROR = 2319;
 	const NOT_AVAILABLE_IN_COUNTRY_OR_CURRENCY_ERROR = 2327;
 	const WRONG_BILLING_PROFILE_ERROR = 2006;
@@ -35,7 +36,15 @@ const OnboardingErrorModal = ( { onCloseModal } ) => {
 	switch ( couponRedeemInfo?.error_code ) {
 		case ALREADY_REDEEMED_ERROR:
 			errorMessageText = __(
-				'Advertiser already has a redeemed offer',
+				'Advertiser already has a redeemed offer.',
+				'pinterest-for-woocommerce'
+			);
+
+			break;
+
+		case DIFFERENT_ADVERTISER_ALREADY_REDEEMED_ERROR:
+			errorMessageText = __(
+				'The merchant already redeemed the offer on another advertiser.',
 				'pinterest-for-woocommerce'
 			);
 

--- a/assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js
@@ -33,7 +33,7 @@ const OnboardingErrorModal = ( { onCloseModal } ) => {
 		?.coupon_redeem_info;
 
 	let errorMessageText = '';
-	switch ( couponRedeemInfo?.error_code ) {
+	switch ( couponRedeemInfo?.error_id ) {
 		case ALREADY_REDEEMED_ERROR:
 			errorMessageText = __(
 				'Advertiser already has a redeemed offer.',

--- a/assets/source/catalog-sync/components/OnboardingModals/index.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/index.js
@@ -25,7 +25,7 @@ const OnboardingModals = ( { onCloseModal } ) => {
 	}
 
 	// Ads campaign modal no error.
-	if ( ! couponRedeemInfo?.error_code ) {
+	if ( ! couponRedeemInfo?.error_id ) {
 		return <OnboardingAdsModal onCloseModal={ onCloseModal } />;
 	}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -910,8 +910,14 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function maybe_check_billing_setup() {
+			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
+			$has_billing_setup_old = is_array( $account_data ) && $account_data['is_billing_setup'] ?? false;
 			if ( Billing::should_check_billing_setup_often() ) {
-				self::add_billing_setup_info_to_account_data();
+				$has_billing_setup_new = self::add_billing_setup_info_to_account_data();
+				// Detect change in billing setup to true and try to redeem.
+				if ( $has_billing_setup_new && ! $has_billing_setup_old ) {
+					AdCredits::handle_redeem_credit();
+				}
 			}
 		}
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -105,15 +105,13 @@ class AdCredits {
 				return false;
 			}
 
-			$redeem_credits_data = (array) $result['data'];
-
-			if ( ! isset( $redeem_credits_data[ $offer_code ] ) ) {
+			$redeem_credits_data     = (array) $result['data'];
+			$offer_code_credits_data = reset( $redeem_credits_data );
+			if ( false === $offer_code_credits_data ) {
 				// No data for the requested offer code.
 				Logger::log( __( 'There is no available data for the requested offer code.', 'pinterest-for-woocommerce' ) );
 				return false;
 			}
-
-			$offer_code_credits_data = $redeem_credits_data[ $offer_code ];
 
 			if ( ! $offer_code_credits_data->success ) {
 				Logger::log( $offer_code_credits_data->failure_reason, 'error' );

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -105,17 +105,11 @@ class AdCredits {
 				return false;
 			}
 
-			$redeem_credits_data = (array) $result['data'];
-
-			if ( ! isset( $redeem_credits_data[ $offer_code ] ) ) {
+			$redeem_credits_data     = (array) $result['data'];
+			$offer_code_credits_data = reset( $redeem_credits_data );
+			if ( false === $offer_code_credits_data ) {
 				// No data for the requested offer code.
 				Logger::log( __( 'There is no available data for the requested offer code.', 'pinterest-for-woocommerce' ) );
-				return false;
-			}
-
-			$offer_code_credits_data = reset( $redeem_credits_data );
-
-			if ( false === $offer_code_credits_data ) {
 				return false;
 			}
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -34,7 +34,7 @@ class AdCredits {
 	 * @since x.x.x
 	 */
 	public static function schedule_event() {
-		add_action( Heartbeat::DAILY, array( static::class, 'handle_redeem_credit' ), 20 );
+		add_action( Heartbeat::HOURLY, array( static::class, 'handle_redeem_credit' ), 20 );
 	}
 
 	/**
@@ -113,7 +113,11 @@ class AdCredits {
 				return false;
 			}
 
-			$offer_code_credits_data = $redeem_credits_data[ $offer_code ];
+			$offer_code_credits_data = reset( $redeem_credits_data );
+
+			if ( false === $offer_code_credits_data ) {
+				return false;
+			}
 
 			if ( ! $offer_code_credits_data->success ) {
 				Logger::log( $offer_code_credits_data->failure_reason, 'error' );
@@ -192,7 +196,7 @@ class AdCredits {
 	 * @return bool Wether the campaign is active or not.
 	 */
 	private static function get_is_campaign_active_from_recommendations() {
-
+		return true;
 		$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
 		$recommendations = array();
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -196,7 +196,6 @@ class AdCredits {
 	 * @return bool Wether the campaign is active or not.
 	 */
 	private static function get_is_campaign_active_from_recommendations() {
-		return true;
 		$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
 		$recommendations = array();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #607.

Add error case when the offer code was already redeemed by another user's advertiser.


### Detailed test instructions:
1. Create 2 Pinterest advertisers with the same user.
2. Connect to an advertiser and redeem the offer code.
3. Disconnect.
4. Connect to a second advertiser.
5. The error modal should display that the offer code was already redeemed by another user's advertiser.
