### PR TITLE
Hide banner in case of redeem error.

### DIFF
--- a/assets/source/catalog-sync/App.js
+++ b/assets/source/catalog-sync/App.js
@@ -46,6 +46,9 @@ import { useSettingsSelect } from '../setup-guide/app/helpers/effects';
 const CatalogSyncApp = () => {
 	const adsCampaignIsActive = useSettingsSelect()?.ads_campaign_is_active;
 
+	const couponRedeemErrorID = useSettingsSelect()?.account_data
+		?.coupon_redeem_info?.error_id;
+
 	useCreateNotice( wcSettings.pinterest_for_woocommerce.error );
 	const [ isOnboardingModalOpen, setIsOnboardingModalOpen ] = useState(
 		false
@@ -85,8 +88,19 @@ const CatalogSyncApp = () => {
 			return;
 		}
 
+		if (
+			couponRedeemErrorID !== undefined &&
+			couponRedeemErrorID !== 2322
+		) {
+			return;
+		}
+
 		setIsAdCreditsNoticeOpen( true );
-	}, [ userInteractions?.ads_notice_dismissed, userInteractionsLoaded ] );
+	}, [
+		userInteractions?.ads_notice_dismissed,
+		userInteractionsLoaded,
+		couponRedeemErrorID,
+	] );
 
 	const closeOnboardingModal = () => {
 		setIsOnboardingModalOpen( false );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hide banner in case redeem error happens.
Show only in case `already redeemed` ( with the same advertiser ) error.

Closes #617 .

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check #617 for testing instructions.


