### PR TITLE
Add additional parameters into WC tracker for Pinterest

### DIFF
--- a/src/FeedFileOperations.php
+++ b/src/FeedFileOperations.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Pinterest for WooCommerce Feed File Operations.
+ *
+ * @package     Pinterest_For_WooCommerce/Classes/
+ * @version     x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Exception;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class which handles all feed file filesystem operations.
+ */
+class FeedFileOperations {
+
+	/**
+	 * Local Feed Configurations class.
+	 *
+	 * @var LocalFeedConfigs of local feed configurations;
+	 */
+	private $configurations;
+
+	/**
+	 * @param LocalFeedConfigs $local_feeds_configurations local feed configuration.
+	 * @since x.x.x
+	 */
+	public function __construct( LocalFeedConfigs $local_feeds_configurations ) {
+		$this->configurations = $local_feeds_configurations;
+	}
+
+	/**
+	 * Prepare a fresh temporary file for each local configuration.
+	 * Files is populated with the XML headers.
+	 *
+	 * @since x.x.x
+	 * @throws Exception Can't open or write to the file.
+	 */
+	public function prepare_temporary_files(): void {
+		foreach ( $this->configurations->get_configurations() as $config ) {
+			$bytes_written = file_put_contents(
+				$config['tmp_file'],
+				ProductsXmlFeed::get_xml_header()
+			);
+
+			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
+		}
+	}
+
+	/**
+	 * Add XML footer to all temporary feed files.
+	 *
+	 * @since x.x.x
+	 * @throws Exception Can't open or write to the file.
+	 */
+	public function add_footer_to_temporary_feed_files(): void {
+		foreach ( $this->configurations->get_configurations() as $config ) {
+			$bytes_written = file_put_contents(
+				$config['tmp_file'],
+				ProductsXmlFeed::get_xml_footer(),
+				FILE_APPEND
+			);
+
+			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
+		}
+	}
+
+	/**
+	 * Check if we have a feed file on the disk.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function check_if_feed_file_exists(): bool {
+		$configs = $this->configurations->get_configurations();
+		$config  = reset( $configs );
+		if ( false === $config ) {
+			return false;
+		}
+		return isset( $config['feed_file'] ) && file_exists( $config['feed_file'] );
+	}
+
+	/**
+	 * Checks the status of the file write operation and throws if issues are found.
+	 * Utility function for functions using file_put_contents.
+	 *
+	 * @since x.x.x
+	 * @param integer $bytes_written How much data was written to the file.
+	 * @param string  $file          File location.
+	 *
+	 * @throws Exception Can't open or write to the file.
+	 */
+	private function check_write_for_io_errors( $bytes_written, $file ): void {
+
+		if ( false === $bytes_written ) {
+			throw new Exception(
+				sprintf(
+					/* translators: error message with file path */
+					__( 'Could not open temporary file %s for writing', 'pinterest-for-woocommerce' ),
+					$file
+				)
+			);
+		}
+
+		if ( 0 === $bytes_written ) {
+			throw new Exception(
+				sprintf(
+					/* translators: error message with file path */
+					__( 'Temporary file: %s is not writeable.', 'pinterest-for-woocommerce' ),
+					$file
+				)
+			);
+		}
+	}
+
+	/**
+	 * Rename temporary feed files to final name.
+	 * This is the last step of the feed file generation process.
+	 *
+	 * @since x.x.x
+	 * @throws \Exception Renaming not possible.
+	 */
+	public function rename_temporary_feed_files_to_final(): void {
+		foreach ( $this->configurations->get_configurations() as $config ) {
+			$status = rename( $config['tmp_file'], $config['feed_file'] );
+			if ( false === $status ) {
+				throw new Exception(
+					sprintf(
+						/* translators: 1: temporary file name 2: final file name */
+						__( 'Could not rename %1$s to %2$s', 'pinterest-for-woocommerce' ),
+						$config['tmp_file'],
+						$config['feed_file']
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Write pre-populated buffers to feed files.
+	 *
+	 * @param array $buffers an array of (locale => content) elements.
+	 * @since x.x.x
+	 * @throws Exception Can't open or write to the file.
+	 */
+	public function write_buffers_to_temp_files( array $buffers ): void {
+		foreach ( $this->configurations->get_configurations() as $location => $config ) {
+			if ( '' === $buffers[ $location ] ) {
+				continue;
+			}
+
+			$bytes_written = file_put_contents(
+				$config['tmp_file'],
+				$buffers[ $location ],
+				FILE_APPEND
+			);
+
+			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
+		}
+	}
+}

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -1,4 +1,4 @@
-<?php //phpcs:disable WordPress.WP.AlternativeFunctions --- Uses FS read/write in order to reliable append to an existing file.
+<?php //phpcs:disable WordPress.WP.AlternativeFunctions --- Uses FS read/write in order to reliably append to an existing file.
 /**
  * Pinterest for WooCommerce Feed Files Generator
  *
@@ -36,12 +36,18 @@ class FeedGenerator extends AbstractChainedJob {
 	const WAIT_ON_ERROR_BEFORE_RETRY = HOUR_IN_SECONDS;
 
 	/**
+	 * Feed file operations class.
+	 *
+	 * @var FeedFileOperations
+	 */
+	private $feed_file_operations;
+
+	/**
 	 * Local Feed Configurations class.
 	 *
 	 * @var LocalFeedConfigs of local feed configurations;
 	 */
 	private $configurations;
-
 
 	/**
 	 * Location buffers. On buffer for each local feed configuration.
@@ -56,11 +62,13 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @since 1.0.10
 	 * @param ActionSchedulerInterface $action_scheduler           Action Scheduler proxy.
+	 * @param FeedFileOperations       $feed_file_operations       Feed file operations.
 	 * @param LocalFeedConfigs         $local_feeds_configurations Locations configuration class.
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, $local_feeds_configurations ) {
+	public function __construct( ActionSchedulerInterface $action_scheduler, FeedFileOperations $feed_file_operations, $local_feeds_configurations ) {
 		parent::__construct( $action_scheduler );
-		$this->configurations = $local_feeds_configurations;
+		$this->feed_file_operations = $feed_file_operations;
+		$this->configurations       = $local_feeds_configurations;
 	}
 
 	/**
@@ -124,19 +132,19 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @since 1.0.10
 	 *
-	 * @throws Throwable Related to issues possible when creating an empty feed temp file and populating the header.
+	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	protected function handle_start() {
 		self::log( __( 'Feed generation start. Preparing temporary files.', 'pinterest-for-woocommerce' ) );
-		ProductFeedStatus::reset_feed_file_generation_time();
 		try {
-			$this->prepare_temporary_files();
+			ProductFeedStatus::reset_feed_file_generation_time();
 			ProductFeedStatus::set(
 				array(
 					'status'        => 'in_progress',
 					'product_count' => 0,
 				)
 			);
+			$this->feed_file_operations->prepare_temporary_files();
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th );
 			throw $th;
@@ -149,20 +157,24 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @since 1.0.10
 	 *
-	 * @throws Throwable Related to issues possible when adding the footer or renaming the files.
+	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
 	protected function handle_end() {
 		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
 		try {
-			$this->add_footer_to_temporary_feed_files();
-			$this->rename_temporary_feed_files_to_final();
+			$this->feed_file_operations->add_footer_to_temporary_feed_files();
+			$this->feed_file_operations->rename_temporary_feed_files_to_final();
+			ProductFeedStatus::set(
+				array(
+					'status'                                                     => 'generated',
+					ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => ProductFeedStatus::get()['product_count'],
+				)
+			);
 			ProductFeedStatus::set_feed_file_generation_time( time() );
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th );
 			throw $th;
 		}
-
-		ProductFeedStatus::set( array( 'status' => 'generated' ) );
 		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
 
 		// Check if feed is dirty and reschedule in necessary.
@@ -261,8 +273,7 @@ class FeedGenerator extends AbstractChainedJob {
 				}
 			);
 
-			$this->write_buffers_to_temp_files();
-
+			$this->feed_file_operations->write_buffers_to_temp_files( $this->buffers );
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th );
 			throw $th;
@@ -334,73 +345,6 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
-	 * Prepare a fresh temporary file for each local configuration.
-	 * Files is populated with the XML headers.
-	 *
-	 * @since 1.0.10
-	 */
-	private function prepare_temporary_files(): void {
-		foreach ( $this->configurations->get_configurations() as $config ) {
-			$bytes_written = file_put_contents(
-				$config['tmp_file'],
-				ProductsXmlFeed::get_xml_header()
-			);
-
-			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
-		}
-	}
-
-	/**
-	 * Add XML footer to all of the temporary feed files.
-	 *
-	 * @since 1.0.10
-	 */
-	private function add_footer_to_temporary_feed_files(): void {
-		foreach ( $this->configurations->get_configurations() as $config ) {
-			$bytes_written = file_put_contents(
-				$config['tmp_file'],
-				ProductsXmlFeed::get_xml_footer(),
-				FILE_APPEND
-			);
-
-			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
-		}
-	}
-
-	/**
-	 * Checks the status of the file write operation and throws if issues are found.
-	 * Utility function for functions using file_put_contents.
-	 *
-	 * @since 1.0.10
-	 * @param integer $bytes_written How much data was written to the file.
-	 * @param string  $file          File location.
-	 *
-	 * @throws Exception Can't open or write to the file.
-	 */
-	private function check_write_for_io_errors( $bytes_written, $file ): void {
-
-		if ( false === $bytes_written ) {
-			throw new Exception(
-				sprintf(
-					/* translators: error message with file path */
-					__( 'Could not open temporary file %s for writing', 'pinterest-for-woocommerce' ),
-					$file
-				)
-			);
-		}
-
-		if ( 0 === $bytes_written ) {
-			throw new Exception(
-				sprintf(
-					/* translators: error message with file path */
-					__( 'Temporary file: %s is not writeable.', 'pinterest-for-woocommerce' ),
-					$file
-				)
-			);
-		}
-	}
-
-	/**
 	 * React to errors during feed files generation process.
 	 *
 	 * @since 1.0.10
@@ -420,29 +364,6 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
-	 * Rename temporary feed files to final name.
-	 * This is the last step of the feed file generation process.
-	 *
-	 * @since 1.0.10
-	 * @throws \Exception Renaming not possible.
-	 */
-	private function rename_temporary_feed_files_to_final(): void {
-		foreach ( $this->configurations->get_configurations() as $config ) {
-			$status = rename( $config['tmp_file'], $config['feed_file'] );
-			if ( false === $status ) {
-				throw new Exception(
-					sprintf(
-						/* translators: 1: temporary file name 2: final file name */
-						__( 'Could not rename %1$s to %2$s', 'pinterest-for-woocommerce' ),
-						$config['tmp_file'],
-						$config['feed_file']
-					)
-				);
-			}
-		}
-	}
-
-	/**
 	 * Remove feed files and cancel pending actions.
 	 * Part of the cleanup procedure.
 	 *
@@ -459,41 +380,6 @@ class FeedGenerator extends AbstractChainedJob {
 			}
 		}
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
-	}
-
-	/**
-	 * Write pre-populated buffers to feed files.
-	 *
-	 * @since 1.0.10
-	 */
-	private function write_buffers_to_temp_files(): void {
-		foreach ( $this->configurations->get_configurations() as $location => $config ) {
-			if ( '' === $this->buffers[ $location ] ) {
-				continue;
-			}
-
-			$bytes_written = file_put_contents(
-				$config['tmp_file'],
-				$this->buffers[ $location ],
-				FILE_APPEND
-			);
-
-			$this->check_write_for_io_errors( $bytes_written, $config['tmp_file'] );
-		}
-	}
-
-	/**
-	 * Check if we have a feed file on the disk.
-	 *
-	 * @since 1.0.10
-	 */
-	public function check_if_feed_file_exists() {
-		$configs = $this->configurations->get_configurations();
-		$config  = reset( $configs );
-		if ( false === $config ) {
-			return false;
-		}
-		return isset( $config['feed_file'] ) && file_exists( $config['feed_file'] );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -128,6 +128,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function handle_start() {
 		self::log( __( 'Feed generation start. Preparing temporary files.', 'pinterest-for-woocommerce' ) );
+		/* Remember the time a feed generation has started. */
+		TrackerSnapshot::reset_feed_file_generation_time();
 		try {
 			$this->prepare_temporary_files();
 			ProductFeedStatus::set(
@@ -152,7 +154,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function handle_end() {
 		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
-
+		/* Calculate the time it took a feed to generate. */
+		TrackerSnapshot::set_feed_file_generation_time( time() );
 		try {
 			$this->add_footer_to_temporary_feed_files();
 			$this->rename_temporary_feed_files_to_final();

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -128,7 +128,6 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function handle_start() {
 		self::log( __( 'Feed generation start. Preparing temporary files.', 'pinterest-for-woocommerce' ) );
-		/* Remember the time a feed generation has started. */
 		ProductFeedStatus::reset_feed_file_generation_time();
 		try {
 			$this->prepare_temporary_files();
@@ -157,7 +156,6 @@ class FeedGenerator extends AbstractChainedJob {
 		try {
 			$this->add_footer_to_temporary_feed_files();
 			$this->rename_temporary_feed_files_to_final();
-			/* Calculate the time it took a feed to generate. */
 			ProductFeedStatus::set_feed_file_generation_time( time() );
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th );
@@ -415,7 +413,6 @@ class FeedGenerator extends AbstractChainedJob {
 				'error_message' => $th->getMessage(),
 			)
 		);
-		/* Marks feed as failed to generate. */
 		ProductFeedStatus::mark_feed_file_generation_as_failed();
 
 		self::log( $th->getMessage(), 'error' );

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -166,7 +166,7 @@ class FeedGenerator extends AbstractChainedJob {
 			$this->feed_file_operations->rename_temporary_feed_files_to_final();
 			ProductFeedStatus::set(
 				array(
-					'status'                                                     => 'generated',
+					'status' => 'generated',
 					ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => ProductFeedStatus::get()['product_count'],
 				)
 			);

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -33,22 +33,22 @@ class FeedRegistration {
 	private $configurations;
 
 	/**
-	 * Feed File Generator Instance
+	 * Feed File Operations Instance
 	 *
-	 * @var $feed_generator FeedGenerator
+	 * @var $feed_file_operations FeedFileOperations
 	 */
-	private $feed_generator = null;
+	private $feed_file_operations;
 
 	/**
 	 * Feed Registration.
 	 *
 	 * @since 1.0.10
-	 * @param LocalFeedConfigs $local_feeds_configurations Locations configuration class.
-	 * @param FeedGenerator    $feed_generator Feed generator class.
+	 * @param LocalFeedConfigs   $local_feeds_configurations Locations configuration class.
+	 * @param FeedFileOperations $feed_file_operations Feed file operations class.
 	 */
-	public function __construct( $local_feeds_configurations, $feed_generator ) {
-		$this->configurations = $local_feeds_configurations;
-		$this->feed_generator = $feed_generator;
+	public function __construct( $local_feeds_configurations, $feed_file_operations ) {
+		$this->configurations       = $local_feeds_configurations;
+		$this->feed_file_operations = $feed_file_operations;
 	}
 
 	/**
@@ -153,7 +153,7 @@ class FeedRegistration {
 	 * @return bool
 	 */
 	public function feed_file_exists() {
-		return $this->feed_generator->check_if_feed_file_exists();
+		return $this->feed_file_operations->check_if_feed_file_exists();
 	}
 
 	/**

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -99,15 +99,9 @@ class ProductFeedStatus {
 	 * @return void
 	 */
 	public static function deregister() {
-		$properties_to_persist = array(
-			self::PROP_FEED_GENERATION_WALL_TIME,
-			self::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT,
-		);
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
-			if ( ! in_array( $key, $properties_to_persist, true ) ) {
-				self::$state[ $key ] = $default_value;
-				delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
-			}
+			self::$state[ $key ] = $default_value;
+			delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
 		}
 	}
 

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -18,10 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ProductFeedStatus {
 
 	const STATE_PROPS = array(
-		'status'        => 'pending_config',
-		'last_activity' => 0,
-		'product_count' => 0,
-		'error_message' => '',
+		'status'                                   => 'pending_config',
+		'last_activity'                            => 0,
+		'product_count'                            => 0,
+		'error_message'                            => '',
+		self::PROP_FEED_GENERATION_WALL_START_TIME => false,
+		self::PROP_FEED_GENERATION_WALL_TIME       => false,
 	);
 
 	const PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feeds_';
@@ -96,6 +98,7 @@ class ProductFeedStatus {
 	public static function deregister() {
 
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
+			self::$state[ $key ] = $default_value;
 			delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
 		}
 	}
@@ -106,8 +109,8 @@ class ProductFeedStatus {
 	public static function reset_feed_file_generation_time() {
 		self::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => time(),
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 0,
+				self::PROP_FEED_GENERATION_WALL_START_TIME => time(),
+				self::PROP_FEED_GENERATION_WALL_TIME       => 0,
 			)
 		);
 	}
@@ -118,11 +121,11 @@ class ProductFeedStatus {
 	 * @param int $time_now - current time, e.g. time().
 	 */
 	public static function set_feed_file_generation_time( int $time_now ) {
-		$recent_feed_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$recent_feed_start_time = self::get()[ self::PROP_FEED_GENERATION_WALL_START_TIME ];
 		if ( false !== $recent_feed_start_time ) {
 			self::set(
 				array(
-					ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => $time_now - (int) $recent_feed_start_time,
+					self::PROP_FEED_GENERATION_WALL_TIME => $time_now - (int) $recent_feed_start_time,
 				)
 			);
 		}
@@ -132,9 +135,9 @@ class ProductFeedStatus {
 	 * Sets feed generation time into negative value to communicate feed generation failure.
 	 */
 	public static function mark_feed_file_generation_as_failed() {
-		ProductFeedStatus::set(
+		self::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => -1,
+				self::PROP_FEED_GENERATION_WALL_TIME => -1,
 			)
 		);
 	}

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -105,6 +105,9 @@ class ProductFeedStatus {
 
 	/**
 	 * Resets a feed generation start time.
+	 *
+	 * @since x.x.x
+	 * @return void
 	 */
 	public static function reset_feed_file_generation_time() {
 		self::set(
@@ -119,6 +122,8 @@ class ProductFeedStatus {
 	 * Calculates and sets feed generation time.
 	 *
 	 * @param int $time_now - current time, e.g. time().
+	 * @since x.x.x
+	 * @return void
 	 */
 	public static function set_feed_file_generation_time( int $time_now ) {
 		$recent_feed_start_time = self::get()[ self::PROP_FEED_GENERATION_WALL_START_TIME ];
@@ -133,6 +138,9 @@ class ProductFeedStatus {
 
 	/**
 	 * Sets feed generation time into negative value to communicate feed generation failure.
+	 *
+	 * @since x.x.x
+	 * @return void
 	 */
 	public static function mark_feed_file_generation_as_failed() {
 		self::set(

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -18,12 +18,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ProductFeedStatus {
 
 	const STATE_PROPS = array(
-		'status'                                   => 'pending_config',
-		'last_activity'                            => 0,
-		'product_count'                            => 0,
-		'error_message'                            => '',
-		self::PROP_FEED_GENERATION_WALL_START_TIME => false,
-		self::PROP_FEED_GENERATION_WALL_TIME       => false,
+		'status'                                        => 'pending_config',
+		'last_activity'                                 => 0,
+		'product_count'                                 => 0,
+		'error_message'                                 => '',
+		self::PROP_FEED_GENERATION_WALL_START_TIME      => false,
+		self::PROP_FEED_GENERATION_WALL_TIME            => 0,
+		self::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 0,
 	);
 
 	const PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feeds_';
@@ -31,6 +32,8 @@ class ProductFeedStatus {
 	const PROP_FEED_GENERATION_WALL_START_TIME = 'feed_generation_wall_start_time';
 
 	const PROP_FEED_GENERATION_WALL_TIME = 'feed_generation_wall_time';
+
+	const PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT = 'feed_generation_recent_product_count';
 
 	/**
 	 * The array that holds the state of the feed, used as cache.
@@ -96,10 +99,15 @@ class ProductFeedStatus {
 	 * @return void
 	 */
 	public static function deregister() {
-
+		$properties_to_persist = array(
+			self::PROP_FEED_GENERATION_WALL_TIME,
+			self::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT,
+		);
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
-			self::$state[ $key ] = $default_value;
-			delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
+			if ( ! in_array( $key, $properties_to_persist, true ) ) {
+				self::$state[ $key ] = $default_value;
+				delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
+			}
 		}
 	}
 
@@ -113,7 +121,6 @@ class ProductFeedStatus {
 		self::set(
 			array(
 				self::PROP_FEED_GENERATION_WALL_START_TIME => time(),
-				self::PROP_FEED_GENERATION_WALL_TIME       => 0,
 			)
 		);
 	}

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -26,6 +26,10 @@ class ProductFeedStatus {
 
 	const PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feeds_';
 
+	const PROP_FEED_GENERATION_WALL_START_TIME = 'feed_generation_wall_start_time';
+
+	const PROP_FEED_GENERATION_WALL_TIME = 'feed_generation_wall_time';
+
 	/**
 	 * The array that holds the state of the feed, used as cache.
 	 *
@@ -94,5 +98,44 @@ class ProductFeedStatus {
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
 			delete_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
 		}
+	}
+
+	/**
+	 * Resets a feed generation start time.
+	 */
+	public static function reset_feed_file_generation_time() {
+		self::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => time(),
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 0,
+			)
+		);
+	}
+
+	/**
+	 * Calculates and sets feed generation time.
+	 *
+	 * @param int $time_now - current time, e.g. time().
+	 */
+	public static function set_feed_file_generation_time( int $time_now ) {
+		$recent_feed_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		if ( false !== $recent_feed_start_time ) {
+			self::set(
+				array(
+					ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => $time_now - (int) $recent_feed_start_time,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Sets feed generation time into negative value to communicate feed generation failure.
+	 */
+	public static function mark_feed_file_generation_as_failed() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => -1,
+			)
+		);
 	}
 }

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -120,14 +120,14 @@ class ProductSync {
 	 * @since 1.0.10
 	 */
 	private static function initialize_feed_components() {
-		$action_scheduler        = new ActionSchedulerProxy();
 		self::$configurations    = LocalFeedConfigs::get_instance();
-		self::$feed_generator    = new FeedGenerator( $action_scheduler, self::$configurations );
-		self::$feed_registration = new FeedRegistration( self::$configurations, self::$feed_generator );
+		$action_scheduler        = new ActionSchedulerProxy();
+		$feed_file_operations    = new FeedFileOperations( self::$configurations );
+		self::$feed_generator    = new FeedGenerator( $action_scheduler, $feed_file_operations, self::$configurations );
+		self::$feed_registration = new FeedRegistration( self::$configurations, $feed_file_operations );
 
 		self::$feed_registration->init();
 		self::$feed_generator->init();
-
 	}
 
 	/**

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -66,7 +66,7 @@ class TrackerSnapshot {
 			),
 			'feed'     => array(
 				'generation_time' => $feed_generation_time,
-				'product_count'   => (int) ProductFeedStatus::get()['product_count'] ?? 0,
+				'product_count'   => (int) ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ] ?? 0,
 			),
 		);
 

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -19,22 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TrackerSnapshot {
 
 	/**
-	 * Transient key name; the time when was the feed generation started.
-	 *
-	 * @var string
-	 */
-	public const TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_wctracker_feed_generation_wall_start_time';
-
-	/**
-	 * Transient key name; the time it took to generate feed.
-	 *
-	 * @var string
-	 */
-	public const TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_wctracker_feed_generation_wall_time';
-
-	public const TRANSIENT_WCTRACKER_LIFE_TIME = 2 * WEEK_IN_SECONDS;
-
-	/**
 	 * Not needed if allow_tracking is disabled.
 	 *
 	 * @return bool Whether the object is needed.

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -66,7 +66,7 @@ class TrackerSnapshot {
 			),
 			'feed'     => array(
 				'generation_time' => $feed_generation_time,
-				'products_count'  => (int) ProductFeedStatus::get()['product_count'] ?? 0,
+				'product_count'   => (int) ProductFeedStatus::get()['product_count'] ?? 0,
 			),
 		);
 

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -18,6 +18,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TrackerSnapshot {
 
+	/**
+	 * Transient key name; the time when was the feed generation started.
+	 *
+	 * @var string
+	 */
+	public const TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_wctracker_feed_generation_wall_start_time';
+
+	/**
+	 * Transient key name; the time it took to generate feed.
+	 *
+	 * @var string
+	 */
+	public const TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_wctracker_feed_generation_wall_time';
+
+	public const TRANSIENT_WCTRACKER_LIFE_TIME = 2 * WEEK_IN_SECONDS;
 
 	/**
 	 * Not needed if allow_tracking is disabled.
@@ -57,8 +72,18 @@ class TrackerSnapshot {
 			$data['extensions'] = array();
 		}
 
+		$feed_generation_time = (int) get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
+
 		$data['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] = array(
 			'settings' => self::parse_settings(),
+			'store'    => [
+				'connected'        => Pinterest_For_Woocommerce::is_connected(),
+				'actively_syncing' => ProductSync::is_product_sync_enabled(),
+			],
+			'feed'     => [
+				'generation_time' => $feed_generation_time,
+				'products_count'  => ProductFeedStatus::get()['product_count'] ?? 0,
+			],
 		);
 
 		return $data;
@@ -86,5 +111,31 @@ class TrackerSnapshot {
 
 		$settings = array_intersect_key( $settings, array_flip( $tracked_settings ) );
 		return array_map( 'wc_bool_to_string', $settings ) + array( 'version' => PINTEREST_FOR_WOOCOMMERCE_VERSION );
+	}
+
+	/**
+	 * Resets a feed generation start time.
+	 *
+	 * @return bool
+	 */
+	public static function reset_feed_file_generation_time(): bool {
+		$start_time = set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, time(), self::TRANSIENT_WCTRACKER_LIFE_TIME );
+		$wall_time  = set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, 0, self::TRANSIENT_WCTRACKER_LIFE_TIME );
+		return $start_time && $wall_time;
+	}
+
+	/**
+	 * Calculates and sets feed generation time.
+	 *
+	 * @param int $time_now - current time, e.g. time().
+	 *
+	 * @return bool
+	 */
+	public static function set_feed_file_generation_time( int $time_now ): bool {
+		$recent_feed_start_time = get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
+		if ( false !== $recent_feed_start_time ) {
+			return set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, $time_now - (int) $recent_feed_start_time, self::TRANSIENT_WCTRACKER_LIFE_TIME );
+		}
+		return false;
 	}
 }

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -77,8 +77,8 @@ class TrackerSnapshot {
 		$data['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] = array(
 			'settings' => self::parse_settings(),
 			'store'    => array(
-				'connected'        => Pinterest_For_Woocommerce::is_connected(),
-				'actively_syncing' => ProductSync::is_product_sync_enabled(),
+				'connected'        => wc_bool_to_string( Pinterest_For_Woocommerce::is_connected() ),
+				'actively_syncing' => wc_bool_to_string( ProductSync::is_product_sync_enabled() ),
 			),
 			'feed'     => array(
 				'generation_time' => $feed_generation_time,

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -76,14 +76,14 @@ class TrackerSnapshot {
 
 		$data['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] = array(
 			'settings' => self::parse_settings(),
-			'store'    => [
+			'store'    => array(
 				'connected'        => Pinterest_For_Woocommerce::is_connected(),
 				'actively_syncing' => ProductSync::is_product_sync_enabled(),
-			],
-			'feed'     => [
+			),
+			'feed'     => array(
 				'generation_time' => $feed_generation_time,
 				'products_count'  => ProductFeedStatus::get()['product_count'] ?? 0,
-			],
+			),
 		);
 
 		return $data;

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -72,7 +72,7 @@ class TrackerSnapshot {
 			$data['extensions'] = array();
 		}
 
-		$feed_generation_time = (int) get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
+		$feed_generation_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 
 		$data['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] = array(
 			'settings' => self::parse_settings(),

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -62,7 +62,7 @@ class TrackerSnapshot {
 			'settings' => self::parse_settings(),
 			'store'    => array(
 				'connected'        => wc_bool_to_string( Pinterest_For_Woocommerce::is_connected() ),
-				'actively_syncing' => wc_bool_to_string( ProductSync::is_product_sync_enabled() ),
+				'actively_syncing' => wc_bool_to_string( ! ! Pinterest_For_Woocommerce::get_data( 'feed_registered' ) ),
 			),
 			'feed'     => array(
 				'generation_time' => $feed_generation_time,

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -82,7 +82,7 @@ class TrackerSnapshot {
 			),
 			'feed'     => array(
 				'generation_time' => $feed_generation_time,
-				'products_count'  => ProductFeedStatus::get()['product_count'] ?? 0,
+				'products_count'  => (int) ProductFeedStatus::get()['product_count'] ?? 0,
 			),
 		);
 
@@ -113,29 +113,5 @@ class TrackerSnapshot {
 		return array_map( 'wc_bool_to_string', $settings ) + array( 'version' => PINTEREST_FOR_WOOCOMMERCE_VERSION );
 	}
 
-	/**
-	 * Resets a feed generation start time.
-	 *
-	 * @return bool
-	 */
-	public static function reset_feed_file_generation_time(): bool {
-		$start_time = set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, time(), self::TRANSIENT_WCTRACKER_LIFE_TIME );
-		$wall_time  = set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, 0, self::TRANSIENT_WCTRACKER_LIFE_TIME );
-		return $start_time && $wall_time;
-	}
 
-	/**
-	 * Calculates and sets feed generation time.
-	 *
-	 * @param int $time_now - current time, e.g. time().
-	 *
-	 * @return bool
-	 */
-	public static function set_feed_file_generation_time( int $time_now ): bool {
-		$recent_feed_start_time = get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
-		if ( false !== $recent_feed_start_time ) {
-			return set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, $time_now - (int) $recent_feed_start_time, self::TRANSIENT_WCTRACKER_LIFE_TIME );
-		}
-		return false;
-	}
 }

--- a/tests/Unit/FeedFileOperationsTest.php
+++ b/tests/Unit/FeedFileOperationsTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\FeedFileOperations;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
+use Automattic\WooCommerce\Pinterest\ProductsXmlFeed;
+use Exception;
+
+class FeedFileOperationsTest extends \WP_UnitTestCase {
+
+	/** @var LocalFeedConfigs */
+	private $local_feed_configs;
+
+	public function setUp() {
+		parent::setUp();
+		$this->local_feed_configs = $this->createMock( LocalFeedConfigs::class );
+		ProductFeedStatus::set( ProductFeedStatus::STATE_PROPS );
+	}
+
+	public function test_prepare_temporary_files_creates_files_with_xml_headers() {
+		$US_temp_file = tempnam( sys_get_temp_dir(), 'USTestXMLHeader' );
+		$UA_temp_file = tempnam( sys_get_temp_dir(), 'UATestXMLHeader' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'tmp_file' => $US_temp_file,
+					),
+					'UA' => array(
+						'tmp_file' => $UA_temp_file,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$feed_file_operations->prepare_temporary_files();
+
+		$this->assertEquals( ProductsXmlFeed::get_xml_header(), file_get_contents( $US_temp_file ) );
+		$this->assertEquals( ProductsXmlFeed::get_xml_header(), file_get_contents( $UA_temp_file ) );
+	}
+
+	public function test_prepare_temporary_files_creates_files_with_xml_footers() {
+		$US_temp_file = tempnam( sys_get_temp_dir(), 'USTestXMLFooter' );
+		$UA_temp_file = tempnam( sys_get_temp_dir(), 'UATestXMLFooter' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'tmp_file' => $US_temp_file,
+					),
+					'UA' => array(
+						'tmp_file' => $UA_temp_file,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$feed_file_operations->add_footer_to_temporary_feed_files();
+
+		$this->assertEquals( ProductsXmlFeed::get_xml_footer(), file_get_contents( $US_temp_file ) );
+		$this->assertEquals( ProductsXmlFeed::get_xml_footer(), file_get_contents( $UA_temp_file ) );
+	}
+
+	public function test_if_feed_file_exists_returns_true_if_file_is_there() {
+		$US_temp_file = tempnam( sys_get_temp_dir(), 'USTestFeedFile' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'feed_file' => $US_temp_file,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$file_exists          = $feed_file_operations->check_if_feed_file_exists();
+
+		$this->assertTrue( $file_exists );
+	}
+
+	public function test_if_feed_file_exists_returns_false_if_config_is_empty() {
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn( array() );
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$file_exists          = $feed_file_operations->check_if_feed_file_exists();
+
+		$this->assertFalse( $file_exists );
+	}
+
+	public function test_if_feed_file_exists_returns_false_if_there_is_no_file() {
+		$US_temp_file = sys_get_temp_dir() . uniqid( 'USTestFeedFile' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'feed_file' => $US_temp_file,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$file_exists          = $feed_file_operations->check_if_feed_file_exists();
+
+		$this->assertFalse( $file_exists );
+	}
+
+	public function test_rename_temporary_feed_files_to_final_renames_successfully() {
+		$US_temp_file = tempnam( sys_get_temp_dir(), 'USFeedFile' );
+		$US_feed_file = sys_get_temp_dir() . uniqid( '/USFeedFile' );
+		$UA_temp_file = tempnam( sys_get_temp_dir(), 'UAFeedFile' );
+		$UA_feed_file = sys_get_temp_dir() . uniqid( '/UAFeedFile' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'tmp_file'  => $US_temp_file,
+						'feed_file' => $US_feed_file,
+					),
+					'UA' => array(
+						'tmp_file'  => $UA_temp_file,
+						'feed_file' => $UA_feed_file,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$feed_file_operations->rename_temporary_feed_files_to_final();
+
+		$this->assertTrue( file_exists( $US_feed_file ) );
+		$this->assertTrue( file_exists( $UA_feed_file ) );
+	}
+
+	public function test_rename_temporary_feed_files_to_final_throws_exception_if_rename_failed() {
+		// Silent the warning which rename() will produce if destination is a folder.
+		error_reporting(E_ERROR | E_PARSE);
+
+		// Set destination to be a folder to make rename() return false result.
+		$feed_file_name = '/';
+		$US_temp_file   = tempnam( sys_get_temp_dir(), 'USFeedFile' );
+		$UA_temp_file   = tempnam( sys_get_temp_dir(), 'UAFeedFile' );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( "Could not rename {$US_temp_file} to {$feed_file_name}" );
+
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'tmp_file'  => $US_temp_file,
+						'feed_file' => $feed_file_name,
+					),
+					'UA' => array(
+						'tmp_file'  => $UA_temp_file,
+						'feed_file' => $feed_file_name,
+					),
+				)
+			);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$feed_file_operations->rename_temporary_feed_files_to_final();
+	}
+
+	public function test_write_buffers_to_temp_files_writes_into_file() {
+		$US_temp_file = tempnam( sys_get_temp_dir(), 'USFeedFile' );
+		$UA_temp_file = tempnam( sys_get_temp_dir(), 'UAFeedFile' );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn(
+				array(
+					'US' => array(
+						'tmp_file'  => $US_temp_file,
+					),
+					'UA' => array(
+						'tmp_file'  => $UA_temp_file,
+					),
+				)
+			);
+
+		$buffers = array(
+			'US' => 'Some US buffer content...',
+			'UA' => 'Some UA buffer content...',
+		);
+
+		$feed_file_operations = new FeedFileOperations( $this->local_feed_configs );
+		$feed_file_operations->write_buffers_to_temp_files( $buffers );
+
+		$this->assertEquals( 'Some US buffer content...', file_get_contents( $US_temp_file ) );
+		$this->assertEquals( 'Some UA buffer content...', file_get_contents( $UA_temp_file ) );
+	}
+}

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -29,7 +29,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
 		$an_hour_ago = time() - 3600;
 		$this->assertGreaterThan( $an_hour_ago, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
-		$this->assertEquals( 0, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
+		$this->assertEquals( 0, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
 	}
 
 	function test_feed_generator_handle_end_action_sets_transient_with_the_time_it_took_to_generate_a_feed() {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
+
+class FeedGeneratorTest extends \WP_UnitTestCase {
+
+	function test_feed_generator_handle_start_action_sets_transient_with_the_feed_generation_start_and_total_time_initial_values() {
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
+
+		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
+		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
+
+		$feed_generator->handle_start_action( [] );
+
+		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
+		$an_hour_ago = time() - 3600;
+		$this->assertGreaterThan( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), $an_hour_ago );
+		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), 0 );
+	}
+
+	function test_feed_generator_handle_end_action_sets_transient_with_the_time_it_took_to_generate_a_feed() {
+		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 0 );
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
+
+		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
+		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
+
+		$feed_generator->handle_end_action( [] );
+
+		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
+		$an_hour_ago = time() - 3600;
+		$this->assertGreaterThan( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), $an_hour_ago );
+	}
+
+	function test_feed_generator_handle_end_action_sets_no_transient_with_the_time_it_took_to_generate_a_feed() {
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
+
+		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
+		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
+
+		$feed_generator->handle_end_action( [] );
+
+		$this->assertFalse( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
+	}
+}

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -6,14 +6,22 @@ use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerIn
 
 class FeedGeneratorTest extends \WP_UnitTestCase {
 
+	private ActionSchedulerInterface $action_scheduler;
+
+	private LocalFeedConfigs $local_feed_configs;
+
+	public function setUp() {
+		parent::setUp();
+		$this->action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$this->local_feed_configs = $this->createMock( LocalFeedConfigs::class );
+		$this->local_feed_configs->method( 'get_configurations' )->will( $this->returnValue( [] ) );
+	}
+
 	function test_feed_generator_handle_start_action_sets_transient_with_the_feed_generation_start_and_total_time_initial_values() {
 		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
 		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
 
-		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
-		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
-		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
-
+		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
 		$feed_generator->handle_start_action( [] );
 
 		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
@@ -26,10 +34,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 0 );
 		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
 
-		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
-		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
-		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
-
+		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
 		$feed_generator->handle_end_action( [] );
 
 		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
@@ -41,10 +46,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
 		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME );
 
-		$action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
-		$local_feed_configs = $this->createMock( LocalFeedConfigs::class );
-		$feed_generator     = new FeedGenerator( $action_scheduler, $local_feed_configs );
-
+		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
 		$feed_generator->handle_end_action( [] );
 
 		$this->assertFalse( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -28,8 +28,8 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
 		$an_hour_ago = time() - 3600;
-		$this->assertGreaterThan( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), $an_hour_ago );
-		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), 0 );
+		$this->assertGreaterThan( $an_hour_ago, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
+		$this->assertEquals( 0, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
 	}
 
 	function test_feed_generator_handle_end_action_sets_transient_with_the_time_it_took_to_generate_a_feed() {
@@ -41,7 +41,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		/* More or less a condition to check against. Unlikely Unit tests will ever take an hour to run. */
 		$an_hour_ago = time() - 3600;
-		$this->assertGreaterThan( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), $an_hour_ago );
+		$this->assertGreaterThan( $an_hour_ago, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
 	}
 
 	function test_feed_generator_handle_end_action_sets_no_transient_with_the_time_it_took_to_generate_a_feed() {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1,30 +1,46 @@
 <?php
 
-namespace Automattic\WooCommerce\Pinterest;
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
+use Automattic\WooCommerce\Pinterest\FeedFileOperations;
+use Automattic\WooCommerce\Pinterest\FeedGenerator;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
+use Exception;
 
 class FeedGeneratorTest extends \WP_UnitTestCase {
 
 	/** @var ActionSchedulerInterface */
 	private $action_scheduler;
 
+	/** @var FeedFileOperations */
+	private $feed_file_operations;
+
 	/** @var LocalFeedConfigs */
 	private $local_feed_configs;
 
+	/** @var FeedGenerator */
+	private $feed_generator;
+
 	public function setUp() {
 		parent::setUp();
-		$this->action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
-		$this->local_feed_configs = $this->createMock( LocalFeedConfigs::class );
-		$this->local_feed_configs->method( 'get_configurations' )->will( $this->returnValue( [] ) );
+		$this->action_scheduler     = $this->createMock( ActionSchedulerInterface::class );
+		$this->feed_file_operations = $this->createMock( FeedFileOperations::class );
+		$this->local_feed_configs   = $this->createMock( LocalFeedConfigs::class );
+		$this->local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn( array() );
+
+		$this->feed_generator = new FeedGenerator( $this->action_scheduler, $this->feed_file_operations, $this->local_feed_configs );
+
+		ProductFeedStatus::set( ProductFeedStatus::STATE_PROPS );
 	}
 
-	function test_feed_generator_handle_start_action_sets_product_feed_status_with_the_feed_generation_start_and_total_time_initial_values() {
+	public function test_feed_generator_start_sets_product_feed_status_generation_start_time() {
 		$time_test_started = time();
-		ProductFeedStatus::deregister();
 
-		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
-		$feed_generator->handle_start_action( [] );
+		$this->feed_generator->handle_start_action( array() );
 
 		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
 		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
@@ -33,30 +49,133 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertEquals( 0, $feed_generation_wall_time );
 	}
 
-	function test_feed_generator_handle_end_action_sets_product_feed_status_with_the_time_it_took_to_generate_a_feed() {
+	/**
+	 * When new feed generation starts, make sure not to reset previous run stats like total wall time it took to generate
+	 * the feed and a number of products that feed had.
+	 *
+	 * @return void
+	 */
+	public function test_feed_generator_start_does_not_reset_recent_product_count_and_wall_time() {
 		$time_test_started = time();
-		ProductFeedStatus::deregister();
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME      => 61461453,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 123,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 76823678,
+			)
+		);
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_product_count   = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_start_time );
+		$this->assertEquals( 123, $feed_generation_product_count );
+		$this->assertEquals( 76823678, $feed_generation_wall_time );
+	}
+
+	public function test_feed_generator_start_fails_and_exception_is_thrown() {
+		$this->expectException( Exception::class );
+		$this->feed_file_operations
+			->method( 'prepare_temporary_files' )
+			->willThrowException( new Exception() );
+
+		$this->feed_generator->handle_start_action( array() );
+	}
+
+	public function test_feed_generator_start_fails_and_sets_wall_time_to_negative() {
+		$this->feed_file_operations
+			->method( 'prepare_temporary_files' )
+			->willThrowException( new Exception() );
+
+		try {
+			$this->feed_generator->handle_start_action( array() );
+		} catch ( Exception $e ) {
+			$feed_generation_status        = ProductFeedStatus::get()[ 'status' ];
+			$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+			$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+			$this->assertEquals( 'error', $feed_generation_status );
+			$this->assertEquals( 0, $feed_generation_product_count );
+			$this->assertEquals( -1, $feed_generation_wall_time );
+		}
+	}
+
+	public function test_feed_generator_end_sets_time_it_took_to_generate_the_feed() {
+		$time_test_started = time();
 		ProductFeedStatus::set(
 			array(
 				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 0,
 			)
 		);
 
-		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
-		$feed_generator->handle_end_action( [] );
+		$this->feed_generator->handle_end_action( array() );
 
 		$feed_generation_wall_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 
 		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_time );
 	}
 
-	function test_feed_generator_handle_end_action_sets_no_product_feed_status_with_the_time_it_took_to_generate_a_feed() {
-		ProductFeedStatus::deregister();
+	public function test_feed_generator_end_sets_product_count_into_persistent_state_property() {
+		ProductFeedStatus::set(
+			array(
+				'product_count'                                              => 13,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 1,
+			)
+		);
 
-		$feed_generator = new FeedGenerator( $this->action_scheduler, $this->local_feed_configs );
-		$feed_generator->handle_end_action( [] );
+		$this->feed_generator->handle_end_action( array() );
 
-		$feed_generation_wall_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
-		$this->assertFalse( $feed_generation_wall_time );
+		$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+		$this->assertEquals( 13, $feed_generation_product_count );
+	}
+
+	public function test_feed_generator_end_fails_and_exception_is_thrown() {
+		$this->expectException( Exception::class );
+		$this->feed_file_operations
+			->method( 'add_footer_to_temporary_feed_files' )
+			->willThrowException( new Exception() );
+
+		$this->feed_generator->handle_end_action( array() );
+	}
+
+	public function test_feed_generator_end_fails_and_sets_wall_time_to_negative() {
+		$this->feed_file_operations
+			->method( 'add_footer_to_temporary_feed_files' )
+			->willThrowException( new Exception() );
+
+		try {
+			$this->feed_generator->handle_end_action( array() );
+		} catch ( Exception $e ) {
+			$feed_generation_status        = ProductFeedStatus::get()[ 'status' ];
+			$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+			$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+			$this->assertEquals( 'error', $feed_generation_status );
+			$this->assertEquals( 0, $feed_generation_product_count );
+			$this->assertEquals( -1, $feed_generation_wall_time );
+		}
+	}
+
+	public function test_while_feed_generator_is_in_progress_previous_wall_time_and_recent_product_count_are_not_overwritten() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 19,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 99,
+			)
+		);
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$status        = ProductFeedStatus::get()[ 'status' ];
+		$wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+		$this->assertEquals( 'in_progress', $status );
+		$this->assertEquals( 19, $wall_time );
+		$this->assertEquals( 99, $product_count );
 	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -6,9 +6,11 @@ use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerIn
 
 class FeedGeneratorTest extends \WP_UnitTestCase {
 
-	private ActionSchedulerInterface $action_scheduler;
+	/** @var ActionSchedulerInterface */
+	private $action_scheduler;
 
-	private LocalFeedConfigs $local_feed_configs;
+	/** @var LocalFeedConfigs */
+	private $local_feed_configs;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/Unit/ProductFeedStatusTest.php
+++ b/tests/Unit/ProductFeedStatusTest.php
@@ -34,7 +34,8 @@ class ProductFeedStatusTest extends \WP_UnitTestCase {
 	/**
 	 * Tests if ProductFeedStatus::deregister() does not clean up Feed Generation Wall Time
 	 * and Feed Generation Product Count from the previous successful run to be reused in case
-	 * of feed generation failure.
+	 * of feed generation in progress when tracker snapshot is running (not to get intermediate product count into
+	 * tracker parameters while generation is running we use numbers from the previous run).
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/ProductFeedStatusTest.php
+++ b/tests/Unit/ProductFeedStatusTest.php
@@ -8,52 +8,27 @@ class ProductFeedStatusTest extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		/**
-		 * Cleanup status before each test.
-		 * ProductFeedStatus::deregister() won't work here because deregister()
-		 * is made to skip some keys which values must be persisted e.g. recent feed generation time and
-		 * recent feed generation product count.
-		 */
-		ProductFeedStatus::set( ProductFeedStatus::STATE_PROPS );
+		ProductFeedStatus::deregister();
 	}
 
 	public function test_deregister_resets_feed_generation_product_feed_status_properties_to_defaults() {
 		ProductFeedStatus::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 11214,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME      => 11214,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 53452,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 43623,
 			)
 		);
 
 		ProductFeedStatus::deregister();
 
-		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$start_time    = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
-		$this->assertFalse( $feed_generation_wall_start_time );
-	}
-
-	/**
-	 * Tests if ProductFeedStatus::deregister() does not clean up Feed Generation Wall Time
-	 * and Feed Generation Product Count from the previous successful run to be reused in case
-	 * of feed generation in progress when tracker snapshot is running (not to get intermediate product count into
-	 * tracker parameters while generation is running we use numbers from the previous run).
-	 *
-	 * @return void
-	 */
-	public function test_deregister_does_not_clean_up_feed_generation_time_and_feed_product_count() {
-		ProductFeedStatus::set(
-			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 61515,
-				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 54,
-			)
-		);
-
-		ProductFeedStatus::deregister();
-
-		$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
-		$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
-
-		$this->assertEquals( 61515, $feed_generation_wall_time );
-		$this->assertEquals( 54, $feed_generation_product_count );
+		$this->assertFalse( $start_time );
+		$this->assertEquals( 0, $wall_time );
+		$this->assertEquals( 0, $product_count );
 	}
 
 	public function test_product_feed_state_has_feed_related_data_entries() {

--- a/tests/Unit/ProductFeedStatusTest.php
+++ b/tests/Unit/ProductFeedStatusTest.php
@@ -8,71 +8,106 @@ class ProductFeedStatusTest extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		/* Cleanup status before each test. */
-		ProductFeedStatus::deregister();
+		/**
+		 * Cleanup status before each test.
+		 * ProductFeedStatus::deregister() won't work here because deregister()
+		 * is made to skip some keys which values must be persisted e.g. recent feed generation time and
+		 * recent feed generation product count.
+		 */
+		ProductFeedStatus::set( ProductFeedStatus::STATE_PROPS );
 	}
 
 	public function test_deregister_resets_feed_generation_product_feed_status_properties_to_defaults() {
 		ProductFeedStatus::set(
 			array(
 				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 11214,
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 61515,
 			)
 		);
 
 		ProductFeedStatus::deregister();
 
 		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
-		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 
 		$this->assertFalse( $feed_generation_wall_start_time );
-		$this->assertFalse( $feed_generation_wall_time );
+	}
+
+	/**
+	 * Tests if ProductFeedStatus::deregister() does not clean up Feed Generation Wall Time
+	 * and Feed Generation Product Count from the previous successful run to be reused in case
+	 * of feed generation failure.
+	 *
+	 * @return void
+	 */
+	public function test_deregister_does_not_clean_up_feed_generation_time_and_feed_product_count() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 61515,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 54,
+			)
+		);
+
+		ProductFeedStatus::deregister();
+
+		$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
+
+		$this->assertEquals( 61515, $feed_generation_wall_time );
+		$this->assertEquals( 54, $feed_generation_product_count );
 	}
 
 	public function test_product_feed_state_has_feed_related_data_entries() {
 		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME, ProductFeedStatus::STATE_PROPS );
 		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME, ProductFeedStatus::STATE_PROPS );
+		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT, ProductFeedStatus::STATE_PROPS );
 	}
 
 	public function test_product_feed_state_remembers_feed_generation_data() {
 		ProductFeedStatus::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 4863486,
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 6464624,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME      => 4863486,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 6464624,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 63,
 			)
 		);
 
 		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
 		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_product_count   = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
 		$this->assertEquals( 4863486, $feed_generation_wall_start_time );
 		$this->assertEquals( 6464624, $feed_generation_wall_time );
+		$this->assertEquals( 63, $feed_generation_product_count );
 	}
 
 	public function test_product_feed_state_returns_defaults_for_feed_generation_data() {
-		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
-		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_wall_start_time      = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time            = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_recent_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
 		$this->assertFalse( $feed_generation_wall_start_time );
-		$this->assertFalse( $feed_generation_wall_time );
+		$this->assertEquals( 0, $feed_generation_wall_time );
+		$this->assertEquals( 0, $feed_generation_recent_product_count );
 	}
 
 	public function test_reset_feed_file_generation_time_resets_feed_generation_data_to_defaults() {
 		$time_test_started = time();
 		ProductFeedStatus::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 373111,
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 511511,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME      => 373111,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 511511,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 214,
 			)
 		);
 
 		ProductFeedStatus::reset_feed_file_generation_time();
 
-		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
-		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_wall_start_time      = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time            = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+		$feed_generation_recent_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
 		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_start_time );
-		$this->assertEquals( 0, $feed_generation_wall_time );
+		$this->assertEquals( 511511, $feed_generation_wall_time );
+		$this->assertEquals( 214, $feed_generation_recent_product_count );
 	}
 
 	public function test_set_feed_file_generation_time_sets_time_it_took_to_generate_the_feed() {

--- a/tests/Unit/ProductFeedStatusTest.php
+++ b/tests/Unit/ProductFeedStatusTest.php
@@ -6,7 +6,30 @@ use Pinterest_For_Woocommerce;
 
 class ProductFeedStatusTest extends \WP_UnitTestCase {
 
-	function test_product_feed_state_has_feed_related_data_entries() {
+	public function setUp() {
+		parent::setUp();
+		/* Cleanup status before each test. */
+		ProductFeedStatus::deregister();
+	}
+
+	public function test_deregister_resets_feed_generation_product_feed_status_properties_to_defaults() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 11214,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 61515,
+			)
+		);
+
+		ProductFeedStatus::deregister();
+
+		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->assertFalse( $feed_generation_wall_start_time );
+		$this->assertFalse( $feed_generation_wall_time );
+	}
+
+	public function test_product_feed_state_has_feed_related_data_entries() {
 		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME, ProductFeedStatus::STATE_PROPS );
 		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME, ProductFeedStatus::STATE_PROPS );
 	}
@@ -71,6 +94,6 @@ class ProductFeedStatusTest extends \WP_UnitTestCase {
 
 		$feed_generation_wall_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 
-		$this->asertEquals( -1, $feed_generation_wall_time );
+		$this->assertEquals( -1, $feed_generation_wall_time );
 	}
 }

--- a/tests/Unit/ProductFeedStatusTest.php
+++ b/tests/Unit/ProductFeedStatusTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Pinterest_For_Woocommerce;
+
+class ProductFeedStatusTest extends \WP_UnitTestCase {
+
+	function test_product_feed_state_has_feed_related_data_entries() {
+		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME, ProductFeedStatus::STATE_PROPS );
+		$this->assertArrayHasKey( ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME, ProductFeedStatus::STATE_PROPS );
+	}
+
+	public function test_product_feed_state_remembers_feed_generation_data() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 4863486,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 6464624,
+			)
+		);
+
+		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->assertEquals( 4863486, $feed_generation_wall_start_time );
+		$this->assertEquals( 6464624, $feed_generation_wall_time );
+	}
+
+	public function test_product_feed_state_returns_defaults_for_feed_generation_data() {
+		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->assertFalse( $feed_generation_wall_start_time );
+		$this->assertFalse( $feed_generation_wall_time );
+	}
+
+	public function test_reset_feed_file_generation_time_resets_feed_generation_data_to_defaults() {
+		$time_test_started = time();
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 373111,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME       => 511511,
+			)
+		);
+
+		ProductFeedStatus::reset_feed_file_generation_time();
+
+		$feed_generation_wall_start_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME ];
+		$feed_generation_wall_time       = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_start_time );
+		$this->assertEquals( 0, $feed_generation_wall_time );
+	}
+
+	public function test_set_feed_file_generation_time_sets_time_it_took_to_generate_the_feed() {
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_START_TIME => 10,
+			)
+		);
+
+		ProductFeedStatus::set_feed_file_generation_time( 12 );
+
+		$feed_generation_wall_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->assertEquals( 2, $feed_generation_wall_time );
+	}
+
+	public function test_mark_feed_file_generation_as_failed_sets_generation_wall_time_to_negative_value() {
+		ProductFeedStatus::mark_feed_file_generation_as_failed();
+
+		$feed_generation_wall_time = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
+
+		$this->asertEquals( -1, $feed_generation_wall_time );
+	}
+}

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -37,8 +37,8 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'no' );
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'no' );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], '0' );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['products_count'], '0' );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], 0 );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['products_count'], 0 );
 	}
 
 	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -34,6 +34,11 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['track_conversions'], 'yes', "Boolean track value 'true' is tracked as 'yes'" );
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['erase_plugin_data'], 'no', "Boolean track value 'false' is tracked as 'no'" );
 		$this->assertEquals( count( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings'] ), count(  self::$default_settings ), "All the values should be tracked" );
+
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'no' );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'no' );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], '0' );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['products_count'], '0' );
 	}
 
 	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {
@@ -49,4 +54,29 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 	}
 
