### PR TITLE
Tweak add to cart tracking data

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -244,7 +244,7 @@ class Tracking {
 		$object_id = empty( $variation_id ) ? $product_id : $variation_id;
 		$product   = wc_get_product( $object_id );
 
-		$product_price = self::get_product_price_with_taxes( $product );
+		$product_price = self::get_product_display_price( $product );
 
 		self::add_event(
 			'AddToCart',
@@ -285,7 +285,7 @@ class Tracking {
 
 			$product = $order_item->get_product();
 
-			$product_price = self::get_product_price_with_taxes( $product );
+			$product_price = self::get_product_display_price( $product );
 
 			$terms      = wc_get_object_terms( $product->get_id(), 'product_cat' );
 			$categories = ! empty( $terms ) ? wp_list_pluck( $terms, 'name' ) : array();
@@ -375,7 +375,7 @@ JS;
 
 		$product_id    = $product->get_id();
 		$product_name  = $product->get_name();
-		$product_price = self::get_product_price_with_taxes( $product );
+		$product_price = self::get_product_display_price( $product );
 
 		$wc_currency = get_woocommerce_currency();
 		$tracking    = <<< JS
@@ -658,7 +658,7 @@ JS;
 	private static function filter_add_to_cart_attributes( array $args, WC_Product $product ) {
 		$attributes = array(
 			'data-product_name' => $product->get_name(),
-			'data-price'        => self::get_product_price_with_taxes( $product ),
+			'data-price'        => self::get_product_display_price( $product ),
 		);
 
 		$args['attributes'] = array_merge( $args['attributes'], $attributes );
@@ -727,7 +727,7 @@ JS;
 	 *
 	 * @return string
 	 */
-	protected static function get_product_price_with_taxes( $product ) {
+	protected static function get_product_display_price( $product ) {
 		return WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
 	}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -231,7 +231,7 @@ class Tracking {
 	 *
 	 * @return void
 	 */
-	public static function 	hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
+	public static function hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
 
 		if ( ! empty( $cart_item_key ) ) {
 			_deprecated_argument( __FUNCTION__, '1.2.6' );

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Pinterest\API\AdvertiserConnect;
 use WC_Product;
+use Automattic\WooCommerce\Utilities\NumberUtil;
 use \Premmerce\WooCommercePinterest\PinterestPlugin;
 
 /**
@@ -243,7 +244,7 @@ class Tracking {
 		$object_id = empty( $variation_id ) ? $product_id : $variation_id;
 		$product   = wc_get_product( $object_id );
 
-		$product_price = WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : wc_get_price_excluding_tax( $product );
+		$product_price = self::get_product_price_with_taxes( $product );
 
 		self::add_event(
 			'AddToCart',
@@ -284,7 +285,7 @@ class Tracking {
 
 			$product = $order_item->get_product();
 
-			$product_price = WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : wc_get_price_excluding_tax( $product );
+			$product_price = self::get_product_price_with_taxes( $product );
 
 			$terms      = wc_get_object_terms( $product->get_id(), 'product_cat' );
 			$categories = ! empty( $terms ) ? wp_list_pluck( $terms, 'name' ) : array();
@@ -322,6 +323,24 @@ class Tracking {
 	 * @return void
 	 */
 	public static function ajax_tracking_snippet() {
+
+		if ( is_product() ) {
+			$tracking = self::get_add_to_cart_snippet_product();
+		} else {
+			$tracking = self::get_add_to_cart_snippet_archive();
+		}
+
+		wp_add_inline_script( 'wc-add-to-cart', $tracking );
+
+	}
+
+
+	/**
+	 * Get the add to cart tracking snippet for archives.
+	 *
+	 * @return string
+	 */
+	protected static function get_add_to_cart_snippet_archive() {
 		$wc_currency = get_woocommerce_currency();
 		$tracking    = <<< JS
 jQuery( function( $ ) {
@@ -338,8 +357,43 @@ jQuery( function( $ ) {
 } );
 JS;
 
-		wp_add_inline_script( 'wc-add-to-cart', $tracking );
+		return $tracking;
+	}
 
+
+	/**
+	 * Get the add to cart tracking snippet for single product page.
+	 *
+	 * @return string
+	 */
+	protected static function get_add_to_cart_snippet_product() {
+		$product = wc_get_product( get_the_ID() );
+
+		if ( ! $product ) {
+			return '';
+		}
+
+		$product_id    = $product->get_id();
+		$product_name  = $product->get_name();
+		$product_price = self::get_product_price_with_taxes( $product );
+
+		$wc_currency = get_woocommerce_currency();
+		$tracking    = <<< JS
+jQuery( function( $ ) {
+	$( document.body ).on( 'added_to_cart', function( e, fragments, cart_hash, thisbutton ) {
+		var quantity = document.querySelector( 'input.qty[name="quantity"]' ).value;
+		pintrk( 'track', 'AddToCart', {
+			'product_id': '{$product_id}',
+			'product_name': '{$product_name}',
+			'value': {$product_price} * quantity,
+			'order_quantity': quantity,
+			'currency': '{$wc_currency}'
+		} );
+	} );
+} );
+JS;
+
+		return $tracking;
 	}
 
 
@@ -604,7 +658,7 @@ JS;
 	private static function filter_add_to_cart_attributes( array $args, WC_Product $product ) {
 		$attributes = array(
 			'data-product_name' => $product->get_name(),
-			'data-price'        => $product->get_price(),
+			'data-price'        => self::get_product_price_with_taxes( $product ),
 		);
 
 		$args['attributes'] = array_merge( $args['attributes'], $attributes );
@@ -665,4 +719,16 @@ JS;
 
 		return $third_party_tags;
 	}
+
+	/**
+	 * Get product's price including/excluding tax.
+	 *
+	 * @param WC_Product $product The product object.
+	 *
+	 * @return string
+	 */
+	protected static function get_product_price_with_taxes( $product ) {
+		return WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
+	}
+
 }

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -104,9 +104,7 @@ class Tracking {
 				add_action( 'wp_enqueue_scripts', array( __CLASS__, 'ajax_tracking_snippet' ), 20 );
 				add_filter(
 					'woocommerce_loop_add_to_cart_args',
-					function( $args, $product ) {
-						return self::filter_add_to_cart_attributes( $args, $product );
-					},
+					array( __CLASS__, 'filter_add_to_cart_attributes' ),
 					10,
 					2
 				);
@@ -233,7 +231,11 @@ class Tracking {
 	 *
 	 * @return void
 	 */
-	public static function hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
+	public static function 	hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
+
+		if ( ! empty( $cart_item_key ) ) {
+			_deprecated_argument( __FUNCTION__, '1.2.6' );
+		}
 
 		$redirect_to_cart = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
 
@@ -655,7 +657,7 @@ JS;
 	 *
 	 * @return array The filtered arguments for the Add to cart button.
 	 */
-	private static function filter_add_to_cart_attributes( array $args, WC_Product $product ) {
+	public static function filter_add_to_cart_attributes( array $args, WC_Product $product ) {
 		$attributes = array(
 			'data-product_name' => $product->get_name(),
 			'data-price'        => self::get_product_display_price( $product ),

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest;
+
+class TrackingTest extends \WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+	}
+
+	function test_ajax_tracking_snippet_action_added() {
+		add_option( 'woocommerce_enable_ajax_add_to_cart', 'yes' );
+		add_option( 'woocommerce_cart_redirect_after_add', 'no' );
+		\Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+		\Pinterest_For_Woocommerce::save_setting( 'tracking_tag', 'some-tag-id' );
+
+		Tracking::maybe_init();
+
+		$this->assertEquals(
+			20,
+			has_action( 'wp_enqueue_scripts', array( Tracking::class, 'ajax_tracking_snippet' ) )
+		);
+		$this->assertEquals(
+			10,
+			has_filter( 'woocommerce_loop_add_to_cart_args', array( Tracking::class, 'filter_add_to_cart_attributes' ) )
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #548.

There were some inconsistencies with the data on the add to cart event.
- The data is broken if the site uses AJAX to add products to the cart on the single product pages (a plugin like [this](https://wordpress.org/plugins/woo-ajax-add-to-cart/)).
- The prices were not correct on add to cart event (archive page) and WooCommerce setup with show prices excluding taxes.

### Detailed test instructions:
1. Install a build version of this PR and setup the plugin.
2. Install [this](https://wordpress.org/plugins/woo-ajax-add-to-cart/) plugin.
3. Add to cart a product from the single product page (the event's data should be correct).
4. Configure WooCommerce to display prices in the shop page excluding taxes.
5.  Add to cart a product from the shop page (the price in the event's data should be the same than the displayed price).


### Changelog entry

> Fix - Inconsistencies with the add to cart tracking event.
