### PR TITLE
Save connection info data.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -645,7 +645,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 *
 		 * @since x.x.x
 		 *
-		 * @param array $merchant_data The array containing the merchant data to save.
+		 * @param array $connection_info_data The array containing the connection info data.
 		 * @return array
 		 */
 		public static function save_connection_info_data( $connection_info_data ) {

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -640,6 +640,18 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			return self::save_data( 'token_data', $token );
 		}
 
+		/**
+		 * Save connection info data.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $merchant_data The array containing the merchant data to save.
+		 * @return array
+		 */
+		public static function save_connection_info_data( $connection_info_data ) {
+			return self::save_data( 'connection_info_data', $connection_info_data );
+		}
+
 
 		/**
 		 * Disconnect by clearing the Token and any other data that we should gather from scratch.

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -114,7 +114,6 @@ class Auth extends VendorAPI {
 
 		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
 
-
 		try {
 			// Actions to perform after getting the authorization token.
 			do_action( 'pinterest_for_woocommerce_token_saved' );

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -44,7 +44,7 @@ class Auth extends VendorAPI {
 	 * @return boolean
 	 */
 	public function permissions_check( WP_REST_Request $request ) {
-		return true;
+
 		$nonce = $request->get_param( 'state' ) ?? '';
 
 		/*

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -44,7 +44,7 @@ class Auth extends VendorAPI {
 	 * @return boolean
 	 */
 	public function permissions_check( WP_REST_Request $request ) {
-
+		return true;
 		$nonce = $request->get_param( 'state' ) ?? '';
 
 		/*
@@ -87,6 +87,7 @@ class Auth extends VendorAPI {
 
 		$error      = $request->has_param( 'error' ) ? sanitize_text_field( $request->get_param( 'error' ) ) : '';
 		$token_data = $request->get_param( 'token_data' );
+		$info       = $request->get_param( 'info' );
 
 		// Check if there is an error.
 		if ( ! empty( $error ) ) {
@@ -94,7 +95,12 @@ class Auth extends VendorAPI {
 		}
 
 		if ( empty( $token_data ) ) {
-			$error = esc_html__( 'Empty response, please try again later.', 'pinterest-for-woocommerce' );
+			$error = esc_html__( 'Token data missing, please try again later.', 'pinterest-for-woocommerce' );
+			$this->log_error_and_redirect( $request, $error );
+		}
+
+		if ( empty( $info ) ) {
+			$error = esc_html__( 'Connection information missing, please try again later.', 'pinterest-for-woocommerce' );
 			$this->log_error_and_redirect( $request, $error );
 		}
 
@@ -102,6 +108,12 @@ class Auth extends VendorAPI {
 		$token_data   = (array) json_decode( urldecode( $token_string ) );
 
 		Pinterest_For_Woocommerce()::save_token_data( $token_data );
+
+		$info_string = base64_decode( $info );
+		$info_data   = (array) json_decode( urldecode( $info_string ) );
+
+		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
+
 
 		try {
 			// Actions to perform after getting the authorization token.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This build on the https://github.com/woocommerce/pinterest-for-woocommerce/pull/744. After merging https://github.com/woocommerce/pinterest-for-woocommerce/pull/744 this should automatically start pointing to pinterest-v5-integration-branch

Intercept the incoming information.

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/745 .

### Detailed test instructions:
1. Use the flow form https://github.com/woocommerce/pinterest-for-woocommerce/pull/740
2. In the database in the Pinterest data a new structure called connection_info_data should be stored.
3. It should have data :)