### PR TITLE
Fix price mismatch when taxable address is different than shipping zone

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -495,7 +495,7 @@ class FeedGenerator extends AbstractChainedJob {
 	public function set_store_address_as_taxable_location( array $taxable_location ) {
 
 		if ( ! doing_action( $this->get_action_full_name( self::CHAIN_BATCH ) ) ) {
-			return;
+			return $taxable_location;
 		}
 
 		if ( isset( $taxable_location[0] ) ) {

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -90,6 +90,9 @@ class FeedGenerator extends AbstractChainedJob {
 		if ( false === as_has_scheduled_action( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
 			$this->schedule_next_generator_start( time() );
 		}
+
+		// Set the store address as taxable location.
+		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'set_store_address_as_taxable_location' ) );
 	}
 
 	/**
@@ -479,5 +482,26 @@ class FeedGenerator extends AbstractChainedJob {
 				)
 			)
 		);
+	}
+
+
+	/**
+	 * Set the store address as taxable location.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $taxable_location The taxable location.
+	 */
+	public function set_store_address_as_taxable_location( array $taxable_location ) {
+
+		if ( ! doing_action( $this->get_action_full_name( self::CHAIN_BATCH ) ) ) {
+			return;
+		}
+
+		if ( isset( $taxable_location[0] ) ) {
+			$taxable_location[0] = Pinterest_For_Woocommerce()::get_base_country();
+		}
+
+		return $taxable_location;
 	}
 }

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -391,9 +391,6 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_sale_price( $product, $property ) {
 
-		// Set the store address as taxable location.
-		add_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
-
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_sale_price' ) ) {
 			$regular_price = $product->get_variation_regular_price( 'min', true );
 			$sale_price    = $product->get_variation_sale_price( 'min', true );
@@ -408,8 +405,6 @@ class ProductsXmlFeed {
 				)
 			) : '';
 		}
-
-		remove_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
 
 		if ( empty( $price ) ) {
 			return;
@@ -566,8 +561,6 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_product_regular_price( $product ) {
-		// Set the store address as taxable location.
-		add_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
 
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
 			$price = $product->get_variation_regular_price( 'min', true );
@@ -580,26 +573,9 @@ class ProductsXmlFeed {
 			);
 		}
 
-		remove_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
-
 		return $price;
 	}
 
-	/**
-	 * Set the store address as taxable location.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param array $taxable_location The taxable location.
-	 */
-	public static function set_store_address_as_taxable_location( array $taxable_location ) {
-
-		if ( isset( $taxable_location[0] ) ) {
-			$taxable_location[0] = Pinterest_For_Woocommerce()::get_base_country();
-		}
-
-		return $taxable_location;
-	}
 
 	/**
 	 * Sanitize XML.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -561,6 +561,9 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_product_regular_price( $product ) {
+		// Set the store address as taxable location.
+		add_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
+
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_price' ) ) {
 			$price = $product->get_variation_regular_price( 'min', true );
 		} else {
@@ -572,7 +575,25 @@ class ProductsXmlFeed {
 			);
 		}
 
+		remove_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
+
 		return $price;
+	}
+
+	/**
+	 * Set the store address as taxable location.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $taxable_location The taxable location.
+	 */
+	public static function set_store_address_as_taxable_location( array $taxable_location ) {
+
+		if ( isset( $taxable_location[0] ) ) {
+			$taxable_location[0] = Pinterest_For_Woocommerce()::get_base_country();
+		}
+
+		return $taxable_location;
 	}
 
 	/**

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -391,6 +391,9 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_sale_price( $product, $property ) {
 
+		// Set the store address as taxable location.
+		add_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
+
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_sale_price' ) ) {
 			$regular_price = $product->get_variation_regular_price( 'min', true );
 			$sale_price    = $product->get_variation_sale_price( 'min', true );
@@ -405,6 +408,8 @@ class ProductsXmlFeed {
 				)
 			) : '';
 		}
+
+		remove_filter( 'woocommerce_customer_taxable_address', array( static::class, 'set_store_address_as_taxable_location' ) );
 
 		if ( empty( $price ) ) {
 			return;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #638.

There is a price mismatch between the feed and the price displayed in the shop if the following conditions are met:
- Price entered inclusive of taxes.
- Display prices in the shop including taxes.
- Store address in XX country (e.g. Spain).
- Tax set only for the country where the store is set (e.g. Spain).
- The last shipping zone in the list do not include the store's address: e.g.:
   - Europe (Flat Rate...)
   - US (Flat Rate...)

For this particular kind of scenario the price in the feed does not take into account the tax, since it gets the taxable address in a country different than Spain.

### Detailed test instructions:
1. Install a build of this PR.
2. Setup WC as described above (store address, tax region, shipping zone, etc).
3. The price in the feed should match with the price displayed in the shop.

### Changelog entry

> Fix - Price inconsistencies when tax region is different than shipping zone.
