### PR TITLE
Adds `esc_url` to `add_query_arg` function calls

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -830,7 +830,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			set_transient( PINTEREST_FOR_WOOCOMMERCE_AUTH, $control_key, MINUTE_IN_SECONDS * 5 );
 
-			return self::get_connection_proxy_url() . 'login/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE . '?' . $state;
+			return esc_url( self::get_connection_proxy_url() . 'login/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE . '?' . $state );
 		}
 
 

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -144,9 +144,11 @@ class Auth extends VendorAPI {
 			$query_args['view'] = sanitize_key( $view );
 		}
 
-		return add_query_arg(
-			$query_args,
-			admin_url( 'admin.php' )
+		return esc_url(
+			add_query_arg(
+				$query_args,
+				admin_url( 'admin.php' )
+			)
 		);
 	}
 }

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -610,7 +610,7 @@ class Base {
 	public static function update_merchant_feed( $merchant_id, $feed_id, $args ) {
 
 		return self::make_request(
-			add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ),
+			esc_url( add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ) ),
 			'PUT'
 		);
 	}

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -86,9 +86,11 @@ class SaveToPinterest {
 		 */
 		return sprintf(
 			'<div class="pinterest-for-woocommerce-image-wrapper"><a data-pin-do="buttonPin" href="%s"></a></div>',
-			add_query_arg(
-				$attributes,
-				'https://www.pinterest.com/pin/create/button/'
+			esc_url(
+				add_query_arg(
+					$attributes,
+					'https://www.pinterest.com/pin/create/button/'
+				)
 			)
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `esc_url` to all `add_query_arg` function calls.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Verify WooCommerce is installed and activated.
2. Verify Pinterest for WooCommerce plugin is installed and activated.
3. Navigate to `Marketing > Pinterest > Connection` and verify that you are able to disconnect (if already connected) and reconnect successfully.
4. Navigate to the site store by clicking on the `Visit Store` link.
5. Hover over the product thumbnails and click on the `Save` icon from `Pinterest`. Verify the product is saved to Pinterest.
6. Install `semgrep` using `brew install semgrep`
7. Clone this repository in a top-level folder: `git clone git@github.com:Automattic/wpscan-semgrep-rules.git`
8. Run `semgrep --no-git-ignore --text -c audit ../pinterest-for-woocommerce` for `semgrep` results. The results should not return any findings.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - unescaped `add_query_arg` function calls
