### PR TITLE
Remove deprecated argument function call inside action handler.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -232,11 +232,6 @@ class Tracking {
 	 * @return void
 	 */
 	public static function hook_add_to_cart_event( $cart_item_key, $product_id, $quantity, $variation_id ) {
-
-		if ( ! empty( $cart_item_key ) ) {
-			_deprecated_argument( __FUNCTION__, '1.2.11' );
-		}
-
 		$redirect_to_cart = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
 
 		if ( wp_doing_ajax() && ! $redirect_to_cart ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removing a call to _deprecated_argument function added by mistake when inside an action hook function.

### Detailed test instructions:

1. Go to a single product page and click `Add to cart` button.
2. Depending if you have AJAX Add to cart enabled or not you will see wither AJAX response coming in with the Deprecation notice or a notice on top of the page.3. 

![DevTools_-_facebook_dima_works_product_album_](https://user-images.githubusercontent.com/9010963/218463597-4f5e2137-075f-478d-8437-be79b06010e8.png)

OR

![Album_–_WordPress_Facebook](https://user-images.githubusercontent.com/9010963/218463488-4bfefb12-0bdf-4747-9ace-7b8a1d6d028f.png)

3. Checkout the branch and add product to cart again.
4. No deprecated notice must be present.

### Changelog entry

> Dev - Remove deprecated argument call from inside a hook action handler function.