+	function test_reset_feed_file_generation_time_resets_transients() {
+		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, 1234567 );
+		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 9876543 );
+
+		TrackerSnapshot::reset_feed_file_generation_time();
+
+		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), 0 );
+		$this->assertNotEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), 9876543 );
+	}
+
+	function test_set_feed_file_generation_time_calculates_generation_time() {
+		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 12 );
+
+		TrackerSnapshot::set_feed_file_generation_time( 10 );
+
+		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), 2 );
+	}
+
+	function test_set_feed_file_generation_time_does_not_set_generation_time() {
+		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
+
+		TrackerSnapshot::set_feed_file_generation_time( 10 );
+
+		$this->assertFalse( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
+	}
 }

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -67,7 +67,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 	function test_set_feed_file_generation_time_calculates_generation_time() {
 		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 12 );
 
-		TrackerSnapshot::set_feed_file_generation_time( 10 );
+		TrackerSnapshot::set_feed_file_generation_time( 14 );
 
 		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), 2 );
 	}

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -36,7 +36,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		$this->assertEquals( count( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings'] ), count(  self::$default_settings ), "All the values should be tracked" );
 	}
 
-	public function test_extension_connection_status_is_tracked_as_no_if_opt_in() {
+	public function test_extension_connection_status_is_tracked_as_no_if_no_feed_registered() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
@@ -46,24 +46,25 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'] );
 	}
 
-	public function test_extension_connection_status_is_tracked_as_yes_if_opt_in() {
-		$settings = array_merge(
-			self::$default_settings,
-			array(
-				'account_data'         => array(
-					'is_any_website_verified' => true,
-				),
-				'tracking_tag'         => true,
-				'product_sync_enabled' => true,
-			)
-		);
+	public function test_extension_connection_status_is_tracked_as_no_if_feed_registered_has_empty_value() {
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+		Pinterest_For_Woocommerce::save_data( 'feed_registered', '' );
 
-		Pinterest_For_Woocommerce::save_settings( $settings );
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+
+		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'] );
+		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'] );
+	}
+
+	public function test_extension_connection_status_is_tracked_as_yes_if_opt_in() {
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 		Pinterest_For_Woocommerce::save_token(
 			array(
 				'access_token' => 'some-fake-access-token',
 			)
 		);
+		Pinterest_For_Woocommerce::save_data( 'feed_registered', uniqid() );
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Automattic\WooCommerce\Pinterest;
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
+use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
+use Automattic\WooCommerce\Pinterest\TrackerSnapshot;
 use Pinterest_For_Woocommerce;
 
 class TrackerSnapshotTest extends \WP_UnitTestCase {
@@ -81,26 +83,32 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'product_count', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
 	}
 
-	public function test_extension_feed_generation_time_has_the_value_from_product_feed_status_storage() {
+	public function test_extension_feed_generation_time_and_recent_product_count_have_values_from_product_feed_status_storage() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
 
 		ProductFeedStatus::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => 786453786,
+				'product_count'                                              => 19,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => 786453786,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 99,
 			)
 		);
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 		$this->assertEquals( 786453786, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'] );
+		$this->assertEquals( 99, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['product_count'] );
 
 		ProductFeedStatus::set(
 			array(
-				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => -87935467089345,
+				'product_count'                                              => 39,
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME            => -87935467089345,
+				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 69,
 			)
 		);
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 		$this->assertEquals( -87935467089345, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'] );
+		$this->assertEquals( 69, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['product_count'] );
 	}
 
 	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -78,7 +78,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'feed', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX] );
 		$this->assertArrayHasKey( 'generation_time', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
-		$this->assertArrayHasKey( 'products_count', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
+		$this->assertArrayHasKey( 'product_count', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
 	}
 
 	public function test_extension_feed_generation_time_has_the_value_from_product_feed_status_storage() {

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -2,8 +2,9 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
-class TrackerSnapshotTest extends \WP_UnitTestCase {
+use Pinterest_For_Woocommerce;
 
+class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 	public static $default_settings = array(
 		'version'                => PINTEREST_FOR_WOOCOMMERCE_VERSION,
@@ -22,61 +23,88 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 	}
 
-
 	function test_settings_are_tracked_by_woo_tracker_if_opt_in() {
-
-		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['track_conversions'], 'yes', "Boolean track value 'true' is tracked as 'yes'" );
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['erase_plugin_data'], 'no', "Boolean track value 'false' is tracked as 'no'" );
 		$this->assertEquals( count( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings'] ), count(  self::$default_settings ), "All the values should be tracked" );
+	}
+
+	public function test_extension_connection_status_is_tracked_as_no_if_opt_in() {
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'no' );
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'no' );
+	}
+
+	public function test_extension_connection_status_is_tracked_as_yes_if_opt_in() {
+		$settings = array_merge(
+			self::$default_settings,
+			array(
+				'token'                => 'some-fake-token',
+				'account_data'         => array(
+					'is_any_website_verified' => true,
+				),
+				'tracking_tag'         => true,
+				'product_sync_enabled' => true,
+			)
+		);
+		Pinterest_For_Woocommerce::save_settings( $settings );
+
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'yes' );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'yes' );
+	}
+
+	public function test_extension_feed_status_is_tracked_if_opt_in() {
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+
+		TrackerSnapshot::maybe_init();
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], 0 );
 		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['products_count'], 0 );
 	}
 
