### PR TITLE
Fix - 510: Avoid splitting strings for translations

### DIFF
--- a/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, external as externalIcon } from '@wordpress/icons';
 import {
 	Button,
@@ -20,16 +21,15 @@ const OnboardingModalText = ( { isBillingSetup } ) => {
 	if ( ! isBillingSetup ) {
 		return (
 			<Text variant="body">
-				{ __(
-					'You are eligible for $125 of Pinterest ad credits. To claim the credits, ',
-					'pinterest-for-woocommerce'
-				) }
-				<strong>
-					{ __(
-						'you would need to add your billing details and spend $15 on Pinterest ads.',
+				{ createInterpolateElement(
+					__(
+						'You are eligible for $125 of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend $15 on Pinterest ads.</strong>',
 						'pinterest-for-woocommerce'
-					) }
-				</strong>
+					),
+					{
+						strong: <strong />,
+					}
+				) }
 			</Text>
 		);
 	}

--- a/assets/source/setup-guide/app/steps/SetupTracking.js
+++ b/assets/source/setup-guide/app/steps/SetupTracking.js
@@ -357,41 +357,42 @@ const SetupTracking = ( { view = 'settings' } ) => {
 								) }
 								<br />
 								<br />
-								{ __(
-									'Using conversion tags means you agree to our',
-									'pinterest-for-woocommerce'
-								) }{ ' ' }
-								<Button
-									isLink
-									{ ...documentationLinkProps( {
-										href:
-											wcSettings.pinterest_for_woocommerce
-												.pinterestLinks.adGuidelines,
-										linkId: 'ad-guidelines',
-										context: view,
-									} ) }
-								>
-									{ __(
-										'Ad Guidelines',
+								{ createInterpolateElement(
+									__(
+										'Using conversion tags means you agree to our <buttonGuidelines>Ad Guidelines</buttonGuidelines> and <buttonTerms>Ad Data Terms</buttonTerms>',
 										'pinterest-for-woocommerce'
-									) }
-								</Button>{ ' ' }
-								{ __( 'and', 'pinterest-for-woocommerce' ) }{ ' ' }
-								<Button
-									isLink
-									{ ...documentationLinkProps( {
-										href:
-											wcSettings.pinterest_for_woocommerce
-												.pinterestLinks.adDataTerms,
-										linkId: 'ad-data-terms',
-										context: view,
-									} ) }
-								>
-									{ __(
-										'Ad Data Terms',
-										'pinterest-for-woocommerce'
-									) }
-								</Button>
+									),
+									{
+										buttonGuidelines: (
+											<Button
+												isLink
+												{ ...documentationLinkProps( {
+													href:
+														wcSettings
+															.pinterest_for_woocommerce
+															.pinterestLinks
+															.adGuidelines,
+													linkId: 'ad-guidelines',
+													context: view,
+												} ) }
+											/>
+										),
+										buttonTerms: (
+											<Button
+												isLink
+												{ ...documentationLinkProps( {
+													href:
+														wcSettings
+															.pinterest_for_woocommerce
+															.pinterestLinks
+															.adDataTerms,
+													linkId: 'ad-data-terms',
+													context: view,
+												} ) }
+											/>
+										),
+									}
+								) }
 							</>
 						}
 						readMore={ documentationLinkProps( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #510.

Review and improve difficult to translate strings.

### Detailed test instructions:
1. Generate a build of the current branch.
2. There shouldn't be any string difficult to translate in `pinterest-for-woocommerce.pot`.

### Changelog entry

> Tweak - Improve translators strings.
