### PR TITLE
Check full download url in local vs remote feed config comparison.

### DIFF
--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -121,13 +121,13 @@ class Feeds {
 	public static function match_local_feed_configuration_to_registered_feeds( $merchant_id ) {
 		$configs       = LocalFeedConfigs::get_instance()->get_configurations();
 		$config        = reset( $configs );
-		$local_path    = dirname( $config['feed_url'] );
+		$local_path    = $config['feed_url'];
 		$local_country = Pinterest_For_Woocommerce()::get_base_country() ?? 'US';
 		$local_locale  = LocaleMapper::get_locale_for_api();
 		$feeds         = self::get_merchant_feeds( $merchant_id );
 
 		foreach ( $feeds as $feed ) {
-			$configured_path = dirname( $feed->location_config->full_feed_fetch_location );
+			$configured_path = $feed->location_config->full_feed_fetch_location;
 			if (
 				$configured_path === $local_path &&
 				$local_country === $feed->country &&

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -174,6 +174,8 @@ class Merchants {
 
 		$merchant_id = $response['data'];
 
+		Feeds::invalidate_get_merchant_feeds_cache( $merchant_id, true );
+
 		try {
 			$feed_id = Feeds::match_local_feed_configuration_to_registered_feeds( $response['data'] );
 		} catch ( Throwable $th ) {
@@ -186,7 +188,7 @@ class Merchants {
 		// Update the registered feed id setting.
 		Pinterest_For_Woocommerce()::save_data( 'feed_registered', $feed_id );
 
-		Feeds::invalidate_get_merchant_feeds_cache( $merchant_id, true );
+
 		return array(
 			'merchant_id' => $merchant_id,
 			'feed_id'     => $feed_id,

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -188,7 +188,6 @@ class Merchants {
 		// Update the registered feed id setting.
 		Pinterest_For_Woocommerce()::save_data( 'feed_registered', $feed_id );
 
-
 		return array(
 			'merchant_id' => $merchant_id,
 			'feed_id'     => $feed_id,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When comparing remote and local feed configs the full URL should be considered and not just the folder location where the feed file is located.

Closes #724 .

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
 
Check #724 for testing instructions. With this patch the issues should be gone.

### Changelog entry

Fix - When a new feed configuration is created it should be updated in the pinterest.com config.
