### PR TITLE
Fix/fatal error rest cart

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -735,7 +735,7 @@ JS;
 	 * @return bool
 	 */
 	protected static function price_includes_tax() {
-		if ( isset( WC()->cart ) ) {
+		if ( isset( WC()->cart ) && method_exists( WC()->cart, 'display_prices_including_tax' ) ) {
 			return WC()->cart->display_prices_including_tax();
 		}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -725,16 +725,16 @@ JS;
 	 * @return string
 	 */
 	protected static function get_product_display_price( $product ) {
-		return self::prices_include_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
+		return self::price_includes_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
 	}
 
 	/**
-	 * Get if prices should include/exclude tax.
+	 * Get if prices should include tax.
 	 *
 	 * @since x.x.x
 	 * @return bool
 	 */
-	protected static function prices_include_tax() {
+	protected static function price_includes_tax() {
 		if ( isset( WC()->cart ) ) {
 			return WC()->cart->display_prices_including_tax();
 		}

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -725,7 +725,25 @@ JS;
 	 * @return string
 	 */
 	protected static function get_product_display_price( $product ) {
-		return WC()->cart->display_prices_including_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
+		return self::prices_include_tax() ? wc_get_price_including_tax( $product ) : NumberUtil::round( wc_get_price_excluding_tax( $product ), wc_get_price_decimals() );
+	}
+
+	/**
+	 * Get if prices should include/exclude tax.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	protected static function prices_include_tax() {
+		if ( isset( WC()->cart ) ) {
+			return WC()->cart->display_prices_including_tax();
+		}
+
+		if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
+			return false;
+		}
+
+		return 'incl' === get_option( 'woocommerce_tax_display_cart' );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix fatal error for rest calls: https://wordpress.org/support/topic/fatal-error-4386/

### Changelog entry

> Fix - Fatal error if cart is not set.
