### PR TITLE
Fix multiple registered feeds on site language change.

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -530,6 +530,33 @@ class Base {
 		);
 	}
 
+	/**
+	 * Disable a feed.
+	 *
+	 * @param string $merchant_id     The merchant ID the feed belongs to.
+	 * @param string $feed_profile_id The ID of the feed to be disabled.
+	 *
+	 * @return mixed
+	 */
+	public static function disable_merchant_feed( $merchant_id, $feed_profile_id ) {
+		return self::make_request(
+			"catalogs/disable_feed_profile/{$merchant_id}/{$feed_profile_id}/"
+		);
+	}
+
+	/**
+	 * Enable a feed.
+	 *
+	 * @param string $merchant_id     The merchant ID the feed belongs to.
+	 * @param string $feed_profile_id The ID of the feed to be enabled.
+	 *
+	 * @return mixed
+	 */
+	public static function enable_merchant_feed( $merchant_id, $feed_profile_id ) {
+		return self::make_request(
+			"catalogs/enable_feed_profile/{$merchant_id}/{$feed_profile_id}/"
+		);
+	}
 
 	/**
 	 * Get a merchant's feeds.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -83,8 +83,7 @@ class Base {
 	public static function make_request( $endpoint, $method = 'POST', $payload = array(), $api = '', $cache_expiry = false ) {
 
 		if ( ! empty( $cache_expiry ) ) {
-			$cache_key = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_request_' . md5( $endpoint . $method . wp_json_encode( $payload ) . $api );
-			$cache     = get_transient( $cache_key );
+			$cache = self::get_cached_response( $endpoint, $method, $payload, $api );
 
 			if ( $cache ) {
 				return $cache;
@@ -165,6 +164,52 @@ class Base {
 
 	}
 
+	/**
+	 * Get the cache key.
+	 *
+	 * @since x.x.x
+	 * @param string $endpoint Endpoint.
+	 * @param string $method   Request method.
+	 * @param array  $payload  Request payload.
+	 * @param string $api      Request API.
+	 *
+	 * @return string The cache key.
+	 */
+	public static function get_cache_key( $endpoint, $method, $payload, $api ) {
+		return PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_request_' . md5( $endpoint . $method . wp_json_encode( $payload ) . $api );
+	}
+
+	/**
+	 * Get the cached value.
+	 *
+	 * @since x.x.x
+	 * @param string $endpoint Endpoint.
+	 * @param string $method   Request method.
+	 * @param array  $payload  Request payload.
+	 * @param string $api      Request API.
+	 *
+	 * @return mixed Value of the transient or false if it doesn't exist.
+	 */
+	public static function get_cached_response( $endpoint, $method, $payload, $api ) {
+		$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
+		return get_transient( $cache_key );
+	}
+
+	/**
+	 * Invalidate the cached value.
+	 *
+	 * @since x.x.x
+	 * @param string $endpoint Endpoint.
+	 * @param string $method   Request method.
+	 * @param array  $payload  Request payload.
+	 * @param string $api      Request API.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_cached_response( $endpoint, $method, $payload, $api ) {
+		$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
+		delete_transient( $cache_key );
+	}
 
 	/**
 	 * Handle the request

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -566,6 +566,7 @@ class Base {
 	 * Get a merchant's feeds.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param bool   $include_disabled Whether to include disabled feeds.
 	 *
 	 * @return mixed
 	 */

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -533,6 +533,8 @@ class Base {
 	/**
 	 * Disable a feed.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param string $merchant_id     The merchant ID the feed belongs to.
 	 * @param string $feed_profile_id The ID of the feed to be disabled.
 	 *
@@ -546,6 +548,8 @@ class Base {
 
 	/**
 	 * Enable a feed.
+	 *
+	 * @since x.x.x
 	 *
 	 * @param string $merchant_id     The merchant ID the feed belongs to.
 	 * @param string $feed_profile_id The ID of the feed to be enabled.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -569,11 +569,18 @@ class Base {
 	 *
 	 * @return mixed
 	 */
-	public static function get_merchant_feeds( $merchant_id ) {
+	public static function get_merchant_feeds( $merchant_id, $include_disabled = false ) {
+
+		$args = array();
+
+		if ( $include_disabled ) {
+			$args['include_disabled'] = 'true';
+		}
+
 		return self::make_request(
 			"catalogs/{$merchant_id}/feed_profiles/",
 			'GET',
-			array(),
+			$args,
 			'',
 			MINUTE_IN_SECONDS
 		);

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -632,6 +632,29 @@ class Base {
 		);
 	}
 
+	/**
+	 * Invalidate the merchant's feeds cache.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param bool   $include_disabled Whether to include disabled feeds.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_merchant_feeds_cache( $merchant_id, $include_disabled = false ) {
+
+		$args = array();
+
+		if ( $include_disabled ) {
+			$args['include_disabled'] = 'true';
+		}
+
+		self::invalidate_cached_response(
+			"catalogs/{$merchant_id}/feed_profiles/",
+			'GET',
+			$args,
+			'',
+		);
+	}
 
 	/**
 	 * Get a specific merchant's feed report using the given arguments.

--- a/src/API/FeedIssues.php
+++ b/src/API/FeedIssues.php
@@ -57,7 +57,7 @@ class FeedIssues extends VendorAPI {
 	public function get_feed_issues( WP_REST_Request $request ) {
 
 		try {
-			$feed_id = FeedRegistration::get_registered_feed_id();
+			$feed_id = FeedRegistration::get_locally_stored_registered_feed_id();
 			if ( ! Pinterest\ProductSync::is_product_sync_enabled() || ! $feed_id ) {
 				return array( 'lines' => array() );
 			}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -377,7 +377,7 @@ class FeedState extends VendorAPI {
 	 */
 	private function add_feed_sync_status( $result ) {
 
-		$feed_id = FeedRegistration::get_registered_feed_id();
+		$feed_id = FeedRegistration::get_locally_stored_registered_feed_id();
 		if ( ! $feed_id ) {
 			throw new \Exception( esc_html__( 'Feed is not registered with Pinterest.', 'pinterest-for-woocommerce' ) );
 		}

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -134,8 +134,11 @@ class FeedRegistration {
 
 		Pinterest_For_Woocommerce()::save_data( 'feed_registered', $feed_id );
 
-		self::feed_enable_status_maintenance( $merchant_id, $feed_id );
+		if ( ! $feed_id ) {
+			return false;
+		}
 
+		self::feed_enable_status_maintenance( $merchant_id, $feed_id );
 		return true;
 	}
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -129,7 +129,7 @@ class FeedRegistration {
 		$merchant_id   = $merchant['data']->id;
 		$local_feed_id = self::get_locally_stored_registered_feed_id();
 
-		if ( ! $local_feed_id || ! Feeds::is_local_feed_registered( $merchant_id ) ) {
+		if ( ! $local_feed_id || ! Feeds::match_local_feed_configuration_to_registered_feeds( $merchant_id ) ) {
 
 			$response = Merchants::update_or_create_merchant();
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -131,7 +131,7 @@ class FeedRegistration {
 			 * Update feed if we don't have a feed_id saved or if local feed is not properly registered.
 			 * for cases where the already existed in the API.
 			 */
-			$registered = self::get_registered_feed_id();
+			$registered = self::get_locally_stored_registered_feed_id();
 
 			if ( ! $registered || ! Feeds::is_local_feed_registered( $merchant['data']->id ) ) {
 
@@ -158,11 +158,14 @@ class FeedRegistration {
 	}
 
 	/**
-	 * Returns the feed profile ID if it's registered. Returns `false` otherwise.
+	 * Returns the feed profile ID stored locally if it's registered.
+	 * Returns `false` otherwise.
+	 * If everything is configured correctly, this feed profile id will match
+	 * the setup that the merchant has in Pinterest.
 	 *
 	 * @return string|boolean
 	 */
-	public static function get_registered_feed_id() {
+	public static function get_locally_stored_registered_feed_id() {
 		return Pinterest_For_Woocommerce()::get_data( 'feed_registered' ) ?? false;
 	}
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -124,12 +124,7 @@ class FeedRegistration {
 			return false;
 		}
 
-		$feed_id = self::get_locally_stored_registered_feed_id();
-
-		// If the feed is not registered, try to match it to a registered feed.
-		if ( ! $feed_id ) {
-			$feed_id = Feeds::match_local_feed_configuration_to_registered_feeds( $merchant_id );
-		}
+		$feed_id = Feeds::match_local_feed_configuration_to_registered_feeds( $merchant_id );
 
 		// If no matching registered feed found try to create it.
 		if ( ! $feed_id ) {

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -112,7 +112,7 @@ class FeedRegistration {
 	 * Also if a different feed is registered, it will update using the URL in the
 	 * $feed_args.
 	 *
-	 * @return boolean|string
+	 * @return boolean
 	 *
 	 * @throws Exception PHP Exception.
 	 */
@@ -138,8 +138,10 @@ class FeedRegistration {
 				// The response only contains the merchant id.
 				$response = Merchants::update_or_create_merchant();
 
-				// The response contains an array with the ID of merchant and feed.
-				$registered = $response['feed_id'];
+				// If he response contains an array with the feed id this means that it is registered.
+				if ( $response['feed_id'] ) {
+					$registered = true;
+				}
 			}
 		}
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -127,9 +127,10 @@ class FeedRegistration {
 			self::log( 'Pinterest returned a Declined status for product_pin_approval_status' );
 
 		} else {
-
-			// Update feed if we don't have a feed_id saved or if local feed is not properly registered.
-			// for cases where the already existed in the API.
+			/*
+			 * Update feed if we don't have a feed_id saved or if local feed is not properly registered.
+			 * for cases where the already existed in the API.
+			 */
 			$registered = self::get_registered_feed_id();
 
 			if ( ! $registered || ! Feeds::is_local_feed_registered( $merchant['data']->id ) ) {

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -206,6 +206,8 @@ class FeedRegistration {
 		$config     = reset( $configs );
 		$local_path = dirname( $config['feed_url'] );
 
+		$invalidate_cache = false;
+
 		foreach ( $feed_profiles as $feed ) {
 			// Local feed should not be disabled.
 			if ( $feed_id === $feed->id ) {
@@ -222,12 +224,16 @@ class FeedRegistration {
 				continue;
 			}
 
+			// Disable the feed if it is active.
 			if ( 'ACTIVE' === $feed->feed_status ) {
 				Feeds::disable_feed( $merchant_id, $feed->id );
+				$invalidate_cache = true;
 			}
 		}
 
-		// TODO: Invalidate cache.
+		if ( $invalidate_cache ) {
+			Feeds::invalidate_get_merchant_feeds_cache( $merchant_id );
+		}
 	}
 
 	/**

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -202,9 +202,9 @@ class FeedRegistration {
 			return;
 		}
 
-		$configs       = LocalFeedConfigs::get_instance()->get_configurations();
-		$config        = reset( $configs );
-		$local_path    = dirname( $config['feed_url'] );
+		$configs    = LocalFeedConfigs::get_instance()->get_configurations();
+		$config     = reset( $configs );
+		$local_path = dirname( $config['feed_url'] );
 
 		foreach ( $feed_profiles as $feed ) {
 			// Local feed should not be disabled.
@@ -218,7 +218,7 @@ class FeedRegistration {
 			}
 
 			// Only disable feeds that have matching feed file URL.
-			if ( $local_path !== dirname( $feed->location_config->full_feed_fetch_location ) ) {
+			if ( dirname( $feed->location_config->full_feed_fetch_location ) !== $local_path ) {
 				continue;
 			}
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -66,7 +66,7 @@ class Feeds {
 
 
 	/**
-	 * Get merchant's feeds
+	 * Get merchant's feeds.
 	 *
 	 * @param string $merchant_id The merchant ID.
 	 *

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -77,8 +77,7 @@ class Feeds {
 	public static function get_merchant_feeds( $merchant_id ) {
 
 		try {
-
-			$feeds = API\Base::get_merchant_feeds( $merchant_id );
+			$feeds = API\Base::get_merchant_feeds( $merchant_id, true );
 
 			if ( 'success' !== $feeds['status'] ) {
 				throw new Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -100,13 +100,14 @@ class Feeds {
 
 
 	/**
-	 * Verify if the local feed is already registered to the merchant
+	 * Verify if the local feed is already registered to the merchant.
+	 * Return its ID if it is.
 	 *
 	 * @param string $merchant_id The merchant ID.
 	 *
 	 * @return string Returns the ID of the feed if properly registered or an empty string otherwise.
 	 */
-	public static function is_local_feed_registered( $merchant_id ) {
+	public static function match_local_feed_configuration_to_registered_feeds( $merchant_id ) {
 		$configs       = LocalFeedConfigs::get_instance()->get_configurations();
 		$config        = reset( $configs );
 		$local_path    = dirname( $config['feed_url'] );

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -180,7 +180,7 @@ class Feeds {
 		try {
 			$result = Base::disable_merchant_feed( $merchant_id, $feed_profile_id );
 
-			return true;
+			return $result['status'] === 'success';
 		} catch ( \Throwable $th ) {
 			Logger::log( $th->getMessage(), 'error' );
 			return false;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -179,7 +179,7 @@ class Feeds {
 		try {
 			$result = Base::disable_merchant_feed( $merchant_id, $feed_profile_id );
 
-			return $result['status'] === 'success';
+			return 'success' === $result['status'];
 		} catch ( \Throwable $th ) {
 			Logger::log( $th->getMessage(), 'error' );
 			return false;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -97,6 +97,16 @@ class Feeds {
 		}
 	}
 
+	/**
+	 * Invalidate the merchant feeds cache.
+	 *
+	 * @since x.x.x
+	 * @param string $merchant_id The merchant ID.
+	 * @return void
+	 */
+	public static function invalidate_get_merchant_feeds_cache( $merchant_id ) {
+		API\Base::invalidate_merchant_feeds_cache( $merchant_id, true );
+	}
 
 	/**
 	 * Verify if the local feed is already registered to the merchant.
@@ -157,6 +167,9 @@ class Feeds {
 	public static function enabled_feed( $merchant_id, $feed_profile_id ) {
 		try {
 			$result = Base::enable_merchant_feed( $merchant_id, $feed_profile_id );
+
+			// We don't need to check the status, lets just invalidate the cache for extra safety.
+			self::invalidate_get_merchant_feeds_cache( $merchant_id, true );
 
 			return 'success' === $result['status'];
 		} catch ( \Throwable $th ) {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -35,7 +35,7 @@ class Feeds {
 		try {
 
 			// Get the feeds of the merchant.
-			$feeds = Base::get_merchant_feeds( $merchant_id );
+			$feeds = Base::get_merchant_feeds( $merchant_id, true );
 
 			if ( 'success' !== $feeds['status'] ) {
 				throw new Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
@@ -158,7 +158,7 @@ class Feeds {
 		try {
 			$result = Base::enable_merchant_feed( $merchant_id, $feed_profile_id );
 
-			return true;
+			return 'success' === $result['status'];
 		} catch ( \Throwable $th ) {
 			Logger::log( $th->getMessage(), 'error' );
 			return false;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -129,4 +129,61 @@ class Feeds {
 		return '';
 	}
 
+	/**
+	 * Check if the registered feed is enabled.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $merchant_id     The merchant ID.
+	 * @param string $feed_profile_id The ID of the feed.
+	 *
+	 * @return bool True if the feed is active, false otherwise.
+	 */
+	public static function is_local_feed_enabled( $merchant_id, $feed_profile_id ) {
+		$feed = self::get_merchant_feed( $merchant_id, $feed_profile_id );
+		return 'ACTIVE' === $feed->feed_status;
+	}
+
+	/**
+	 * Enabled the feed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $merchant_id     The merchant ID.
+	 * @param string $feed_profile_id The ID of the feed.
+	 *
+	 * @return bool True if the feed is has been enabled, false otherwise.
+	 */
+	public static function enabled_feed( $merchant_id, $feed_profile_id ) {
+		try {
+			$result = Base::enable_merchant_feed( $merchant_id, $feed_profile_id );
+
+			return true;
+		} catch ( \Throwable $th ) {
+			Logger::log( $th->getMessage(), 'error' );
+			return false;
+		}
+	}
+
+	/**
+	 * Enabled the feed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $merchant_id     The merchant ID.
+	 * @param string $feed_profile_id The ID of the feed.
+	 *
+	 * @return bool True if the feed is has been disabled, false otherwise.
+	 */
+	public static function disable_feed( $merchant_id, $feed_profile_id ) {
+		try {
+			$result = Base::disable_merchant_feed( $merchant_id, $feed_profile_id );
+
+			return true;
+		} catch ( \Throwable $th ) {
+			Logger::log( $th->getMessage(), 'error' );
+			return false;
+		}
+	}
+
 }

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -168,7 +168,7 @@ class Merchants {
 			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
 		}
 
-		$registered_feed = Feeds::is_local_feed_registered( $response['data'] );
+		$registered_feed = Feeds::match_local_feed_configuration_to_registered_feeds( $response['data'] );
 
 		// Clean the cached delay.
 		Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', false );

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -130,7 +130,12 @@ class Merchants {
 		$configs = LocalFeedConfigs::get_instance()->get_configurations();
 		$config  = reset( $configs );
 
-		// TODO: Add comment.
+		/**
+		 * Filters the default merchant name: pinterest_for_woocommerce_default_merchant_name. This vale appears in the
+		 * feed configuration page in Pinterest.
+		 *
+		 * @param string $merchant_name The default merchant name.
+		 */
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
 		$args = array(

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -172,7 +172,7 @@ class Merchants {
 			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
 		}
 
-		$feed_id    = Feeds::match_local_feed_configuration_to_registered_feeds( $response['data'] );
+		$feed_id     = Feeds::match_local_feed_configuration_to_registered_feeds( $response['data'] );
 		$merchant_id = $response['data'];
 
 		// Clean the cached delay.

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -130,6 +130,7 @@ class Merchants {
 		$configs = LocalFeedConfigs::get_instance()->get_configurations();
 		$config  = reset( $configs );
 
+		// TODO: Add comment. 
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
 		$args = array(
@@ -152,6 +153,7 @@ class Merchants {
 		try {
 			// The response only contains the merchant id.
 			$response = Base::update_or_create_merchant( $args );
+			// TODO: invalidate cache for feed fetch.
 		} catch ( Throwable $th ) {
 			$delay = Pinterest_For_Woocommerce()::get_data( 'create_merchant_delay' ) ?? MINUTE_IN_SECONDS;
 

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -130,7 +130,7 @@ class Merchants {
 		$configs = LocalFeedConfigs::get_instance()->get_configurations();
 		$config  = reset( $configs );
 
-		// TODO: Add comment. 
+		// TODO: Add comment.
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
 		$args = array(
@@ -151,7 +151,6 @@ class Merchants {
 		}
 
 		try {
-			// The response only contains the merchant id.
 			$response = Base::update_or_create_merchant( $args );
 			// TODO: invalidate cache for feed fetch.
 		} catch ( Throwable $th ) {

--- a/src/Notes/Collection/CatalogSyncErrors.php
+++ b/src/Notes/Collection/CatalogSyncErrors.php
@@ -52,7 +52,7 @@ class CatalogSyncErrors extends AbstractNote {
 		}
 
 		try {
-			$feed_id  = FeedRegistration::get_registered_feed_id();
+			$feed_id  = FeedRegistration::get_locally_stored_registered_feed_id();
 			$workflow = FeedIssues::get_feed_workflow( $feed_id );
 			if ( false === $workflow ) {
 				// No workflow to check.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the user changes the locale a new feed configuration is created. It now reflects the new locale ( language ). We can't delete the old feed configuration ( API limitation ) but we can disable it. 
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #643  .

- Correctly identify the registered feed configuration as local.
- Make sure that the additional old feed configurations are disabled.


### TODO:
- [x] cache invalidation.
- [x] remove TODOs comments.
- [x] feed enable feature when feed configuration detected but not enabled.
- [x] comments.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

**Using develop**

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
( this is a copy from #643 )
1. Log into your account
2. Go to Settings -> General
3. Change Site Language
4. Wait 2 hours
5. Go to the Pinterest Ads portal and go to Ads -> Catalogs.
6. You will see more than 1 catalog record

**Switch to this branch**
Wait for some time ( < 10 minutes ) The automation should clean things up.
You should receive an email about that a data source has been deleted - Pinterest is working on making that message less scary.
If you now check the feed records in Pinterest UI there should be only one active.

### Additional details:

The code in this PR checks for all of the feed configurations and acts only on the ones that are registered as WooCommerce integrations. It also compares the URLs. This means that the cleanup procedure only works for multiple feed files that are coming from the same website. Connecting multiple ( different ) sites is still supported (whether that is good or bad is a different discussion and more a business decision )


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent multiple active feed files.
