### PR TITLE
Fix undefined variable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 	  ],
 	"require": {
 		"php": ">=7.3",
+		"ext-json": "*",
 		"automattic/jetpack-autoloader": "^2.10.1",
 		"defuse/php-encryption": "^2.2",
 		"woocommerce/action-scheduler-job-framework": "^2.0.0"

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -113,6 +113,7 @@ class Base {
 			$response = self::handle_request( $request );
 
 			if ( ! empty( $cache_expiry ) ) {
+				$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
 				set_transient( $cache_key, $response, $cache_expiry );
 			}
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -20,7 +20,7 @@ class Logger {
 	/**
 	 * The single instance of the class.
 	 *
-	 * @var WC_Logger
+	 * @var \WC_Logger
 	 * @since 1.0.0
 	 */
 	public static $logger;
@@ -39,10 +39,8 @@ class Logger {
 	 * @param string $level   The level/context of the message.
 	 * @param string $feature Used to direct logs to a separate file.
 	 * @param string $force   Used to bypass system settings and force the logs.
-	 *
-	 * @return string
 	 */
-	public static function log( $message, $level = 'debug', $feature = null, $force = false ) {
+	public static function log( $message, $level = 'debug', $feature = null, $force = false ): void {
 
 		$allow_logging = true;
 		if ( 'debug' === $level ) {
@@ -69,15 +67,15 @@ class Logger {
 	/**
 	 * Helper for Logging API requests.
 	 *
-	 * @param string $url The URL of the request.
-	 * @param string $args The Arguments of the request.
-	 * @param string $level The default level/context of the message to be logged.
+	 * @param string   $url   The URL of the request.
+	 * @param string[] $args  The Arguments of the request.
+	 * @param string   $level The default level/context of the message to be logged.
 	 *
 	 * @return void
 	 */
 	public static function log_request( $url, $args, $level = 'debug' ) {
 		unset( $args['headers'] );
-		$method = isset( $args['method'] ) ? $args['method'] : 'POST';
+		$method = $args['method'] ?? 'POST';
 		$data   = ! empty( $args['body'] ) ? $args['body'] : '--- EMPTY STRING ---';
 		$data   = is_array( $data ) ? wp_json_encode( $data ) : $data;
 		self::log( "{$method} Request: " . $url . "\n\n" . $data . "\n", $level );
@@ -86,7 +84,7 @@ class Logger {
 	/**
 	 *  Helper for Logging API responses.
 	 *
-	 * @param array|WP_Error $response The body of the response.
+	 * @param array|\WP_Error $response The body of the response.
 	 * @param string         $level The default level/context of the message to be logged.
 	 *
 	 * @return void

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -85,7 +85,7 @@ class Logger {
 	 *  Helper for Logging API responses.
 	 *
 	 * @param array|\WP_Error $response The body of the response.
-	 * @param string         $level The default level/context of the message to be logged.
+	 * @param string          $level    The default level/context of the message to be logged.
 	 *
 	 * @return void
 	 */

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -39,6 +39,8 @@ class Logger {
 	 * @param string $level   The level/context of the message.
 	 * @param string $feature Used to direct logs to a separate file.
 	 * @param string $force   Used to bypass system settings and force the logs.
+	 *
+	 * @return void
 	 */
 	public static function log( $message, $level = 'debug', $feature = null, $force = false ): void {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


I noticed a warning on my local regarding the undefined variable "$cache_key":

```
Warning: Undefined variable $cache_key in /Users/nima/Documents/Automattic/pinterest-for-woocommerce/src/API/Base.php on line 117
```

In the `\Automattic\WooCommerce\Pinterest\API\Base::make_request` method, the $cache_key variable was used but not defined.

This PR fixes that issue and some minor code-style issues I noticed while working on it.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Load the marketing dashboard and confirm you do not see the PHP warning regarding undefined variable "$cache_key"


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Undefined variable when caching API requests
