### PR TITLE
Fix/remove feed file config during uninstall procedure.

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 /**
  * Remove the feed configuration.
  */
-$data        = get_option( 'pinterest_for_woocommerce_data' );
+$data        = get_option( 'pinterest_for_woocommerce_data', [] );
 $merchant_id = $data['merchant_id'] ?? '';
 
 if ( $merchant_id ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,11 +8,22 @@
  * @version     1.0.0
  */
 
+ use Automattic\WooCommerce\Pinterest\FeedRegistration;
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-$plugin_settings = get_option( 'pinterest_for_woocommerce' );
+/**
+ * Remove the feed configuration.
+ */
+$data        = get_option( 'pinterest_for_woocommerce_data' );
+$merchant_id = $data['merchant_id'] ?? '';
+
+if ( $merchant_id ) {
+	// At this time all feeds are considered stale so we just need pass bogus value as the second argument.
+	FeedRegistration::maybe_disable_stale_feeds_for_merchant( $merchant_id, '' );
+}
 
 if ( $plugin_settings['erase_plugin_data'] ) {
 	delete_option( 'pinterest_for_woocommerce' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,8 @@ if ( $merchant_id ) {
 	FeedRegistration::maybe_disable_stale_feeds_for_merchant( $merchant_id, '' );
 }
 
+$plugin_settings = get_option( 'pinterest_for_woocommerce' );
+
 if ( $plugin_settings['erase_plugin_data'] ) {
 	delete_option( 'pinterest_for_woocommerce' );
 	delete_option( 'pinterest_for_woocommerce_data' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #735 .

We have not been handling feed configuration removal during plugin uninstall.
This reuses the stale feed disable procedure that we have added for the feed maintenance.
It should check all the feed configurations and disable all of them that are active and coming
from the host on which the plugin is being disabled.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check steps from #735
2. This time the catalog should be gone.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer-facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix  -  Remove feed configuration during plugin uninstall procedure.
