### PR TITLE
Fix fatal error if get account data fails during onboarding

### DIFF
--- a/assets/source/setup-guide/app/views/WizardApp.js
+++ b/assets/source/setup-guide/app/views/WizardApp.js
@@ -45,15 +45,16 @@ const WizardApp = ( { query } ) => {
 
 	const appSettings = useSettingsSelect();
 	const isDomainVerified = useSettingsSelect( 'isDomainVerified' );
+	const createNotice = useCreateNotice();
 
 	useEffect( () => {
 		if ( ! isConnected ) {
 			setIsBusinessConnected( false );
 		}
-	}, [ isConnected, setIsBusinessConnected ] );
+		createNotice( 'error', wcSettings.pinterest_for_woocommerce.error );
+	}, [ isConnected, setIsBusinessConnected, createNotice ] );
 
 	useBodyClasses( 'wizard' );
-	useCreateNotice()( wcSettings.pinterest_for_woocommerce.error );
 
 	const steps = [
 		{

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -848,40 +848,51 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 *
 		 * @since 1.0.0
 		 *
-		 * @return array() account_data from Pinterest
+		 * @return array Account data from Pinterest.
+		 *
+		 * @throws Exception PHP Exception.
 		 */
 		public static function update_account_data() {
 
-			$account_data = Pinterest\API\Base::get_account_info();
+			try {
 
-			if ( 'success' === $account_data['status'] ) {
+				$account_data = Pinterest\API\Base::get_account_info();
 
-				$data = array_intersect_key(
-					(array) $account_data['data'],
-					array(
-						'verified_user_websites'  => '',
-						'is_any_website_verified' => '',
-						'username'                => '',
-						'full_name'               => '',
-						'id'                      => '',
-						'image_medium_url'        => '',
-						'is_partner'              => '',
-					)
-				);
+				if ( 'success' === $account_data['status'] ) {
 
-				/*
-				 * For now we assume that the billing is not setup and credits are not redeemed.
-				 * We will be able to check that only when the advertiser will be connected.
-				 * The billing is tied to advertiser.
-				 */
-				$data['is_billing_setup']   = false;
-				$data['coupon_redeem_info'] = array( 'redeem_status' => false );
+					$data = array_intersect_key(
+						(array) $account_data['data'],
+						array(
+							'verified_user_websites'  => '',
+							'is_any_website_verified' => '',
+							'username'                => '',
+							'full_name'               => '',
+							'id'                      => '',
+							'image_medium_url'        => '',
+							'is_partner'              => '',
+						)
+					);
 
-				Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
-				return $data;
+					/*
+					 * For now we assume that the billing is not setup and credits are not redeemed.
+					 * We will be able to check that only when the advertiser will be connected.
+					 * The billing is tied to advertiser.
+					 */
+					$data['is_billing_setup']   = false;
+					$data['coupon_redeem_info'] = array( 'redeem_status' => false );
+
+					Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
+					return $data;
+				}
+
+				self::get_linked_businesses( true );
+
+			} catch ( Throwable $th ) {
+
+				self::disconnect();
+
+				throw new Exception( esc_html__( 'There was an error getting the account data.', 'pinterest-for-woocommerce' ) );
 			}
-
-			self::get_linked_businesses( true );
 
 			return array();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #671.

Handle properly errors that may occur getting the account data after saving the authorization token during the onboarding.

### Detailed test instructions:
1. Install a build of this PR.
2. Add the following snippet:
`add_action( 'pinterest_for_woocommerce_token_saved', function() {
	throw new Exception( 'Test error during onboarding' );
}, 0 );`
3. An error notice should popup after connecting the account. Since we are simulating the error with an action the account is not disconnected. In a real scenario the account is disconnected too.

### Changelog entry

> Fix - Prevent fatal error if retrieving account fails during onboarding
