### PR TITLE
Update Tracking.php

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -350,8 +350,15 @@ JS;
 	 */
 	private static function tracking_enabled() {
 		
-		if ( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) ) {
-		  return false; 
+		/**
+		 * Allow third party plugins to disable the tracking pixel. 
+		 *
+		 * @since 1.2.6
+		 *
+		 * @param bool $is_disable Tracking is enabled if false, and disabled if true.
+		 */
+		if ( apply_filters('woocommerce_pinterest_disable_tracking', false) ) {
+			return false;
 		}
 
 		if ( ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' ) || ! self::get_active_tag() ) {

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -349,6 +349,10 @@ JS;
 	 * @return boolean
 	 */
 	private static function tracking_enabled() {
+		
+		if ( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) ) {
+		  return false; 
+		}
 
 		if ( ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' ) || ! self::get_active_tag() ) {
 			return false;

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -349,15 +349,15 @@ JS;
 	 * @return boolean
 	 */
 	private static function tracking_enabled() {
-		
+
 		/**
-		 * Allow third party plugins to disable the tracking pixel. 
+		 * Allow third party plugins to disable the tracking pixel.
 		 *
 		 * @since 1.2.6
 		 *
 		 * @param bool $is_disable Tracking is enabled if false, and disabled if true.
 		 */
-		if ( apply_filters('woocommerce_pinterest_disable_tracking', false) ) {
+		if ( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I am the developer of the [Pixel Manager for WooCommerce](https://wordpress.org/plugins/woocommerce-google-adwords-conversion-tracking-tag/). The Pixel Manager pro version also offers event tracking for Pinterest. 

We have customers who want to use the Pinterest for WooCommerce plugin and the Pixel Manager for WooCommerce together. So essentially, they need Pinterest for WooCommerce for the feed and pins and the Pixel Manager for WooCommerce to handle the tracking (which has a few advantages over using the native implementation of Pinterest for WooCommerce. Let me know if you need more details on that.). 

In such a case, it would be great to have a filter in the Pinterest for WooCommerce plugin, which the Pixel Manager can use to disable the Pinterest for WooCommerce event tracking and take over. The filter will only be used if tracking for Pinterest gets enabled in the Pixel Manager. 

This pull request adds such a filter to the Pinterest for WooCommerce plugin.  