### PR TITLE
Add warning message duplicated Rich Pins meta tags

### DIFF
--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\FeedRegistration;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\ProductSync;
+use Automattic\WooCommerce\Pinterest\RichPins;
 use Automattic\WooCommerce\Pinterest\Tracking;
 use \WP_REST_Server;
 
@@ -82,6 +83,7 @@ class FeedState extends VendorAPI {
 		add_filter( 'pinterest_for_woocommerce_feed_state', array( $this, 'add_local_feed_state' ) );
 		add_filter( 'pinterest_for_woocommerce_feed_state', array( $this, 'add_feed_registration_state' ) );
 		add_filter( 'pinterest_for_woocommerce_feed_state', array( $this, 'add_third_party_tags_warning' ) );
+		add_filter( 'pinterest_for_woocommerce_feed_state', array( $this, 'add_rich_pins_conflict_warning' ) );
 	}
 
 
@@ -336,7 +338,7 @@ class FeedState extends VendorAPI {
 
 	/**
 	 * Adds to the result variable an array with info about the
-	 * registration and configuration process of the XML feed to the Pinterest API.
+	 * third party plugins that may conflict with the tracking feature.
 	 *
 	 * @since 1.2.3
 	 *
@@ -356,6 +358,37 @@ class FeedState extends VendorAPI {
 
 		$result['workflow'][] = array(
 			'label'        => esc_html__( 'Pinterest tag', 'pinterest-for-woocommerce' ),
+			'status'       => 'warning',
+			'status_label' => esc_html__( 'Potential conflicting plugins', 'pinterest-for-woocommerce' ),
+			'extra_info'   => $warning_message,
+		);
+
+		return $result;
+	}
+
+
+	/**
+	 * Adds to the result variable an array with info about the
+	 * third party plugins that may conflict with the Rich Pins feature.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $result The result array to add values to.
+	 *
+	 * @return array
+	 *
+	 * @throws \Exception PHP Exception.
+	 */
+	public function add_rich_pins_conflict_warning( $result ) {
+
+		$warning_message = RichPins::get_third_party_conflict_warning_message();
+
+		if ( empty( $warning_message ) ) {
+			return $result;
+		}
+
+		$result['workflow'][] = array(
+			'label'        => esc_html__( 'Pinterest Rich Pins', 'pinterest-for-woocommerce' ),
 			'status'       => 'warning',
 			'status_label' => esc_html__( 'Potential conflicting plugins', 'pinterest-for-woocommerce' ),
 			'extra_info'   => $warning_message,

--- a/src/RichPins.php
+++ b/src/RichPins.php
@@ -271,4 +271,50 @@ class RichPins {
 
 		return '';
 	}
+
+
+	/**
+	 * Get the formatted warning message for the potential conflicting rich pin tags.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string The warning message.
+	 */
+	public static function get_third_party_conflict_warning_message() {
+
+		$third_party_plugins = self::get_third_party_conflicting_plugins();
+
+		if ( empty( $third_party_plugins ) ) {
+			return '';
+		}
+
+		return sprintf(
+			/* Translators: 1: Conflicting plugins, 2: Plugins Admin page opening tag, 3: Pinterest settings opening tag, 4: Closing anchor tag */
+			esc_html__( 'The following installed plugin(s) can potentially cause problems with Rich Pins: %1$s. %2$sRemove conflicting plugins%4$s or %3$smanage Rich Pins settings%4$s.', 'pinterest-for-woocommerce' ),
+			implode( ', ', $third_party_plugins ),
+			sprintf( '<a href="%s" target="_blank">', esc_url( admin_url( 'plugins.php' ) ) ),
+			sprintf( '<a href="%s" target="_blank">', esc_url( wc_admin_url( '&path=/pinterest/settings' ) ) ),
+			'</a>',
+		);
+
+	}
+
+
+	/**
+	 * Detect if there are other plugins installed on the site that conflicts with Rich Pins feature.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array The list of installed plugins.
+	 */
+	public static function get_third_party_conflicting_plugins() {
+
+		$third_party_plugins = array();
+
+		if ( class_exists( 'RankMath' ) ) {
+			$third_party_plugins['rmseo'] = 'RankMath SEO';
+		}
+
+		return $third_party_plugins;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #521 

The meta tags added by Rich Pins feature are duplicated if Rank Math SEO plugin is installed. The PR adds a warning message to the user.

### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/204347846-2351510a-93a7-4521-b1f6-cf7f632c570e.png)

### Detailed test instructions:
1. Install a built version of this PR and do the onboarding.
2. Install the plugin RankMath SEO and activate it.
3. Visit the Catalog tab (there should be a warning message like the Screenshot).

### Changelog entry

> Add - Warning message duplicated meta tags.
