### PR TITLE
Refactor feed generator action backoff.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -545,7 +545,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$settings = self::get_settings( $force, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 
-			return empty( $settings[ $key ] ) ? null : $settings[ $key ];
+			return $settings[ $key ] ?? null;
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -124,6 +124,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			'product_sync_enabled'             => true,
 			'enable_debug_logging'             => false,
 			'erase_plugin_data'                => false,
+
+			'feed_product_batch_size'          => Pinterest\FeedGenerator::DEFAULT_PRODUCT_BATCH_SIZE,
+			'feed_product_batch_attempt'       => 0,
 		);
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -126,7 +126,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			'erase_plugin_data'                => false,
 
 			'feed_product_batch_size'          => Pinterest\FeedGenerator::DEFAULT_PRODUCT_BATCH_SIZE,
-			'feed_product_batch_attempt'       => 0,
+			'feed_product_batch_attempt'       => 1,
 		);
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -124,9 +124,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			'product_sync_enabled'             => true,
 			'enable_debug_logging'             => false,
 			'erase_plugin_data'                => false,
-
-			'feed_product_batch_size'          => Pinterest\FeedGenerator::DEFAULT_PRODUCT_BATCH_SIZE,
-			'feed_product_batch_attempt'       => 1,
 		);
 
 		/**
@@ -571,6 +568,20 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			return self::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 		}
 
+		/**
+		 * Remove APP Data key.
+		 *
+		 * @param string $key - The key of specific data to retrieve.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return bool - True if the data was removed, false otherwise.
+		 */
+		public static function remove_data( string $key ) {
+			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			unset( $settings[ $key ] );
+			return self::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+		}
 
 		/**
 		 * Add API endpoints

--- a/src/Exception/FeedFileOperationsException.php
+++ b/src/Exception/FeedFileOperationsException.php
@@ -14,7 +14,7 @@ use Exception;
 /**
  * An exception thrown then something went wrong writing into a feed file.
  */
