### PR TITLE
Organize update procedures by version

### DIFF
--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -165,6 +165,7 @@ class PluginUpdate {
 	 *
 	 * @since 1.0.9
 	 * @since 1.0.10 Accepts procedure name as parameter.
+	 * @since x.x.x  Log the failed procedure.
 	 * @param  string $update_procedure Name of the migration procedure.
 	 * @throws Throwable Update procedure failures.
 	 * @return void
@@ -175,9 +176,10 @@ class PluginUpdate {
 		} catch ( Throwable $th ) {
 			Logger::log(
 				sprintf(
-					// translators: 1: plugin version, 2: error message.
-					__( 'Plugin update to version %1$s error: %2$s', 'pinterest-for-woocommerce' ),
+					// translators: 1: plugin version, 2: failed procedure, 3: error message.
+					__( 'Plugin update to version %1$s. Procedure: %2$s. Error: %3$s', 'pinterest-for-woocommerce' ),
 					$this->get_plugin_current_version(),
+					$update_procedure,
 					$th->getMessage()
 				),
 				'error',

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -99,13 +99,20 @@ class PluginUpdate {
 	 * List of update procedures
 	 *
 	 * @since 1.0.10
+	 * @since x.x.x Updates procedures organized in an array by plugin version.
 	 * @return array List of update procedures names.
 	 */
 	private function update_procedures() {
 		return array(
-			'domain_verification_migration',
-			'feed_generation_migration',
-			'ads_credits_integration',
+			'1.0.9'  => array(
+				'domain_verification_migration',
+			),
+			'1.0.10' => array(
+				'feed_generation_migration',
+			),
+			'1.2.5'  => array(
+				'ads_credits_integration',
+			),
 		);
 	}
 
@@ -123,8 +130,16 @@ class PluginUpdate {
 		}
 
 		// Run the update procedures.
-		foreach ( $this->update_procedures() as $update_procedure ) {
-			$this->perform_plugin_update_procedure( $update_procedure );
+		foreach ( $this->update_procedures() as $version => $update_procedures ) {
+
+			if ( ! $this->version_needs_update( $version ) ) {
+				// Already up to date.
+				continue;
+			}
+
+			foreach ( $update_procedures as $update_procedure ) {
+				$this->perform_plugin_update_procedure( $update_procedure );
+			}
 		}
 
 		/**
@@ -180,10 +195,7 @@ class PluginUpdate {
 	 * @return void
 	 */
 	protected function domain_verification_migration(): void {
-		if ( ! $this->version_needs_update( '1.0.9' ) ) {
-			// Already up to date.
-			return;
-		}
+
 		$account_data = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
 
 		/**
@@ -206,11 +218,6 @@ class PluginUpdate {
 	 * @return void
 	 */
 	protected function feed_generation_migration(): void {
-		if ( ! $this->version_needs_update( '1.0.10' ) ) {
-			// Already up to date.
-			return;
-		}
-
 		/*
 		 * 1. Cancel old actions.
 		 */
@@ -276,10 +283,6 @@ class PluginUpdate {
 	 * @return void
 	 */
 	protected function ads_credits_integration(): void {
-		if ( ! $this->version_needs_update( '1.2.5' ) ) {
-			return;
-		}
-
 		// Set modals as dismissed and notice as not dismissed.
 		update_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_MODAL_DISMISSED, true, false );
 	}

--- a/tests/Unit/PluginUpdateTest.php
+++ b/tests/Unit/PluginUpdateTest.php
@@ -154,7 +154,7 @@ class Pinterest_Test_Plugin_Update extends TestCase {
 		$mock_plugin_update->maybe_update();
 
 		// Exception was caught and logged.
-		$this->assertEquals( "Plugin update to version {$this->current_version} error: Veni, vidi, error!", $this->mock_logger->message[0] );
+		$this->assertEquals( "Plugin update to version {$this->current_version}. Procedure: domain_verification_migration. Error: Veni, vidi, error!", $this->mock_logger->message[0] );
 
 		// Plugin update message logged.
 		$this->assertEquals( "Plugin updated to version: {$this->current_version}.", $this->mock_logger->message[1] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #414.

Refactor the update procedures in an array organized by plugin versions.

### Detailed test instructions:
1. Fresh install a version previous to the 1.2.5 and do the onboarding (the modal popup related to Ads Credits should not be displayed)
2. Upgrade to a build version of this PR.
3. The ad credits notice should be displayed now (this indicates that update procedures were successfully executed).

### Changelog entry

> Tweak - Refactor update procedures.
