### PR TITLE
Revert "Remove backlog automation github action."

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -1,0 +1,16 @@
+name: Add all new issues to the backlog board.
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/woocommerce/projects/117
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Reverts woocommerce/pinterest-for-woocommerce#728

We need this because we only have a limited number of slots that are required for private repos.