### PR TITLE
Fix issue with applicable products

### DIFF
--- a/src/Admin/Product/Attributes/AttributesTab.php
+++ b/src/Admin/Product/Attributes/AttributesTab.php
@@ -168,7 +168,7 @@ class AttributesTab {
 	 * @return AttributesForm
 	 */
 	protected function get_form( WC_Product $product ): AttributesForm {
-		$attribute_types = $this->attribute_manager->get_attribute_types_for_product_types( $this->get_applicable_product_types() );
+		$attribute_types = $this->attribute_manager->get_attribute_types_for_product_types( array_keys( $this->get_applicable_product_types() ) );
 
 		$form = new AttributesForm( $attribute_types, $this->attribute_manager->get_all_values( $product ) );
 		$form->set_name( 'attributes' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #679.
We introduced an issue in PR #496, the array of applicable products returns the product types as the keys of the array.

### Screenshots
![image](https://user-images.githubusercontent.com/40774170/214845436-dd1b945f-3a66-43ff-8c73-e683ccd8d7a7.png)

### Detailed test instructions:
1. Install a build of this PR.
2. The Pinterest tab on Simple products should not be empty.

### Changelog entry
> Fix - Missing Attributes form on Simple products.
