### PR TITLE
Fix escape javascript product name attribute.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -371,7 +371,7 @@ JS;
 		}
 
 		$product_id    = $product->get_id();
-		$product_name  = $product->get_name();
+		$product_name  = esc_js( $product->get_name() );
 		$product_price = self::get_product_display_price( $product );
 
 		$wc_currency = get_woocommerce_currency();

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -372,9 +372,9 @@ JS;
 
 		$product_id    = $product->get_id();
 		$product_name  = esc_js( $product->get_name() );
-		$product_price = self::get_product_display_price( $product );
+		$product_price = floatval( self::get_product_display_price( $product ) );
 
-		$wc_currency = get_woocommerce_currency();
+		$wc_currency = esc_js( get_woocommerce_currency() );
 		$tracking    = <<< JS
 jQuery( function( $ ) {
 	$( document.body ).on( 'added_to_cart', function( e, fragments, cart_hash, thisbutton ) {

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -338,7 +338,7 @@ class Tracking {
 	 * @return string
 	 */
 	protected static function get_add_to_cart_snippet_archive() {
-		$wc_currency = get_woocommerce_currency();
+		$wc_currency = esc_js( get_woocommerce_currency() );
 		$tracking    = <<< JS
 jQuery( function( $ ) {
 	$( document.body ).on( 'added_to_cart', function( e, fragments, cart_hash, thisbutton ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #716 .

When product name contains a quote tracker at product page fails.

### Detailed test instructions:

1. Create a product with name which contains a single quote.

<img width="1225" alt="Edit_product_“Simple_product’s_name”_‹_WordPress_Pinterest_—_WordPress" src="https://user-images.githubusercontent.com/9010963/231004236-df213ab6-9f2e-41ab-957a-686e99bbddd6.png">

2. Visit product page and see a JS error in a browser's console.

<img width="1225" alt="DevTools_-_pinterest_dima_works__product_simple-product" src="https://user-images.githubusercontent.com/9010963/231004914-10f8eca5-3e14-4044-94bc-054988ed8fe4.png">

3. Checkout `fix/716-escape-js-product-name`.
4. Refresh the product page and see no JS console error and the product name properly escaped.

<img width="1225" alt="DevTools_-_pinterest_dima_works__product_simple-product" src="https://user-images.githubusercontent.com/9010963/231005338-13405efa-a887-4afa-a8fa-d9547866f743.png">

### Changelog entry

> Fix - Escape product name for JS tracker.
