### PR TITLE
Add disapproval reasons

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -87,6 +87,8 @@ Clicking on an external documentation link.
     - with `{ link_id: 'terms-of-service', context: 'ads-credits-terms-and-conditions' }`
 	- with `{ link_id: 'privacy-policy', context: 'ads-credits-terms-and-conditions' }`
 	- with `{ link_id: 'advertising-services-agreement', context: 'ads-credits-terms-and-conditions' }`
+- [FormattedReasons]( assets/source/setup-guide/app/components/HealthCheck/index.js#L29)
+    - with `{ link_id: 'merchant-guidelines', context: 'merchant-disapproval-reasons' }`
 ### [`wcadmin_pfw_domain_verify_failure`](assets/source/setup-guide/app/steps/ClaimWebsite.js#L69)
 Triggered when domain verification fails.
 #### Properties

--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -17,6 +17,15 @@ import './style.scss';
 import { useSettingsSelect, useCreateNotice } from '../../helpers/effects';
 import { DISAPPROVAL_COPY_STATES } from '../../constants';
 
+/**
+ * Render the list of the disapproval reasons.
+ *
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: 'merchant-disapproval-reasons' }`
+ *
+ * @param {Object} props React props
+ * @param {Array} props.reasons
+ * @return { JSX.Element } The rendered element
+ */
 const FormattedReasons = ( { reasons } ) => {
 	if ( reasons === undefined ) {
 		return null;

--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -31,18 +31,18 @@ const FormattedReasons = ( { reasons } ) => {
 		return null;
 	}
 
-	return (
-		<ul className="ul-square">
-			{ reasons.map(
-				( reason ) =>
-					undefined !== DISAPPROVAL_COPY_STATES[ reason ] && (
-						<li key={ reason }>
-							{ DISAPPROVAL_COPY_STATES[ reason ] }
-						</li>
-					)
-			) }
-		</ul>
+	const formattedReasons = reasons.map(
+		( reason ) =>
+			undefined !== DISAPPROVAL_COPY_STATES[ reason ] && (
+				<li key={ reason }>{ DISAPPROVAL_COPY_STATES[ reason ] }</li>
+			)
 	);
+
+	if ( ! formattedReasons ) {
+		return null;
+	}
+
+	return <ul className="ul-square">{ formattedReasons }</ul>;
 };
 
 const HealthCheck = () => {

--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -57,6 +57,14 @@ const DISAPPROVAL_COPY_STATES = {
 		"Merchant's information is incomplete or plagiarized",
 		'pinterest-for-woocommerce'
 	),
+	AUTHENTICITY_NO_SOCIALS_OR_ABOUT: __(
+		"There is no 'About Us' page or no social information in your website",
+		'pinterest-for-woocommerce'
+	),
+	AUTHENTICITY_NO_CONTACT_INFORMATION: __(
+		'There is no contact information in your website',
+		'pinterest-for-woocommerce'
+	),
 	IN_STOCK: __(
 		"Merchant's products are out of stock",
 		'pinterest-for-woocommerce'
@@ -111,6 +119,10 @@ const DISAPPROVAL_COPY_STATES = {
 	),
 	BRAND_REPUTATION: __(
 		'Account does not meet the brand reputation criteria for verification',
+		'pinterest-for-woocommerce'
+	),
+	INCOMPLETE_WEBSITE_TEMPLATE: __(
+		'The template of the website is incomplete',
 		'pinterest-for-woocommerce'
 	),
 };

--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -15,117 +15,7 @@ import {
  */
 import './style.scss';
 import { useSettingsSelect, useCreateNotice } from '../../helpers/effects';
-
-const DISAPPROVAL_COPY_STATES = {
-	MARKETPLACE: __(
-		'Merchant is an affiliate or resale marketplace',
-		'pinterest-for-woocommerce'
-	),
-	PROHIBITED_PRODUCTS: __(
-		'Merchant does not meet our policy on prohibited products',
-		'pinterest-for-woocommerce'
-	),
-	SERVICES: __(
-		'Merchant offers services rather than products',
-		'pinterest-for-woocommerce'
-	),
-	DOMAIN_AGE: __(
-		"Merchant's domain age does not meet minimum requirement",
-		'pinterest-for-woocommerce'
-	),
-	DOMAIN_MISMATCH: __(
-		'Merchant domain mismatched with merchant account',
-		'pinterest-for-woocommerce'
-	),
-	BROKEN_URL: __(
-		"Merchant's URL is broken or requires registration",
-		'pinterest-for-woocommerce'
-	),
-	INCOMPLETE: __(
-		"Merchant's URL is incomplete or inaccessible",
-		'pinterest-for-woocommerce'
-	),
-	NO_SHIPPING_POLICY: __(
-		"Merchant's shipping policy is unclear or unavailable",
-		'pinterest-for-woocommerce'
-	),
-	NO_RETURN_POLICY: __(
-		"Merchant's returns policy is unclear or unavailable",
-		'pinterest-for-woocommerce'
-	),
-	AUTHENTICITY: __(
-		"Merchant's information is incomplete or plagiarized",
-		'pinterest-for-woocommerce'
-	),
-	AUTHENTICITY_NO_SOCIALS_OR_ABOUT: __(
-		"There is no 'About Us' page or no social information in your website",
-		'pinterest-for-woocommerce'
-	),
-	AUTHENTICITY_NO_CONTACT_INFORMATION: __(
-		'There is no contact information in your website',
-		'pinterest-for-woocommerce'
-	),
-	IN_STOCK: __(
-		"Merchant's products are out of stock",
-		'pinterest-for-woocommerce'
-	),
-	BANNER_ADS: __(
-		"Merchant's website includes banner or pop-up ads",
-		'pinterest-for-woocommerce'
-	),
-	IMAGE_QUALITY: __(
-		"Merchant's products do not meet image quality requirements",
-		'pinterest-for-woocommerce'
-	),
-	WATERMARKS: __(
-		"Merchant's product images include watermarks",
-		'pinterest-for-woocommerce'
-	),
-	SALE: __(
-		"Merchant's products are always on sale",
-		'pinterest-for-woocommerce'
-	),
-	OUT_OF_DATE: __(
-		"Merchant's products refer to outdated content",
-		'pinterest-for-woocommerce'
-	),
-	PRODUCT_DESCRIPTION: __(
-		"Merchant's website uses generic product descriptions",
-		'pinterest-for-woocommerce'
-	),
-	POP_UP: __(
-		"Merchant's website displays several pop-up messages",
-		'pinterest-for-woocommerce'
-	),
-	INAUTHENTIC_PHOTOS: __(
-		"Merchant's product images are unavailable or mismatched",
-		'pinterest-for-woocommerce'
-	),
-	RESALE_MARKETPLACE: __(
-		'Resale marketplaces are not allowed',
-		'pinterest-for-woocommerce'
-	),
-	AFFILIATE_MARKETPLACE: __(
-		'Affiliate links are not allowed',
-		'pinterest-for-woocommerce'
-	),
-	WEBSITE_REQUIREMENTS: __(
-		'Account does not meet the website requirements for verification',
-		'pinterest-for-woocommerce'
-	),
-	PRODUCT_REQUIREMENTS: __(
-		'Account does not meet the product requirements for verification',
-		'pinterest-for-woocommerce'
-	),
-	BRAND_REPUTATION: __(
-		'Account does not meet the brand reputation criteria for verification',
-		'pinterest-for-woocommerce'
-	),
-	INCOMPLETE_WEBSITE_TEMPLATE: __(
-		'The template of the website is incomplete',
-		'pinterest-for-woocommerce'
-	),
-};
+import { DISAPPROVAL_COPY_STATES } from '../../constants';
 
 const FormattedReasons = ( { reasons } ) => {
 	if ( reasons === undefined ) {
@@ -134,9 +24,14 @@ const FormattedReasons = ( { reasons } ) => {
 
 	return (
 		<ul className="ul-square">
-			{ reasons.map( ( reason ) => (
-				<li key={ reason }>{ DISAPPROVAL_COPY_STATES[ reason ] }</li>
-			) ) }
+			{ reasons.map(
+				( reason ) =>
+					undefined !== DISAPPROVAL_COPY_STATES[ reason ] && (
+						<li key={ reason }>
+							{ DISAPPROVAL_COPY_STATES[ reason ] }
+						</li>
+					)
+			) }
 		</ul>
 	);
 };

--- a/assets/source/setup-guide/app/constants.js
+++ b/assets/source/setup-guide/app/constants.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Enum of general label status.
  *
  * @readonly
@@ -19,4 +24,118 @@ export const PROCESS_STATUS = Object.freeze( {
 	...LABEL_STATUS,
 	IDLE: 'idle',
 	ERROR: 'error',
+} );
+
+/**
+ * Enum of the disapproval reasons for merchants.
+ */
+export const DISAPPROVAL_COPY_STATES = Object.freeze( {
+	MARKETPLACE: __(
+		'Merchant is an affiliate or resale marketplace',
+		'pinterest-for-woocommerce'
+	),
+	PROHIBITED_PRODUCTS: __(
+		'Merchant does not meet our policy on prohibited products',
+		'pinterest-for-woocommerce'
+	),
+	SERVICES: __(
+		'Merchant offers services rather than products',
+		'pinterest-for-woocommerce'
+	),
+	DOMAIN_AGE: __(
+		"Merchant's domain age does not meet minimum requirement",
+		'pinterest-for-woocommerce'
+	),
+	DOMAIN_MISMATCH: __(
+		'Merchant domain mismatched with merchant account',
+		'pinterest-for-woocommerce'
+	),
+	BROKEN_URL: __(
+		"Merchant's URL is broken or requires registration",
+		'pinterest-for-woocommerce'
+	),
+	INCOMPLETE: __(
+		"Merchant's URL is incomplete or inaccessible",
+		'pinterest-for-woocommerce'
+	),
+	NO_SHIPPING_POLICY: __(
+		"Merchant's shipping policy is unclear or unavailable",
+		'pinterest-for-woocommerce'
+	),
+	NO_RETURN_POLICY: __(
+		"Merchant's returns policy is unclear or unavailable",
+		'pinterest-for-woocommerce'
+	),
+	AUTHENTICITY: __(
+		"Merchant's information is incomplete or plagiarized",
+		'pinterest-for-woocommerce'
+	),
+	AUTHENTICITY_NO_SOCIALS_OR_ABOUT: __(
+		"There is no 'About Us' page or no social information in your website",
+		'pinterest-for-woocommerce'
+	),
+	AUTHENTICITY_NO_CONTACT_INFORMATION: __(
+		'There is no contact information in your website',
+		'pinterest-for-woocommerce'
+	),
+	IN_STOCK: __(
+		"Merchant's products are out of stock",
+		'pinterest-for-woocommerce'
+	),
+	BANNER_ADS: __(
+		"Merchant's website includes banner or pop-up ads",
+		'pinterest-for-woocommerce'
+	),
+	IMAGE_QUALITY: __(
+		"Merchant's products do not meet image quality requirements",
+		'pinterest-for-woocommerce'
+	),
+	WATERMARKS: __(
+		"Merchant's product images include watermarks",
+		'pinterest-for-woocommerce'
+	),
+	SALE: __(
+		"Merchant's products are always on sale",
+		'pinterest-for-woocommerce'
+	),
+	OUT_OF_DATE: __(
+		"Merchant's products refer to outdated content",
+		'pinterest-for-woocommerce'
+	),
+	PRODUCT_DESCRIPTION: __(
+		"Merchant's website uses generic product descriptions",
+		'pinterest-for-woocommerce'
+	),
+	POP_UP: __(
+		"Merchant's website displays several pop-up messages",
+		'pinterest-for-woocommerce'
+	),
+	INAUTHENTIC_PHOTOS: __(
+		"Merchant's product images are unavailable or mismatched",
+		'pinterest-for-woocommerce'
+	),
+	RESALE_MARKETPLACE: __(
+		'Resale marketplaces are not allowed',
+		'pinterest-for-woocommerce'
+	),
+	AFFILIATE_MARKETPLACE: __(
+		'Affiliate links are not allowed',
+		'pinterest-for-woocommerce'
+	),
+	WEBSITE_REQUIREMENTS: __(
+		'Account does not meet the website requirements for verification',
+		'pinterest-for-woocommerce'
+	),
+	PRODUCT_REQUIREMENTS: __(
+		'Account does not meet the product requirements for verification',
+		'pinterest-for-woocommerce'
+	),
+	BRAND_REPUTATION: __(
+		'Account does not meet the brand reputation criteria for verification',
+		'pinterest-for-woocommerce'
+	),
+	INCOMPLETE_WEBSITE_TEMPLATE: __(
+		'The template of the website is incomplete',
+		'pinterest-for-woocommerce'
+	),
 } );

--- a/assets/source/setup-guide/app/constants.js
+++ b/assets/source/setup-guide/app/constants.js
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import documentationLinkProps from './helpers/documentation-link-props';
 
 /**
  * Enum of general label status.
@@ -34,6 +40,18 @@ export const DISAPPROVAL_COPY_STATES = Object.freeze( {
 		'Merchant is an affiliate or resale marketplace',
 		'pinterest-for-woocommerce'
 	),
+	MARKETPLACE_SECOND_HAND: __(
+		'Merchant is a resale marketplace',
+		'pinterest-for-woocommerce'
+	),
+	MARKETPLACE_AFFILIATES: __(
+		'Merchant is an affiliate marketplace or marketer',
+		'pinterest-for-woocommerce'
+	),
+	MARKETPLACE_WHOLESALE: __(
+		'Merchant is a wholesale seller',
+		'pinterest-for-woocommerce'
+	),
 	PROHIBITED_PRODUCTS: __(
 		'Merchant does not meet our policy on prohibited products',
 		'pinterest-for-woocommerce'
@@ -50,24 +68,40 @@ export const DISAPPROVAL_COPY_STATES = Object.freeze( {
 		'Merchant domain mismatched with merchant account',
 		'pinterest-for-woocommerce'
 	),
-	BROKEN_URL: __(
-		"Merchant's URL is broken or requires registration",
-		'pinterest-for-woocommerce'
-	),
-	INCOMPLETE: __(
-		"Merchant's URL is incomplete or inaccessible",
+	SHIPPING: __(
+		"Merchant's shipping policy is unclear or unavailable",
 		'pinterest-for-woocommerce'
 	),
 	NO_SHIPPING_POLICY: __(
 		"Merchant's shipping policy is unclear or unavailable",
 		'pinterest-for-woocommerce'
 	),
+	RETURNS: __(
+		"Merchant's returns policy is unclear or unavailable",
+		'pinterest-for-woocommerce'
+	),
 	NO_RETURN_POLICY: __(
 		"Merchant's returns policy is unclear or unavailable",
 		'pinterest-for-woocommerce'
 	),
+	BROKEN_URL: __(
+		"Merchant's URL is broken or requires registration",
+		'pinterest-for-woocommerce'
+	),
+	BROKEN_404: __(
+		"Merchant's domain URL is broken",
+		'pinterest-for-woocommerce'
+	),
+	BROKEN_REGISTRATION: __(
+		"Merchant's domain requires registration to view products",
+		'pinterest-for-woocommerce'
+	),
+	INCOMPLETE: __(
+		"Merchant's URL is incomplete",
+		'pinterest-for-woocommerce'
+	),
 	AUTHENTICITY: __(
-		"Merchant's information is incomplete or plagiarized",
+		"Merchant's domain does not meet brand information requirements",
 		'pinterest-for-woocommerce'
 	),
 	AUTHENTICITY_NO_SOCIALS_OR_ABOUT: __(
@@ -90,6 +124,10 @@ export const DISAPPROVAL_COPY_STATES = Object.freeze( {
 		"Merchant's products do not meet image quality requirements",
 		'pinterest-for-woocommerce'
 	),
+	LOW_QUALITY_IMAGERY: __(
+		"Merchant's products do not meet image quality requirements",
+		'pinterest-for-woocommerce'
+	),
 	WATERMARKS: __(
 		"Merchant's product images include watermarks",
 		'pinterest-for-woocommerce'
@@ -106,13 +144,51 @@ export const DISAPPROVAL_COPY_STATES = Object.freeze( {
 		"Merchant's website uses generic product descriptions",
 		'pinterest-for-woocommerce'
 	),
+	PRODUCTS: __(
+		"Merchant's product descriptions and categories do not meet requirements",
+		'pinterest-for-woocommerce'
+	),
 	POP_UP: __(
 		"Merchant's website displays several pop-up messages",
+		'pinterest-for-woocommerce'
+	),
+	MINIMUM_WEBSITE_QUALITY: __(
+		'Merchant does not meet minimum website quality requirements',
+		'pinterest-for-woocommerce'
+	),
+	BROKEN_SOCIAL_MEDIA: __(
+		"Merchant's social media links are broken",
+		'pinterest-for-woocommerce'
+	),
+	TERMINATED: __(
+		"We're unable to include you as a merchant at this time. We determined your account doesn't comply with our guidelines. Your full catalog has been removed from Pinterest.",
 		'pinterest-for-woocommerce'
 	),
 	INAUTHENTIC_PHOTOS: __(
 		"Merchant's product images are unavailable or mismatched",
 		'pinterest-for-woocommerce'
+	),
+	INACTIVE_FEED: createInterpolateElement(
+		__(
+			'We recently updated our <merchantGuidelinesLink>merchant guidelines</merchantGuidelinesLink> and have found that your account is currently not in compliance with our guidelines. Merchants who do not comply with our guidelines will not be able to distribute or promote product Pins from their catalog on Pinterest. If you’d like to appeal this decision, review our guidelines for more detailed information on how you can get your products on Pinterest.',
+			'pinterest-for-woocommerce'
+		),
+		{
+			merchantGuidelinesLink: (
+				// Disabling no-content rule - content is interpolated from above string.
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<a
+					{ ...documentationLinkProps( {
+						href:
+							wcSettings.pinterest_for_woocommerce.pinterestLinks
+								.merchantGuidelines,
+						linkId: 'merchant-guidelines',
+						context: 'merchant-disapproval-reasons',
+						rel: 'noreferrer',
+					} ) }
+				/>
+			),
+		}
 	),
 	RESALE_MARKETPLACE: __(
 		'Resale marketplaces are not allowed',
@@ -136,6 +212,26 @@ export const DISAPPROVAL_COPY_STATES = Object.freeze( {
 	),
 	INCOMPLETE_WEBSITE_TEMPLATE: __(
 		'The template of the website is incomplete',
+		'pinterest-for-woocommerce'
+	),
+	TS: __(
+		'Merchant does not meet community guidelines',
+		'pinterest-for-woocommerce'
+	),
+	ADS_QUALITY: __(
+		'Merchant has exceeded number of reported ads',
+		'pinterest-for-woocommerce'
+	),
+	PINNER: __(
+		'Merchant has exceeded number of user reports',
+		'pinterest-for-woocommerce'
+	),
+	SHOPPING: __(
+		'Merchant does not meet minimum product requirements',
+		'pinterest-for-woocommerce'
+	),
+	MERCHANT: __(
+		'Merchant does not meet minimum website quality requirements',
 		'pinterest-for-woocommerce'
 	),
 } );

--- a/src/API/HealthCheck.php
+++ b/src/API/HealthCheck.php
@@ -33,7 +33,7 @@ class HealthCheck extends VendorAPI {
 
 
 	/**
-	 * Get the merchant object from the API and return the status, and if exists, the dissapproval rationale.
+	 * Get the merchant object from the API and return the status, and if exists, the disapproval rationale.
 	 *
 	 * @return array
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #674.

The disapproval reasons that are being displayed to the user are out of date, that's causing the sometimes there are empty entries in the list. This PR adds the new reasons.

### Detailed test instructions:
1. Install a build version of this PR.
2. Connect a disapproved Pinterest merchant to the plugin.
3. There should not be any empty disapproval reason.

### Changelog entry

> Update - Merchant disapproval reasons.
