### PR TITLE
Implement 426,  Pull ads supported countries from the api.

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -6,6 +6,8 @@
  * @since 1.0.5
  */
 
+use  Automattic\WooCommerce\Pinterest\API\Base;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -25,42 +27,59 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 		 * @return string[]
 		 */
 		public static function get_countries() {
-			return array(
-				'AR', // Argentina.
-				'AU', // Australia.
-				'AT', // Austria.
-				'BE', // Belgium.
-				'BR', // Brazil.
-				'CA', // Canada.
-				'CL', // Chile.
-				'CO', // Colombia.
-				'CY', // Cyprus.
-				'CZ', // Czech Republic.
-				'DK', // Denmark.
-				'FI', // Finland.
-				'FR', // France.
-				'DE', // Germany.
-				'GR', // Greece.
-				'HU', // Hungary.
-				'IE', // Ireland.
-				'IT', // Italy.
-				'JP', // Japan.
-				'LU', // Luxembourg.
-				'MT', // Malta.
-				'MX', // Mexico.
-				'NL', // Netherlands.
-				'NZ', // New Zealand.
-				'NO', // Norway.
-				'PL', // Poland.
-				'PT', // Portugal.
-				'RO', // Romania.
-				'SK', // Slovakia.
-				'ES', // Spain.
-				'SE', // Sweden.
-				'CH', // Switzerland.
-				'GB', // United Kingdom (UK).
-				'US', // United States (US).
-			);
+			try {
+
+				$allowed_countries = Base::get_list_of_ads_supported_countries();
+				$get_country_code  = function( $country_object ) {
+					return $country_object->code;
+				};
+
+				// Extract codes.
+				$allowed_countries_codes = array_map(
+					$get_country_code,
+					$allowed_countries['data'],
+				);
+
+				return $allowed_countries_codes;
+			} catch ( \Exception $th ) {
+				// A fallback in case of error.
+				return array(
+					'AR', // Argentina.
+					'AU', // Australia.
+					'AT', // Austria.
+					'BE', // Belgium.
+					'BR', // Brazil.
+					'CA', // Canada.
+					'CL', // Chile.
+					'CO', // Colombia.
+					'CY', // Cyprus.
+					'CZ', // Czech Republic.
+					'DK', // Denmark.
+					'FI', // Finland.
+					'FR', // France.
+					'DE', // Germany.
+					'GR', // Greece.
+					'HU', // Hungary.
+					'IE', // Ireland.
+					'IT', // Italy.
+					'JP', // Japan.
+					'LU', // Luxembourg.
+					'MT', // Malta.
+					'MX', // Mexico.
+					'NL', // Netherlands.
+					'NZ', // New Zealand.
+					'NO', // Norway.
+					'PL', // Poland.
+					'PT', // Portugal.
+					'RO', // Romania.
+					'SK', // Slovakia.
+					'ES', // Spain.
+					'SE', // Sweden.
+					'CH', // Switzerland.
+					'GB', // United Kingdom (UK).
+					'US', // United States (US).
+				);
+			}
 		}
 
 		/**

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -650,7 +650,7 @@ class Base {
 	 *
 	 * @since x.x.x
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public static function get_list_of_ads_supported_countries() {
 		$request_url = 'advertisers/countries';

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -644,4 +644,16 @@ class Base {
 
 		return self::make_request( $request_url, 'GET', array(), 'ads' );
 	}
+
+	/**
+	 * Pull ads supported countries information from the API.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return mixed
+	 */
+	public static function get_list_of_ads_supported_countries() {
+		$request_url = 'advertisers/countries';
+		return self::make_request( $request_url, 'GET', array(), 'ads', DAY_IN_SECONDS );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use `advertiser/countries` API endpoint to fetch the supported ads countries.

Closes #426  .

When countries list is requested fetch the countries from the API endpoint. Process the results to generate countries code array. In case of error return a fallback array. The API results are cached for `DAY_IN_SECONDS` to reduce the servers load.

### Screenshots:

<img width="354" alt="image" src="https://user-images.githubusercontent.com/17271089/201516607-26841f39-c338-444c-b028-af985fe78584.png">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set a breakpoint on the API fetch
2. Check that the response is being processed and that resulting array is similar to the fallback ( number of items may be different )


### Additional details:

The following country codes are available in the API and are not used currently by the plugin: KR, IL, HK, SG.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Pull supported countries from the API.
