### PR TITLE
Fix products with 'on backorder' status are skipped from a feed.

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -267,29 +267,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function process_items( array $items, array $args ) {
 		try {
-			// Get included product types.
-			$included_product_types = array_diff(
-				self::get_included_product_types(),
-				self::get_excluded_product_types(),
-			);
-
-			$products_query_args = array(
-				'type'       => $included_product_types,
-				'include'    => $items,
-				'visibility' => 'catalog',
-				'orderby'    => 'none',
-				'limit'      => $this->get_batch_size(),
-			);
-
-			// Exclude variation subscriptions.
-			$products_query_args['parent_exclude'] = $this->get_excluded_products_by_parent();
-
-			// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set.
-			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-				$products_query_args['stock_status'] = 'instock';
-			}
-
-			$products = wc_get_products( $products_query_args );
+			$products = $this->get_feed_products( $items );
 
 			$this->prepare_feed_buffers();
 
@@ -321,6 +299,38 @@ class FeedGenerator extends AbstractChainedJob {
 		);
 		/* translators: number of products */
 		self::log( sprintf( __( 'Feed batch generated. Wrote %s products to the feed file.', 'pinterest-for-woocommerce' ), count( $products ) ) );
+	}
+
+	/**
+	 * Returns WC products by product ids. Products returned are of either `in stock` or `on backorder` statuses.
+	 *
+	 * @param int[] $ids - array of product ids.
+	 * @return array|\stdClass
+	 */
+	public function get_feed_products( array $ids ) {
+		// Get included product types.
+		$included_product_types = array_diff(
+			self::get_included_product_types(),
+			self::get_excluded_product_types(),
+		);
+
+		$products_query_args = array(
+			'type'       => $included_product_types,
+			'include'    => $ids,
+			'visibility' => 'catalog',
+			'orderby'    => 'none',
+			'limit'      => $this->get_batch_size(),
+		);
+
+		// Exclude variation subscriptions.
+		$products_query_args['parent_exclude'] = $this->get_excluded_products_by_parent();
+
+		// Do not sync out of stock products which do not support backorders if woocommerce_hide_out_of_stock_items is set.
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+			$products_query_args['stock_status'] = [ 'instock', 'onbackorder' ];
+		}
+
+		return wc_get_products( $products_query_args );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -304,7 +304,10 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Returns WC products by product ids. Products returned are of either `in stock` or `on backorder` statuses.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param int[] $ids - array of product ids.
+	 *
 	 * @return array|\stdClass
 	 */
 	public function get_feed_products( array $ids ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #717 .

It was reported products with status of 'On backorder' were not included into a Pinterest feed file. Current PR fixes this bug.

### Detailed test instructions:

1. Make sure you have `Hide out of stock items from the catalog` enabled.

<img width="1215" alt="WooCommerce_settings_‹_WordPress_Pinterest_—_WordPress" src="https://user-images.githubusercontent.com/9010963/230995229-6d26d5f0-e453-41cc-afac-33376d10c80d.png">

2. Make sure you have at least a single product with Stock Status set to `On backorder`.

<img width="1215" alt="Edit_product_“Simple_product”_‹_WordPress_Pinterest_—_WordPress" src="https://user-images.githubusercontent.com/9010963/230988635-9cbb8987-4dd0-4968-bb16-99431c151fe6.png">

AND/OR

<img width="1215" alt="Edit_product_“Simple_product__updated_”_‹_WordPress_Pinterest_—_WordPress" src="https://user-images.githubusercontent.com/9010963/230991808-14cefeed-799f-4b45-b73b-dda5082709bf.png">

**NOTE!** _Both variants must be tested._

3. When on `develop` branch run `pinterest-for-woocommerce-start-feed-generation` action from `Pending` tab.

<img width="1215" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://user-images.githubusercontent.com/9010963/230988365-09aad256-f6d3-4747-80d8-73dd45b57273.png">

4. Check the feed file by following the link to the feed file. 

<img width="1215" alt="Products_Catalog_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://user-images.githubusercontent.com/9010963/230989304-0c148c81-2c3e-432e-bdc3-8270566d9878.png">

5. Find no products with Stock Status `On backorder`. Such products would appear in the feed with `<g:availability>preorder</g:availability>` tag. E.g.

<img width="1215" alt="https___pinterest_dima_works_wp-content_uploads_pinterest-for-woocommerce-sLGSPc_xml" src="https://user-images.githubusercontent.com/9010963/230989066-0c8f6551-8d8f-41d4-8b58-0c099afb4f50.png">

6. Checkout `fix/717-onbackorder-products-arent-included-into-a-feed`  branch.
7. Run `pinterest-for-woocommerce-start-feed-generation` again.
8. Check the feed file.
9. See  the feed now includes products with Stock Status set `On backorder` (but in the feed it is transformed into `preorder`).

### Changelog entry

> Fix - On backorder items missing from the feed.
