### PR TITLE
Add WordPress locale mapping to Pinterest API locale.

### DIFF
--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -230,6 +230,18 @@ const HealthCheck = () => {
 				'pinterest-for-woocommerce'
 			),
 		},
+		merchant_locale_not_valid: {
+			status: 'error',
+			dismissible: false,
+			message: __(
+				'Unable to register feed.',
+				'pinterest-for-woocommerce'
+			),
+			body: __(
+				'It looks like your WordPress language settings are not supported by Pinterest.',
+				'pinterest-for-woocommerce'
+			),
+		},
 		error: {
 			status: 'error',
 			dismissible: false,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,6 +20,7 @@
 	<rule ref="WooCommerce-Core">
 		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 
 	<!-- Specific excludes -->

--- a/src/API/HealthCheck.php
+++ b/src/API/HealthCheck.php
@@ -54,6 +54,11 @@ class HealthCheck extends VendorAPI {
 				return array( 'status' => 'merchant_connected_diff_platform' );
 			}
 
+			$locale_error = Pinterest_For_Woocommerce()::get_data( 'merchant_locale_not_valid' );
+			if ( $locale_error ) {
+				return array( 'status' => 'merchant_locale_not_valid' );
+			}
+
 			$merchant = Pinterest\Merchants::get_merchant();
 
 			if ( 'success' !== $merchant['status'] || empty( $merchant['data']->product_pin_approval_status ) ) {

--- a/src/Exception/PinterestApiLocaleException.php
+++ b/src/Exception/PinterestApiLocaleException.php
@@ -14,4 +14,4 @@ use Exception;
 /**
  * Exception thrown when the the application locale is not supported by the API.
  */
-class PinterestApiLocaleException extends Exception {}
+class PinterestApiLocaleException extends Exception implements PinterestException {}

--- a/src/Exception/PinterestApiLocaleException.php
+++ b/src/Exception/PinterestApiLocaleException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * PinterestApiLocaleException interface.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use Exception;
+
+/**
+ * Exception thrown when the the application locale is not supported by the API.
+ */
+class PinterestApiLocaleException extends Exception {}

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -80,7 +80,7 @@ class FeedRegistration {
 	public function handle_feed_registration() {
 
 		// Clean merchants error code.
-		Pinterest_For_Woocommerce()::save_data( 'merchant_connected_diff_platform', false );
+		$this->clear_merchant_error_code();
 
 		if ( ! self::feed_file_exists() ) {
 			self::log( 'Feed didn\'t fully generate yet. Retrying later.', 'debug' );
@@ -96,6 +96,7 @@ class FeedRegistration {
 			throw new Exception( esc_html__( 'Could not register feed.', 'pinterest-for-woocommerce' ) );
 
 		} catch ( PinterestApiLocaleException $e ) {
+			Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', true );
 
 			// translators: %s: Error message.
 			$error_message = "Could not register feed. Error: {$e->getMessage()}";
@@ -103,7 +104,6 @@ class FeedRegistration {
 
 		} catch ( Throwable $th ) {
 			if ( method_exists( $th, 'get_pinterest_code' ) && 4163 === $th->get_pinterest_code() ) {
-				// Save the error to read it during the Health Check.
 				Pinterest_For_Woocommerce()::save_data( 'merchant_connected_diff_platform', true );
 			}
 
@@ -111,6 +111,17 @@ class FeedRegistration {
 			return false;
 		}
 
+	}
+
+	/**
+	 * Clear merchant error code.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private function clear_merchant_error_code() {
+		Pinterest_For_Woocommerce()::save_data( 'merchant_connected_diff_platform', false );
+		Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', false );
 	}
 
 	/**

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Pinterest;
 use Exception;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
+use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -93,6 +94,12 @@ class FeedRegistration {
 			}
 
 			throw new Exception( esc_html__( 'Could not register feed.', 'pinterest-for-woocommerce' ) );
+
+		} catch ( PinterestApiLocaleException $e ) {
+
+			// translators: %s: Error message.
+			$error_message = "Could not register feed. Error: {$e->getMessage()}";
+			self::log( $error_message, 'error' );
 
 		} catch ( Throwable $th ) {
 			if ( method_exists( $th, 'get_pinterest_code' ) && 4163 === $th->get_pinterest_code() ) {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -12,8 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Pinterest\API\Base;
 use \Exception;
+use Automattic\WooCommerce\Pinterest\API\Base;
+use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 
 /**
  * Class handling fetch methods for feed profiles.
@@ -127,7 +128,13 @@ class Feeds {
 		$configured_path = dirname( $feed->location_config->full_feed_fetch_location );
 		$local_path      = dirname( $config['feed_url'] );
 		$local_country   = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
-		$local_locale    = LocaleMapper::get_locale_for_api();
+
+		try {
+			$local_locale = LocaleMapper::get_locale_for_api();
+		} catch ( PinterestApiLocaleException $e ) {
+			// Local feed locale is not supported by Pinterest.
+			return '';
+		}
 
 		$registered_feed = '';
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -128,14 +128,7 @@ class Feeds {
 		$configured_path = dirname( $feed->location_config->full_feed_fetch_location );
 		$local_path      = dirname( $config['feed_url'] );
 		$local_country   = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
-
-		try {
-			$local_locale = LocaleMapper::get_locale_for_api();
-		} catch ( PinterestApiLocaleException $e ) {
-			// Local feed locale is not supported by Pinterest.
-			return '';
-		}
-
+		$local_locale    = LocaleMapper::get_locale_for_api();
 		$registered_feed = '';
 
 		if ( $configured_path === $local_path && $local_country === $feed->country && $local_locale === $feed->locale ) {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -127,7 +127,7 @@ class Feeds {
 		$configured_path = dirname( $feed->location_config->full_feed_fetch_location );
 		$local_path      = dirname( $config['feed_url'] );
 		$local_country   = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
-		$local_locale    = LocaleMapper::get_locale_for_api( get_locale() );
+		$local_locale    = LocaleMapper::get_locale_for_api();
 
 		$registered_feed = '';
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -116,6 +116,7 @@ class Feeds {
 	 *
 	 * @param string $merchant_id The merchant ID.
 	 *
+	 * @throws PinterestApiLocaleException No valid locale found to check for the registered feed.
 	 * @return string Returns the ID of the feed if properly registered or an empty string otherwise.
 	 */
 	public static function is_local_feed_registered( $merchant_id ) {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -127,7 +127,7 @@ class Feeds {
 		$configured_path = dirname( $feed->location_config->full_feed_fetch_location );
 		$local_path      = dirname( $config['feed_url'] );
 		$local_country   = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
-		$local_locale    = str_replace( '_', '-', determine_locale() );
+		$local_locale    = LocaleMapper::get_locale_for_api( get_locale() );
 
 		$registered_feed = '';
 

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -10,7 +10,7 @@ namespace Automattic\WooCommerce\Pinterest;
 
 defined( 'ABSPATH' ) || exit;
 
-use Exception;
+use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 
 /**
  * Class LocaleMapper.
@@ -83,7 +83,7 @@ class LocaleMapper {
 	 *
 	 * @since x.x.x
 	 * @return string
-	 * @throws Exception If no matching locale code is found.
+	 * @throws PinterestApiLocaleException If no matching locale code is found.
 	 */
 	public static function get_locale_for_api() {
 		$locale = self::get_wordpress_locale();
@@ -101,7 +101,7 @@ class LocaleMapper {
 		}
 
 		// If no match was found, throw an exception.
-		throw new Exception( 'No matching Pinterest API locale found for ' . $locale );
+		throw new PinterestApiLocaleException( 'No matching Pinterest API locale found for ' . $locale );
 	}
 
 	/**

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -94,7 +94,7 @@ class LocaleMapper {
 		}
 
 		// If the locale is not in the list of Pinterest locales, try to find a match for just the language code.
-		$locale_parts = explode( '_', $locale );
+		$locale_parts = explode( '-', $locale );
 
 		if ( in_array( $locale_parts[0], self::PINTEREST_LOCALE_CODES, true ) ) {
 			return $locale_parts[0];

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -86,21 +86,32 @@ class LocaleMapper {
 	 * @throws Exception If no matching locale code is found.
 	 */
 	public static function get_locale_for_api() {
-		$wordpress_locale = determine_locale();
+		$locale = self::get_wordpress_locale();
 
 		// If the locale is in the list of Pinterest locales, return it.
-		if ( in_array( $wordpress_locale, self::PINTEREST_LOCALE_CODES, true ) ) {
-			return str_replace( '_', '-', $wordpress_locale );
+		if ( in_array( $locale, self::PINTEREST_LOCALE_CODES, true ) ) {
+			return $locale;
 		}
 
 		// If the locale is not in the list of Pinterest locales, try to find a match for just the language code.
-		$wordpress_locale_parts = explode( '_', $wordpress_locale );
+		$locale_parts = explode( '_', $locale );
 
-		if ( in_array( $wordpress_locale_parts[0], self::PINTEREST_LOCALE_CODES, true ) ) {
-			return $wordpress_locale_parts[0];
+		if ( in_array( $locale_parts[0], self::PINTEREST_LOCALE_CODES, true ) ) {
+			return $locale_parts[0];
 		}
 
 		// If no match was found, throw an exception.
-		throw new Exception( 'No matching API locale found for ' . $wordpress_locale );
+		throw new Exception( 'No matching Pinterest API locale found for ' . $locale );
+	}
+
+	/**
+	 * Get WordPress locale code.
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private static function get_wordpress_locale() {
+		$wordpress_locale = determine_locale();
+		return str_replace( '_', '-', $wordpress_locale );
 	}
 }

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Pinterest for WooCommerce locale mapping class.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ * @version x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Exception;
+
+/**
+ * Class LocaleMapper.
+ *
+ * This class maps WooCommerce locale codes to Pinterest locale codes.
+ * Pinterest API uses a different set of locale codes than WordPress.
+ * Most of the time, the locale codes are the same, but there are some exceptions.
+ * Like for example German Standard is de_DE in WordPress, but de in Pinterest.
+ *
+ * @since x.x.x
+ */
+class LocaleMapper {
+
+	/**
+	 * Pinterest locale codes.
+	 * Locales have been collected on 01.02.2023 from Pinterest API response message.
+	 */
+	const PINTEREST_LOCALE_CODES = array(
+		'it',
+		'es-419',
+		'ru-RU',
+		'hu-HU',
+		'hr-HR',
+		'sv-SE',
+		'de',
+		'nb-NO',
+		'th-TH',
+		'sk-SK',
+		'ro-RO',
+		'es-MX',
+		'uk-UA',
+		'nl',
+		'en-AU',
+		'he-IL',
+		'tr',
+		'es-ES',
+		'pl-PL',
+		'cs-CZ',
+		'en-CA',
+		'fi-FI',
+		'pt-PT',
+		'el-GR',
+		'ja',
+		'ar-SA',
+		'fr-CA',
+		'en-GB',
+		'es-AR',
+		'da-DK',
+		'zh-CN',
+		'en-US',
+		'vi-VN',
+		'id-ID',
+		'bg-BG',
+		'zh-TW',
+		'en-IN',
+		'tl-PH',
+		'ko-KR',
+		'af-ZA',
+		'ms-MY',
+		'bn-IN',
+		'te-IN',
+		'fr',
+		'hi-IN',
+		'pt-BR',
+	);
+
+	/**
+	 * Get Pinterest locale code for API.
+	 * Pinterest API uses hyphens instead of underscores in locale codes so we need to replace them.
+	 *
+	 * @since x.x.x
+	 * @return string
+	 * @throws Exception If no matching locale code is found.
+	 */
+	public static function get_locale_for_api() {
+		$wordpress_locale = determine_locale();
+
+		// If the locale is in the list of Pinterest locales, return it.
+		if ( in_array( $wordpress_locale, self::PINTEREST_LOCALE_CODES, true ) ) {
+			return str_replace( '_', '-', $wordpress_locale );
+		}
+
+		// If the locale is not in the list of Pinterest locales, try to find a match for just the language code.
+		$wordpress_locale_parts = explode( '_', $wordpress_locale );
+
+		if ( in_array( $wordpress_locale_parts[0], self::PINTEREST_LOCALE_CODES, true ) ) {
+			return $wordpress_locale_parts[0];
+		}
+
+		// If no match was found, throw an exception.
+		throw new Exception( 'No matching API locale found for ' . $wordpress_locale );
+	}
+}

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -29,52 +29,52 @@ class LocaleMapper {
 	 * Locales have been collected on 01.02.2023 from Pinterest API response message.
 	 */
 	const PINTEREST_LOCALE_CODES = array(
-		'it',
-		'es-419',
-		'ru-RU',
-		'hu-HU',
-		'hr-HR',
-		'sv-SE',
-		'de',
-		'nb-NO',
-		'th-TH',
-		'sk-SK',
-		'ro-RO',
-		'es-MX',
-		'uk-UA',
-		'nl',
-		'en-AU',
-		'he-IL',
-		'tr',
-		'es-ES',
-		'pl-PL',
-		'cs-CZ',
-		'en-CA',
-		'fi-FI',
-		'pt-PT',
-		'el-GR',
-		'ja',
-		'ar-SA',
-		'fr-CA',
-		'en-GB',
-		'es-AR',
-		'da-DK',
-		'zh-CN',
-		'en-US',
-		'vi-VN',
-		'id-ID',
-		'bg-BG',
-		'zh-TW',
-		'en-IN',
-		'tl-PH',
-		'ko-KR',
-		'af-ZA',
-		'ms-MY',
-		'bn-IN',
-		'te-IN',
-		'fr',
-		'hi-IN',
-		'pt-BR',
+		'it'     => 1,
+		'es-419' => 1,
+		'ru-RU'  => 1,
+		'hu-HU'  => 1,
+		'hr-HR'  => 1,
+		'sv-SE'  => 1,
+		'de'     => 1,
+		'nb-NO'  => 1,
+		'th-TH'  => 1,
+		'sk-SK'  => 1,
+		'ro-RO'  => 1,
+		'es-MX'  => 1,
+		'uk-UA'  => 1,
+		'nl'     => 1,
+		'en-AU'  => 1,
+		'he-IL'  => 1,
+		'tr'     => 1,
+		'es-ES'  => 1,
+		'pl-PL'  => 1,
+		'cs-CZ'  => 1,
+		'en-CA'  => 1,
+		'fi-FI'  => 1,
+		'pt-PT'  => 1,
+		'el-GR'  => 1,
+		'ja'     => 1,
+		'ar-SA'  => 1,
+		'fr-CA'  => 1,
+		'en-GB'  => 1,
+		'es-AR'  => 1,
+		'da-DK'  => 1,
+		'zh-CN'  => 1,
+		'en-US'  => 1,
+		'vi-VN'  => 1,
+		'id-ID'  => 1,
+		'bg-BG'  => 1,
+		'zh-TW'  => 1,
+		'en-IN'  => 1,
+		'tl-PH'  => 1,
+		'ko-KR'  => 1,
+		'af-ZA'  => 1,
+		'ms-MY'  => 1,
+		'bn-IN'  => 1,
+		'te-IN'  => 1,
+		'fr'     => 1,
+		'hi-IN'  => 1,
+		'pt-BR'  => 1,
 	);
 
 	/**
@@ -89,15 +89,15 @@ class LocaleMapper {
 		$locale = self::get_wordpress_locale();
 
 		// If the locale is in the list of Pinterest locales, return it.
-		if ( in_array( $locale, self::PINTEREST_LOCALE_CODES, true ) ) {
+		if ( array_key_exists( $locale, self::PINTEREST_LOCALE_CODES ) ) {
 			return $locale;
 		}
 
 		// If the locale is not in the list of Pinterest locales, try to find a match for just the language code.
-		$locale_parts = explode( '-', $locale );
+		[ $language ] = explode( '-', $locale );
 
-		if ( in_array( $locale_parts[0], self::PINTEREST_LOCALE_CODES, true ) ) {
-			return $locale_parts[0];
+		if ( array_key_exists( $language, self::PINTEREST_LOCALE_CODES ) ) {
+			return $language;
 		}
 
 		// If no match was found, throw an exception.

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -101,7 +101,8 @@ class LocaleMapper {
 		}
 
 		// If no match was found, throw an exception.
-		throw new PinterestApiLocaleException( 'No matching Pinterest API locale found for ' . $locale );
+		// translators: %s is the locale code.
+		throw new PinterestApiLocaleException( sprintf( __( 'No matching Pinterest API locale found for %s', 'pinterest-for-woocommerce' ), $locale ) );
 	}
 
 	/**

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -167,7 +167,11 @@ class Merchants {
 			throw new Exception( __( 'Response error when trying to create a merchant or update the existing one.', 'pinterest-for-woocommerce' ), 400 );
 		}
 
-		$registered_feed = Feeds::is_local_feed_registered( $response['data'] );
+		try {
+			$registered_feed = Feeds::is_local_feed_registered( $response['data'] );
+		} catch ( Throwable $th ) {
+			$registered_feed = '';
+		}
 
 		// Clean the cached delay.
 		Pinterest_For_Woocommerce()::save_data( 'create_merchant_delay', false );

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -137,7 +137,7 @@ class Merchants {
 			'feed_location'    => $config['feed_url'],
 			'feed_format'      => 'XML',
 			'country'          => Pinterest_For_Woocommerce()::get_base_country() ?? 'US',
-			'locale'           => str_replace( '_', '-', determine_locale() ),
+			'locale'           => LocaleMapper::get_locale_for_api(),
 			'currency'         => get_woocommerce_currency(),
 			'merchant_name'    => $merchant_name,
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #683  .

Pinterest API requires a different set of locales compared to what is used in WordPress. Most of the time the locales match. Sometimes 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Enable debug logging. 

**- supported locale**

1. Select one of the supported locales ( check #683 for the list ), WordPress language settings.
2. Perform the full onboarding flow.
3. Things should work.
4. ( logs ) call to https://api.pinterest.com/v3/catalogs/partner/connect/ should be OK

**- partially supported locale**

1. Select one of the partially supported locales ( check #683 for the list ), WordPress language settings.
2. Perform the full onboarding flow.
3. Things should work.
4. ( logs ) call to https://api.pinterest.com/v3/catalogs/partner/connect/ should be OK

**- unsupported locale** 

1. Select a locale that is not supported, ( not on the list in #683 ), WordPress language settings.
2. Perform the full onboarding flow.
3. Things should not work. 
4. ( logs ) **No** call to https://api.pinterest.com/v3/catalogs/partner/connect/ in logs
5. The following message should be visible in the UI ( Marketing -> Pinterest )
<img width="883" alt="image" src="https://user-images.githubusercontent.com/17271089/217277911-48218431-a431-437e-a170-ccd9d49caca3.png">

### Additional details:

#688 implements unit tests for this feature.

The error message copy ( last testing scenario ) is not final. We want to add a link to supported languages somewhere inside the Pinterest documentation. That page is not available yet. It will be a separate PR when the page will be created.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Add - WordPress locale to Pinterest locale mapping.
