### PR TITLE
Disable save button if chrome extension is detected

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -1,3 +1,5 @@
+/*global fetch*/
+
 /**
  * Disable the Save to Pinterest button if the Chrome extension is detected.
  */

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -1,0 +1,23 @@
+/**
+ * Disable the Save to Pinterest button if the Chrome extension is detected.
+ */
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'load', function () {
+	const disableSaveButton = () => {
+		document
+			.querySelectorAll( '.pinterest-for-woocommerce-image-wrapper' )
+			.forEach( function ( button ) {
+				button.style.display = 'none';
+			} );
+	};
+
+	const isChromeExtensionDetected = () => {
+		fetch(
+			`chrome-extension://gpdjojdkbbmdfjfahjcgigfpmkopogic/html/save.html`
+		)
+			.then( () => disableSaveButton() )
+			.catch( () => false );
+	};
+
+	isChromeExtensionDetected();
+} );

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -31,6 +31,9 @@ class SaveToPinterest {
 		add_action( 'woocommerce_before_single_product_summary', array( __CLASS__, 'render_product_pin' ) );
 		add_action( 'woocommerce_before_shop_loop_item', array( __CLASS__, 'render_product_pin' ), 1 );
 		add_filter( 'woocommerce_blocks_product_grid_item_html', array( __CLASS__, 'add_to_wc_blocks' ), 10, 3 );
+
+		// Enqueue our JS files.
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 	}
 
 
@@ -121,6 +124,25 @@ class SaveToPinterest {
 		}
 
 		return str_replace( '</li>', self::render_pin( $product->get_id() ) . '</li>', $html );
+	}
+
+
+	/**
+	 * Enqueue JS files necessary to properly track actions such as search.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_scripts() {
+
+		$ext = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		wp_enqueue_script(
+			PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-save-button',
+			Pinterest_For_Woocommerce()->plugin_url() . '/assets/js/pinterest-for-woocommerce-save-button' . $ext . '.js',
+			array(),
+			PINTEREST_FOR_WOOCOMMERCE_VERSION,
+			true
+		);
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #362.

The pin button is duplicated if [this Chrome extension](https://chrome.google.com/webstore/detail/pinterest-save-button/gpdjojdkbbmdfjfahjcgigfpmkopogic?hl=en) is installed.

### Detailed test instructions:
1. Install pinterest Chrome extension https://chrome.google.com/webstore/detail/pinterest-save-button/gpdjojdkbbmdfjfahjcgigfpmkopogic?hl=en
2. Ensure "Save to Pinterest" enabled in Woocommerce for Pinterest settings.
3. There should be only one pin button in the product's image.

### Changelog entry

> Fix - Disable pin button if Chrome extension is detected.
