### PR TITLE
Add/intercept v5 connect data

### DIFF
--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -114,6 +114,12 @@ class Auth extends VendorAPI {
 		exit;
 	}
 
+	/**
+	 * Logs the error and redirects to the settings page.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @param string          $error   The error message.
+	 */
 	public function log_error_and_redirect( WP_REST_Request $request, $error ) {
 		$error_args = '&error=' . $error;
 		Logger::log( wp_json_encode( $error ), 'error', null, true );

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -46,11 +46,12 @@ class Auth extends VendorAPI {
 	public function permissions_check( WP_REST_Request $request ) {
 
 		$nonce = $request->get_param( 'state' ) ?? '';
+
 		/*
 		 * Check if the nonce is valid. We grab the nonce from the transient because wp_verify_nonce() in REST API call
 		 * is generated for user 0 and therefore it always returns false.
 		 */
-		return $nonce === get_transient( \PINTEREST_FOR_WOOCOMMERCE_CONNECT_NONCE );
+		return get_transient( \PINTEREST_FOR_WOOCOMMERCE_CONNECT_NONCE ) === $nonce;
 	}
 
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -320,7 +320,7 @@ class Base {
 	 */
 	public static function get_token() {
 		if ( is_null( self::$token ) ) {
-			self::$token = Pinterest_For_Woocommerce()::get_token();
+			self::$token = Pinterest_For_Woocommerce()::get_access_token();
 		}
 
 		return self::$token;

--- a/tests/Unit/TasksTest.php
+++ b/tests/Unit/TasksTest.php
@@ -52,16 +52,16 @@ class TasksTest extends WP_UnitTestCase {
 		// Assert that the task is not completed.
 		$task        = TaskLists::get_task( 'setup-pinterest' );
 		$is_complete = $task->is_complete();
-		
+
 		$this->assertFalse( $is_complete, 'Cannot assert task not completed.' );
 
-		// Setup complete data. 
+		// Setup complete data.
 		$account_data = array(
 			'is_any_website_verified' => true,
 			'is_partner'              => true,
 		);
 		\Pinterest_For_Woocommerce::save_setting( 'account_data', $account_data );
-		\Pinterest_For_Woocommerce::save_token(
+		\Pinterest_For_Woocommerce::save_token_data(
 			array(
 				'access_token' => 'some-fake-access-token',
 			)

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -60,7 +60,7 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 
 	public function test_extension_connection_status_is_tracked_as_yes_if_opt_in() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
-		Pinterest_For_Woocommerce::save_token(
+		Pinterest_For_Woocommerce::save_token_data(
 			array(
 				'access_token' => 'some-fake-access-token',
 			)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This build on the #740.  After merging #740 this should automatically start pointing to `pinterest-v5-integration-branch`

Intercept the incoming information.

Closes #743   .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use the flow form #740
2. In the database in the Pinterest data a new structure called `token_data` should be stored.
3. It should have data :)
