### PR TITLE
Use min instead of max

### DIFF
--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -158,7 +158,7 @@ class Merchants {
 			set_transient( $cache_key, $th->getCode(), $delay );
 
 			// Double the delay.
-			Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', max( $delay * 2, 6 * HOUR_IN_SECONDS ) );
+			Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', min( $delay * 2, 6 * HOUR_IN_SECONDS ) );
 
 			throw new Exception( $th->getMessage(), $th->getCode() );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix an error calculating the backoff time.
