### PR TITLE
Provide external link EM tooltip

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -82,6 +82,7 @@ Clicking on an external documentation link.
 	- with `{ link_id: 'ad-data-terms', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'ad-terms-of-service', context: 'wizard'|'settings' }`
 	- with `{ link_id: 'install-tag', context: 'wizard'|'settings' }`
+- [`SetupPins`](assets/source/setup-guide/app/steps/SetupPins.js#L45) with `{ link_id: 'enhanced-match', context: 'settings' }`
 - [`WelcomeSection`](assets/source/setup-guide/app/views/LandingPageApp.js#L48) with `{ link_id: 'terms-of-service', context: 'welcome-section' }`
 - [TermsAndConditionsModal]( assets/source/setup-guide/app/components/TermsAndConditionsModal.js#L24)
     - with `{ link_id: 'terms-of-service', context: 'ads-credits-terms-and-conditions' }`

--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -3,13 +3,13 @@
  */
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { Spinner } from '@woocommerce/components';
 import {
 	Tooltip,
 	Card,
 	CardBody,
 	CheckboxControl,
 	Icon,
+	Spinner,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 

--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import {
 	Tooltip,
 	Card,
@@ -17,6 +18,7 @@ import {
  * Internal dependencies
  */
 import StepOverview from '../components/StepOverview';
+import documentationLinkProps from '../helpers/documentation-link-props';
 import {
 	useSettingsSelect,
 	useSettingsDispatch,
@@ -31,6 +33,15 @@ function HelpTooltip( { text } ) {
 	);
 }
 
+/**
+ * Tracking setup component.
+ *
+ * To be used in onboarding stepper.
+ *
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'enhanced-match', context: 'settings' }`
+ *
+ * @return {JSX.Element} rendered component
+ */
 const SetupPins = ( {} ) => {
 	const appSettings = useSettingsSelect();
 	const setAppSettings = useSettingsDispatch( false );
@@ -112,9 +123,32 @@ const SetupPins = ( {} ) => {
 										) }
 										help={
 											<HelpTooltip
-												text={ __(
-													'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled.',
-													'pinterest-for-woocommerce'
+												text={ createInterpolateElement(
+													__(
+														'Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled. <link>See more</link>',
+														'pinterest-for-woocommerce'
+													),
+													{
+														link: (
+															// eslint-disable-next-line jsx-a11y/anchor-has-content -- context passed via documentationLinkProps
+															<a
+																className="pinterest-tooltip-link"
+																{ ...documentationLinkProps(
+																	{
+																		href:
+																			wcSettings
+																				.pinterest_for_woocommerce
+																				.pinterestLinks
+																				.enhancedMatch,
+																		linkId:
+																			'enhanced-match',
+																		context:
+																			'settings',
+																	}
+																) }
+															/>
+														),
+													}
 												) }
 											/>
 										}

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -225,6 +225,10 @@ $root: ".woocommerce-setup-guide";
 					.woocommerce-spinner {
 						display: block;
 					}
+
+					.pinterest-tooltip-link {
+						color: #fff;
+					}
 				}
 
 				&-modal {

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -379,6 +379,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'newAccount'             => 'https://business.pinterest.com/',
 					'claimWebsite'           => 'https://help.pinterest.com/en/business/article/claim-your-website',
 					'richPins'               => 'https://help.pinterest.com/en/business/article/rich-pins',
+					'enhancedMatch'          => 'https://help.pinterest.com/en/business/article/enhanced-match',
 					'createAdvertiser'       => 'https://help.pinterest.com/en/business/article/create-an-advertiser-account',
 					'adGuidelines'           => 'https://policy.pinterest.com/en/advertising-guidelines',
 					'adDataTerms'            => 'https://policy.pinterest.com/en/ad-data-terms',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #267.

Adding back the external link to enhanced match documentation within the tooltip.

### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/221178513-9791303f-759c-4a33-a3da-a6e34ec03730.png)

### Detailed test instructions:
1. Install a build of this PR and do the onboarding.
2. The "See more" link should be available on the enhanced match tooltip.

### Changelog entry

> Add - Enhanced match documentation link.
