### PR TITLE
Add promo information to the readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,10 @@ Pinterest gives people their next great idea. Part collection, part marketplace,
 
 With the Pinterest for WooCommerce extension, you can put your products in front of Pinterest users who are already looking for ideas and things to buy. Connect your WooCommerce store to your *[Pinterest business account](https://business.pinterest.com/)* directly in the WooCommerce app. Your entire catalog will become browsable on Pinterest in just a few clicks.
 
+= Pinterest Ads =
+
+Get started with Pinterest Ads with **$125 free ad credit\*** from Pinterest when you set up Pinterest for WooCommerce and spend $15 on ads! Pinterest *[terms and conditions](https://business.pinterest.com/en-us/business-terms-of-service/)* apply.
+
 = Open-minded and undecided =
 
 People on Pinterest are eager for new ideas, which means they want to hear from you. In fact, 97% of top Pinterest searches are unbranded. Content from brands doesn’t interrupt on Pinterest—it inspires. Shopping features are built into both the organic Pinner experience, and our ad solutions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As requested by the Pinterest team we want ads promo information at the wordpress.org.

The following copy should be used:

Get started with Pinterest Ads with **$125 free ad credit\*** from Pinterest when you set up Pinterest for WooCommerce and spend $15 on ads! Pinterest *[terms and conditions](https://business.pinterest.com/en-us/business-terms-of-service/)* apply.

Using wpreadme.com we can see how this will look:

<img width="753" alt="image" src="https://user-images.githubusercontent.com/17271089/201743886-21f2e264-600f-4ba0-85b0-0ed23dcbaad6.png">

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add Ads Credits promotion information to the readme.txt