### PR TITLE
Release 1.2.8 - merging trunk to develop

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.2.8 - 2023-01-03 =
+* Dev - Add node and npm version restrictions.
+* Fix - Prevent failed to `feed_report` if there is no feed registered.
+* Tweak - WC 7.3 compatibility.
+
 = 1.2.7 - 2022-12-16 =
 * Add - Warning message duplicated meta tags.
 * Fix - Update Tracking.php.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.2.7
+ * Version:           1.2.8
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -26,7 +26,7 @@
  * Requires PHP: 7.3
  *
  * WC requires at least: 5.3
- * WC tested up to: 7.2
+ * WC tested up to: 7.3
  */
 
 /**
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.2.7' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.2.8' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 6.1
 Requires PHP: 7.3
-Stable tag: 1.2.7
+Stable tag: 1.2.8
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.2.8 - 2023-01-03 =
+* Dev - Add node and npm version restrictions.
+* Fix - Prevent failed to `feed_report` if there is no feed registered.
+* Tweak - WC 7.3 compatibility.
+
 = 1.2.7 - 2022-12-16 =
 * Add - Warning message duplicated meta tags.
 * Fix - Update Tracking.php.


### PR DESCRIPTION
Merging trunk branch to develop after https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.2.8 and https://github.com/woocommerce/pinterest-for-woocommerce/pull/657.