-	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {
+	public function test_extension_feed_generation_time_has_the_value_of_the_transient() {
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
+		TrackerSnapshot::maybe_init();
+
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => 786453786,
+			)
+		);
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], 786453786 );
+
+		ProductFeedStatus::set(
+			array(
+				ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME => -87935467089345,
+			)
+		);
+		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
+		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], -87935467089345 );
+	}
+
+	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {
 		update_option( 'woocommerce_allow_tracking', 'no' );
 
-		\Pinterest_For_Woocommerce::save_settings( self::$default_settings );
+		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
 		$this->assertTrue( count($tracks) === 0, "Track data should be empty whe OPT-OUT" );
-
-	}
-
-	function test_reset_feed_file_generation_time_resets_transients() {
-		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME, 1234567 );
-		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 9876543 );
-
-		TrackerSnapshot::reset_feed_file_generation_time();
-
-		$this->assertEquals( 0, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
-		$this->assertNotEquals( 9876543, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
-	}
-
-	function test_set_feed_file_generation_time_calculates_generation_time() {
-		set_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME, 12 );
-
-		TrackerSnapshot::set_feed_file_generation_time( 14 );
-
-		$this->assertEquals( 2, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
-	}
-
-	function test_set_feed_file_generation_time_does_not_set_generation_time() {
-		delete_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME );
-
-		TrackerSnapshot::set_feed_file_generation_time( 10 );
-
-		$this->assertFalse( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
 	}
 }

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -60,8 +60,8 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 		TrackerSnapshot::reset_feed_file_generation_time();
 