-class FeedFileOperationsException extends Exception {
+class FeedFileOperationsException extends Exception implements PinterestException {
 	public const CODE_COULD_NOT_RENAME_ERROR = 10;
 
 	public const CODE_COULD_NOT_OPEN_FILE_ERROR = 20;

--- a/src/Exception/FeedFileOperationsException.php
+++ b/src/Exception/FeedFileOperationsException.php
@@ -1,10 +1,19 @@
 <?php
+/**
+ * Feed file operation exception.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
 declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Pinterest\Exception;
 
 use Exception;
 
+/**
+ * An exception thrown then something went wrong writing into a feed file.
+ */
 class FeedFileOperationsException extends Exception {
 	public const CODE_COULD_NOT_RENAME_ERROR = 10;
 

--- a/src/Exception/FeedFileOperationsException.php
+++ b/src/Exception/FeedFileOperationsException.php
@@ -1,0 +1,14 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use Exception;
+
+class FeedFileOperationsException extends Exception {
+	public const CODE_COULD_NOT_RENAME_ERROR = 10;
+
+	public const CODE_COULD_NOT_OPEN_FILE_ERROR = 20;
+
+	public const CODE_COULD_NOT_WRITE_FILE_ERROR = 30;
+}

--- a/src/FeedFileOperations.php
+++ b/src/FeedFileOperations.php
@@ -8,7 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
-use Exception;
+use Automattic\WooCommerce\Pinterest\Exception\FeedFileOperationsException;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -39,7 +39,7 @@ class FeedFileOperations {
 	 * Files is populated with the XML headers.
 	 *
 	 * @since 1.2.9
-	 * @throws Exception Can't open or write to the file.
+	 * @throws FeedFileOperationsException Can't open or write to the file.
 	 */
 	public function prepare_temporary_files(): void {
 		foreach ( $this->configurations->get_configurations() as $config ) {
@@ -56,7 +56,7 @@ class FeedFileOperations {
 	 * Add XML footer to all temporary feed files.
 	 *
 	 * @since 1.2.9
-	 * @throws Exception Can't open or write to the file.
+	 * @throws FeedFileOperationsException Can't open or write to the file.
 	 */
 	public function add_footer_to_temporary_feed_files(): void {
 		foreach ( $this->configurations->get_configurations() as $config ) {
@@ -93,27 +93,29 @@ class FeedFileOperations {
 	 * @param integer $bytes_written How much data was written to the file.
 	 * @param string  $file          File location.
 	 *
-	 * @throws Exception Can't open or write to the file.
+	 * @throws FeedFileOperationsException Can't open or write to the file.
 	 */
 	private function check_write_for_io_errors( $bytes_written, $file ): void {
 
 		if ( false === $bytes_written ) {
-			throw new Exception(
+			throw new FeedFileOperationsException(
 				sprintf(
 					/* translators: error message with file path */
 					__( 'Could not open temporary file %s for writing', 'pinterest-for-woocommerce' ),
 					$file
-				)
+				),
+				FeedFileOperationsException::CODE_COULD_NOT_OPEN_FILE_ERROR
 			);
 		}
 
 		if ( 0 === $bytes_written ) {
-			throw new Exception(
+			throw new FeedFileOperationsException(
 				sprintf(
 					/* translators: error message with file path */
 					__( 'Temporary file: %s is not writeable.', 'pinterest-for-woocommerce' ),
 					$file
-				)
+				),
+				FeedFileOperationsException::CODE_COULD_NOT_WRITE_FILE_ERROR
 			);
 		}
 	}
@@ -123,19 +125,20 @@ class FeedFileOperations {
 	 * This is the last step of the feed file generation process.
 	 *
 	 * @since 1.2.9
-	 * @throws \Exception Renaming not possible.
+	 * @throws FeedFileOperationsException Renaming not possible.
 	 */
 	public function rename_temporary_feed_files_to_final(): void {
 		foreach ( $this->configurations->get_configurations() as $config ) {
 			$status = rename( $config['tmp_file'], $config['feed_file'] );
 			if ( false === $status ) {
-				throw new Exception(
+				throw new FeedFileOperationsException(
 					sprintf(
 						/* translators: 1: temporary file name 2: final file name */
 						__( 'Could not rename %1$s to %2$s', 'pinterest-for-woocommerce' ),
 						$config['tmp_file'],
 						$config['feed_file']
-					)
+					),
+					FeedFileOperationsException::CODE_COULD_NOT_RENAME_ERROR
 				);
 			}
 		}
@@ -146,7 +149,7 @@ class FeedFileOperations {
 	 *
 	 * @param array $buffers an array of (locale => content) elements.
 	 * @since 1.2.9
-	 * @throws Exception Can't open or write to the file.
+	 * @throws FeedFileOperationsException Can't open or write to the file.
 	 */
 	public function write_buffers_to_temp_files( array $buffers ): void {
 		foreach ( $this->configurations->get_configurations() as $location => $config ) {

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -659,10 +659,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @since 1.2.14
 	 */
 	protected function is_timeout_error( array $error ): bool {
-		return isset( $error['type'] ) &&
-				E_ERROR === $error['type'] &&
-				isset( $error['message'] ) &&
-				strpos( $error ['message'], 'Maximum execution time' ) !== false;
+		return isset( $error['type'] ) && E_ERROR === $error['type'] &&
+			isset( $error['message'] ) && strpos( $error ['message'], 'Maximum execution time' ) !== false;
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -726,7 +726,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Exception Related to max retries reached or missing arguments on the action.
 	 */
 	public function maybe_handle_error_on_timeout( int $action_id ) {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x' );
+		wc_deprecated_function( __METHOD__, 'x.x.x' );
 	}
 
 	/**
@@ -747,13 +747,12 @@ class FeedGenerator extends AbstractChainedJob {
 				'hook'         => $hook,
 				'args'         => $args,
 				'status'       => ActionSchedulerInterface::STATUS_FAILED,
-				'per_page'     => $threshold,
 				'date'         => gmdate( 'U' ) - $time_period,
 				'date_compare' => '>',
 			],
 			'ids'
 		);
 
-		return count( $failed_actions ) === $threshold;
+		return count( $failed_actions ) >= $threshold;
 	}
 }

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -18,7 +18,6 @@ use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerIn
 use Automattic\WooCommerce\Pinterest\Exception\FeedFileOperationsException;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 use ActionScheduler;
-use Error;
 use Exception;
 use Pinterest_For_Woocommerce;
 use Throwable;
@@ -681,7 +680,6 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 	}
-
 
 	/**
 	 * Set the store address as taxable location.

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -152,7 +152,7 @@ class FeedGenerator extends AbstractChainedJob {
 					// Translators: 1. Action Scheduler hook name.
 					__(
 						'Feed Generator `%s` Action reschedule threshold has been reached. Quit.',
-						PINTEREST_FOR_WOOCOMMERCE_PREFIX
+						'pinterest-for-woocommerce'
 					),
 					$hook
 				)
@@ -165,7 +165,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: Action Scheduler hook name.
 				__(
 					'Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it.',
-					PINTEREST_FOR_WOOCOMMERCE_PREFIX
+					'pinterest-for-woocommerce'
 				),
 				$hook
 			)
@@ -179,7 +179,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: 1: Action Scheduler hook name, 2: New products number to process next action run.
 				__(
 					'Feed Generator `%1$s` Action product batch size decreased to %2$d.',
-					PINTEREST_FOR_WOOCOMMERCE_PREFIX
+					'pinterest-for-woocommerce'
 				),
 				$hook,
 				$limit
@@ -228,7 +228,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
 				__(
 					'Feed Generator `%1$s` Action failed to execute due to an error thrown `%2$s.`. A complete feed generation retry has been scheduled.',
-					PINTEREST_FOR_WOOCOMMERCE_PREFIX
+					'pinterest-for-woocommerce'
 				),
 				$hook,
 				$throwable->getMessage()
@@ -247,7 +247,7 @@ class FeedGenerator extends AbstractChainedJob {
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		as_schedule_recurring_action( $timestamp, DAY_IN_SECONDS, self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		/* translators: time in the format hours:minutes:seconds */
-		self::log( sprintf( __( 'Feed scheduled to run at %s.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ), gmdate( 'H:i:s', $timestamp ) ) );
+		self::log( sprintf( __( 'Feed scheduled to run at %s.', 'pinterest-for-woocommerce' ), gmdate( 'H:i:s', $timestamp ) ) );
 	}
 
 	/**
@@ -269,7 +269,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		$this->queue_start();
 		ProductFeedStatus::set( array( 'status' => 'scheduled_for_generation' ) );
-		self::log( __( 'Feed generation queued.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
+		self::log( __( 'Feed generation queued.', 'pinterest-for-woocommerce' ) );
 	}
 
 	/**
@@ -280,7 +280,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	protected function handle_start() {
-		self::log( __( 'Feed generation start. Preparing temporary files.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
+		self::log( __( 'Feed generation start. Preparing temporary files.', 'pinterest-for-woocommerce' ) );
 		try {
 			ProductFeedStatus::reset_feed_file_generation_time();
 			ProductFeedStatus::set(
@@ -327,7 +327,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
 	protected function handle_end() {
-		self::log( __( 'Feed generation end. Moving files to the final destination.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
+		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
 		try {
 			$this->feed_file_operations->add_footer_to_temporary_feed_files();
 			$this->feed_file_operations->rename_temporary_feed_files_to_final();
@@ -342,7 +342,7 @@ class FeedGenerator extends AbstractChainedJob {
 			$this->handle_error( $th );
 			throw $th;
 		}
-		self::log( __( 'Feed generated successfully.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
+		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
 
 		// Check if feed is dirty and reschedule in necessary.
 		if ( $this->feed_is_dirty() ) {
@@ -431,7 +431,7 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 		/* translators: number of products */
-		self::log( sprintf( __( 'Feed batch generated. Wrote %s products to the feed file.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ), $processed_products ) );
+		self::log( sprintf( __( 'Feed batch generated. Wrote %s products to the feed file.', 'pinterest-for-woocommerce' ), $processed_products ) );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -112,6 +112,17 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Returns feed generator actions group name.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	public function get_group_name(): string {
+		return PINTEREST_FOR_WOOCOMMERCE_PREFIX;
+	}
+
+	/**
 	 * Unexpected shutdown handler.
 	 *
 	 * @param int        $action_id - Action Scheduler action ID.
@@ -141,7 +152,7 @@ class FeedGenerator extends AbstractChainedJob {
 					// Translators: 1. Action Scheduler hook name.
 					__(
 						'Feed Generator `%s` Action reschedule threshold has been reached. Quit.',
-						'pinterest-for-woocommerce'
+						PINTEREST_FOR_WOOCOMMERCE_PREFIX
 					),
 					$hook
 				)
@@ -154,7 +165,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: Action Scheduler hook name.
 				__(
 					'Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it.',
-					'pinterest-for-woocommerce'
+					PINTEREST_FOR_WOOCOMMERCE_PREFIX
 				),
 				$hook
 			)
@@ -168,7 +179,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: 1: Action Scheduler hook name, 2: New products number to process next action run.
 				__(
 					'Feed Generator `%1$s` Action product batch size decreased to %2$d.',
-					'pinterest-for-woocommerce'
+					PINTEREST_FOR_WOOCOMMERCE_PREFIX
 				),
 				$hook,
 				$limit
@@ -180,7 +191,7 @@ class FeedGenerator extends AbstractChainedJob {
 			'feed_product_batch_attempt',
 			Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) + 1
 		);
-		$this->action_scheduler->schedule_immediate( $hook, $args );
+		$this->action_scheduler->schedule_immediate( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 	}
 
 	/**
@@ -217,7 +228,7 @@ class FeedGenerator extends AbstractChainedJob {
 				// Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
 				__(
 					'Feed Generator `%1$s` Action failed to execute due to an error thrown `%2$s.`. A complete feed generation retry has been scheduled.',
-					'pinterest-for-woocommerce'
+					PINTEREST_FOR_WOOCOMMERCE_PREFIX
 				),
 				$hook,
 				$throwable->getMessage()
@@ -236,7 +247,7 @@ class FeedGenerator extends AbstractChainedJob {
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		as_schedule_recurring_action( $timestamp, DAY_IN_SECONDS, self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		/* translators: time in the format hours:minutes:seconds */
-		self::log( sprintf( __( 'Feed scheduled to run at %s.', 'pinterest-for-woocommerce' ), gmdate( 'H:i:s', $timestamp ) ) );
+		self::log( sprintf( __( 'Feed scheduled to run at %s.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ), gmdate( 'H:i:s', $timestamp ) ) );
 	}
 
 	/**
@@ -258,7 +269,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		$this->queue_start();
 		ProductFeedStatus::set( array( 'status' => 'scheduled_for_generation' ) );
-		self::log( __( 'Feed generation queued.', 'pinterest-for-woocommerce' ) );
+		self::log( __( 'Feed generation queued.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
 	}
 
 	/**
@@ -269,7 +280,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	protected function handle_start() {
-		self::log( __( 'Feed generation start. Preparing temporary files.', 'pinterest-for-woocommerce' ) );
+		self::log( __( 'Feed generation start. Preparing temporary files.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
 		try {
 			ProductFeedStatus::reset_feed_file_generation_time();
 			ProductFeedStatus::set(
@@ -316,7 +327,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
 	protected function handle_end() {
-		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
+		self::log( __( 'Feed generation end. Moving files to the final destination.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
 		try {
 			$this->feed_file_operations->add_footer_to_temporary_feed_files();
 			$this->feed_file_operations->rename_temporary_feed_files_to_final();
@@ -331,7 +342,7 @@ class FeedGenerator extends AbstractChainedJob {
 			$this->handle_error( $th );
 			throw $th;
 		}
-		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
+		self::log( __( 'Feed generated successfully.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ) );
 
 		// Check if feed is dirty and reschedule in necessary.
 		if ( $this->feed_is_dirty() ) {
@@ -420,7 +431,7 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 		/* translators: number of products */
-		self::log( sprintf( __( 'Feed batch generated. Wrote %s products to the feed file.', 'pinterest-for-woocommerce' ), $processed_products ) );
+		self::log( sprintf( __( 'Feed batch generated. Wrote %s products to the feed file.', PINTEREST_FOR_WOOCOMMERCE_PREFIX ), $processed_products ) );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -251,9 +251,11 @@ class FeedGenerator extends AbstractChainedJob {
 				FROM {$wpdb->posts} as post
 				LEFT JOIN {$wpdb->posts} as parent ON post.post_parent = parent.ID
 				WHERE
-					( post.post_type = 'product_variation' AND parent.post_status = 'publish' )
-				OR
-					( post.post_type = 'product' AND post.post_status = 'publish' )
+					(
+						( post.post_type = 'product_variation' AND parent.post_status = 'publish' )
+					OR
+						( post.post_type = 'product' AND post.post_status = 'publish' )
+					)
 				AND
 					post.ID > %d
 				ORDER BY post.ID ASC

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -582,9 +582,9 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function get_batch_size(): int {
 		return Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) ?? apply_filters(
-				PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_feed_product_batch_size',
-				self::DEFAULT_PRODUCT_BATCH_SIZE
-			);
+			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_feed_product_batch_size',
+			self::DEFAULT_PRODUCT_BATCH_SIZE
+		);
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -716,6 +716,20 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Handle error on generate feed timeout.
+	 *
+	 * @since 1.2.14
+	 * @deprecated x.x.x
+	 *
+	 * @param int $action_id The ID of the action marked as failed.
+	 *
+	 * @throws Exception Related to max retries reached or missing arguments on the action.
+	 */
+	public function maybe_handle_error_on_timeout( int $action_id ) {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x' );
+	}
+
+	/**
 	 * Check whether the action's failure rate is above the specified threshold within the timeframe.
 	 *
 	 * @param string $hook The job action hook.
@@ -727,7 +741,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function is_failure_rate_above_threshold( string $hook, ?array $args = null ): bool {
 		$threshold   = apply_filters( 'pinterest_for_woocommerce_action_failure_threshold', 3 );
-		$time_period = apply_filters( 'pinterest_for_woocommerce_action_failure_time_period', 1800 ); // 30 minutes.
+		$time_period = apply_filters( 'pinterest_for_woocommerce_action_failure_time_period', 30 * MINUTE_IN_SECONDS );
 		$failed_actions = $this->action_scheduler->search(
 			[
 				'hook'         => $hook,

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -114,15 +114,15 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Unexpected shutdown handler.
 	 *
-	 * @param int $action_id
-	 * @param array|null $error
+	 * @param int        $action_id - Action Scheduler action ID.
+	 * @param array|null $error - Error details.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return void
 	 */
 	public function handle_unexpected_shutdown( int $action_id, ?array $error ) {
-		if ( !$error || !$this->is_timeout_error( $error ) ) {
+		if ( ! $error || ! $this->is_timeout_error( $error ) ) {
 			return;
 		}
 		$action = ActionScheduler::store()->fetch_action( $action_id );
@@ -138,6 +138,7 @@ class FeedGenerator extends AbstractChainedJob {
 		if ( $this->is_failure_rate_above_threshold( $hook, $args ) ) {
 			self::log(
 				sprintf(
+					// Translators: 1. Action Scheduler hook name.
 					__(
 						'Feed Generator `%s` Action reschedule threshold has been reached. Quit.',
 						'pinterest-for-woocommerce'
@@ -150,6 +151,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		self::log(
 			sprintf(
+				// Translators: Action Scheduler hook name.
 				__(
 					'Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it.',
 					'pinterest-for-woocommerce'
@@ -163,7 +165,11 @@ class FeedGenerator extends AbstractChainedJob {
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', $limit );
 		self::log(
 			sprintf(
-				__( 'Feed Generator `%s` Action product batch size decreased to %d.', 'pinterest-for-woocommerce' ),
+				// Translators: 1: Action Scheduler hook name, 2: New products number to process next action run.
+				__(
+					'Feed Generator `%1$s` Action product batch size decreased to %2$d.',
+					'pinterest-for-woocommerce'
+				),
 				$hook,
 				$limit
 			)
@@ -180,9 +186,9 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Action exception handler.
 	 *
-	 * @param int $action_id
-	 * @param Throwable $throwable
-	 * @param string $context
+	 * @param int       $action_id - Action Scheduler action id.
+	 * @param Throwable $throwable - Exception object.
+	 * @param string    $context - Action Scheduler context (e.g. WP CLI, Async Request or an empty string).
 	 *
 	 * @since x.x.x
 	 *
@@ -208,7 +214,11 @@ class FeedGenerator extends AbstractChainedJob {
 
 		self::log(
 			sprintf(
-				__( 'Feed Generator `%s` Action failed to execute due to an error thrown `%s.`. A complete feed generation retry has been scheduled.' ),
+				// Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
+				__(
+					'Feed Generator `%1$s` Action failed to execute due to an error thrown `%2$s.`. A complete feed generation retry has been scheduled.',
+					'pinterest-for-woocommerce'
+				),
 				$hook,
 				$throwable->getMessage()
 			),
@@ -400,7 +410,7 @@ class FeedGenerator extends AbstractChainedJob {
 			}
 		}
 
-		// May throw write to file exception
+		// May throw write to file exception.
 		$this->feed_file_operations->write_buffers_to_temp_files( $this->buffers );
 
 		$count = ProductFeedStatus::get()['product_count'] ?? 0;
@@ -573,7 +583,7 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Returns last product id from the last batch of products fetched at the previous step.
 	 *
-	 * @param int $batch_number
+	 * @param int $batch_number - Action Scheduler chain action batch number.
 	 * @return int
 	 */
 	protected function get_last_batch_id( int $batch_number ): int {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -65,18 +65,6 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		);
 	}
 
-	public function test_init_adds_action_scheduler_failed_action_hook() {
-		$this->feed_generator->init();
-
-		$this->assertEquals(
-			10,
-			has_action(
-				'action_scheduler_failed_action',
-				array( $this->feed_generator, 'maybe_handle_error_on_timeout' )
-			)
-		);
-	}
-
 	public function test_feed_generator_start_sets_product_feed_status_generation_start_time() {
 		$time_test_started = time();
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -2,16 +2,17 @@
 
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
+use ActionScheduler_Action;
+use ActionScheduler_Store;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
-use \Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler as ActionSchedulerProxy;
+use Automattic\WooCommerce\Pinterest\Exception\FeedFileOperationsException;
 use Automattic\WooCommerce\Pinterest\FeedFileOperations;
 use Automattic\WooCommerce\Pinterest\FeedGenerator;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
 use Exception;
-use Pinterest_For_Woocommerce;
-use Throwable;
+use WC_Helper_Product;
 
 class FeedGeneratorTest extends \WP_UnitTestCase {
 
@@ -214,7 +215,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			->with(
 				'pinterest/jobs/generate_feed/chain_end',
 				array( array() ),
-				''
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
 			);
 
 		$this->feed_generator->handle_batch_action( 1, array() );
@@ -231,7 +232,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			->with(
 				'pinterest/jobs/generate_feed/chain_batch',
 				array( 2, array() ),
-				''
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
 			);
 
 		$this->feed_generator->handle_batch_action( 1, array() );

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -238,7 +238,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$store  = ActionScheduler::store();
 		$runner = new ActionScheduler_QueueRunner( $store );
 
-		add_action( 'action_scheduler_failed_execution', array( $this->feed_generator, 'handle_failed_execution' ), 10, 3 );
+		add_action( 'action_scheduler_failed_execution', array( $this->feed_generator, 'handle_failed_execution' ), 10, 2 );
 
 		// Add a callback to throw an exception when the action is processed.
 		$callback = function () {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use ActionScheduler_Action;
 use ActionScheduler_QueueRunner;
-use ActionScheduler_Store;
 use ActionScheduler;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
 use Automattic\WooCommerce\Pinterest\FeedFileOperations;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removing `action_scheduler_failed_execution` handler as the one which made feed generation to loop. Adding few other handlers (`action_scheduler_failed_execution` and `action_scheduler_unexpected_shutdown`) to properly handle action exceptions and action unexpected shutdown events.

### Detailed test instructions:

#### Testing `action_scheduler_failed_execution`.
1. Checkout the PR.
2. Edit `FeedGenerator.php::handle_batch_action()` and make it throw an exception (preferably with a message you could remember to look for it in the logs). Search for a string like `Feed Generator pinterest/jobs/generate_feed/chain_batch Action failed to execute due to an error thrown **[Exception message here]**. A complete feed generation retry has been scheduled.`
3. Run a corresponding action and check the logs. Logs must contain records regarding the action failure and some information about retrying the action one hour later.

![WooCommerce_status_‹_Wordpress_—_WordPress](https://user-images.githubusercontent.com/9010963/235175461-51976955-a124-4729-9c3f-abff8bf79a07.png)

#### Testing `action_scheduler_unexpected_shutdown`.
The handler is attached to a `shutdown` hook which runs on php shutdown. Don't have instructions on how to test this.

Both handlers are unit tested.

### Changelog entry

> Update - Pinterest feed generator backoff adjustments.