-		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), 0 );
-		$this->assertNotEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ), 9876543 );
+		$this->assertEquals( 0, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
+		$this->assertNotEquals( 9876543, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_START_TIME ) );
 	}
 
 	function test_set_feed_file_generation_time_calculates_generation_time() {
@@ -69,7 +69,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 		TrackerSnapshot::set_feed_file_generation_time( 14 );
 
-		$this->assertEquals( get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ), 2 );
+		$this->assertEquals( 2, get_transient( TrackerSnapshot::TRANSIENT_WCTRACKER_FEED_GENERATION_WALL_TIME ) );
 	}
 
 	function test_set_feed_file_generation_time_does_not_set_generation_time() {

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -29,8 +29,8 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['track_conversions'], 'yes', "Boolean track value 'true' is tracked as 'yes'" );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['erase_plugin_data'], 'no', "Boolean track value 'false' is tracked as 'no'" );
+		$this->assertEquals( 'yes', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['track_conversions'], "Boolean track value 'true' is tracked as 'yes'" );
+		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings']['erase_plugin_data'], "Boolean track value 'false' is tracked as 'no'" );
 		$this->assertEquals( count( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['settings'] ), count(  self::$default_settings ), "All the values should be tracked" );
 	}
 
@@ -40,15 +40,14 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'no' );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'no' );
+		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'] );
+		$this->assertEquals( 'no', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'] );
 	}
 
 	public function test_extension_connection_status_is_tracked_as_yes_if_opt_in() {
 		$settings = array_merge(
 			self::$default_settings,
 			array(
-				'token'                => 'some-fake-token',
 				'account_data'         => array(
 					'is_any_website_verified' => true,
 				),
@@ -56,13 +55,19 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 				'product_sync_enabled' => true,
 			)
 		);
+
 		Pinterest_For_Woocommerce::save_settings( $settings );
+		Pinterest_For_Woocommerce::save_token(
+			array(
+				'access_token' => 'some-fake-access-token',
+			)
+		);
 
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'], 'yes' );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'], 'yes' );
+		$this->assertEquals( 'yes', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['connected'] );
+		$this->assertEquals( 'yes', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['store']['actively_syncing'] );
 	}
 
 	public function test_extension_feed_status_is_tracked_if_opt_in() {
@@ -71,11 +76,12 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], 0 );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['products_count'], 0 );
+		$this->assertArrayHasKey( 'feed', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX] );
+		$this->assertArrayHasKey( 'generation_time', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
+		$this->assertArrayHasKey( 'products_count', $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed'] );
 	}
 
-	public function test_extension_feed_generation_time_has_the_value_of_the_transient() {
+	public function test_extension_feed_generation_time_has_the_value_from_product_feed_status_storage() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
 		TrackerSnapshot::maybe_init();
@@ -86,7 +92,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 			)
 		);
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], 786453786 );
+		$this->assertEquals( 786453786, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'] );
 
 		ProductFeedStatus::set(
 			array(
@@ -94,7 +100,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 			)
 		);
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
-		$this->assertEquals( $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'], -87935467089345 );
+		$this->assertEquals( -87935467089345, $tracks['extensions'][PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX]['feed']['generation_time'] );
 	}
 
 	function test_settings_are_not_tracked_by_woo_tracker_if_opt_out() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Adding additional WC tracker data: feed generation time and products count, store connection status and product sync status;
- Refactoring feed file operations our of feed generator to unit test feed generation failures and proper tracker snapshot properties update;
- Adding more unit tests on involved classes;

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Basic test
1. Navigate to `WooCommerce > Status > Scheduled Actions > Pending`.
2. Run `pinterest-for-woocommerce-start-feed-generation` action.
3. Using WP CLI run a command `wp wc tracker snapshot`4. 
4. Check the comment output for 
```
... "store":{"connected":"yes","actively_syncing":"yes"},"feed":{"generation_time":111,"products_count":20} ...
```
5. `store` and `feed` objects must be present (they were not before, added within current PR) and have properties with values of the store connection status and sync status as well as recent feed generation details: time it took to generate the feed and the number of products went into the feed.
#### Test when previous results are displayed if feed generation is in progress
-1. Add new simple product into your catalog.
0. Put exit code above the line 173 to emulate feed generation job in progress (like it is having hard times generating 1100500 products)

https://github.com/woocommerce/pinterest-for-woocommerce/blob/0f0da243ff1ceec15b3f90fe029a0bedc9a9566b/src/FeedGenerator.php#L166-L173

**p.s.** _you can also add `sleep(3);` for example, because feed generation may run less than a second an wall time can have 0. value, by adding `sleep(3);` you know that wall time must be at least 3 and check it._

```
$this->feed_file_operations->rename_temporary_feed_files_to_final();
ProductFeedStatus::set(
	array(
		'status'                                                     => 'generated',
		ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => ProductFeedStatus::get()['product_count'],
	)
);
exit;
sleep(3);
ProductFeedStatus::set_feed_file_generation_time( time() );
```
1. Navigate to `WooCommerce > Status > Scheduled Actions > Pending`.
2. Run `pinterest-for-woocommerce-start-feed-generation` action.
3. Using WP CLI run a command `wp wc tracker snapshot`
4. Check the comment output for 
```
... "store":{"connected":"yes","actively_syncing":"yes"},"feed":{"generation_time":111,"products_count":20} ...
```
5. `store` and `feed` objects must be present and have the values from the previous **Basic test** case.
6. Go back to the code and remove `exit;`
7. Navigate to `WooCommerce > Status > Scheduled Actions > In progress` and remove in progress action on feed generation chain.
8. Navigate to `WooCommerce > Status > Scheduled Actions > Pending`.
9. Run `pinterest-for-woocommerce-start-feed-generation` action again.
10. Using WP CLI run a command `wp wc tracker snapshot`
11. Check the comment output for 
```
... "store":{"connected":"yes","actively_syncing":"yes"},"feed":{"generation_time":111,"products_count":20} ...
```
12. `feed` object must be present and contain the values from the new feed generation run: generation time at least 3, product count to be one product more that it was before.



### Changelog entry

> Add - Plugin connection and feed registration status tracking.
> Add - Recent feed generation time and feed product count tracking.
