### PR TITLE
Implement Pinterest API V5 support

### DIFF
--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Pinterest API V5 class
+ *
+ * @class       Pinterest_For_Woocommerce_API
+ * @version     x.x.x
+ * @package     Pinterest_For_WordPress/Classes/
+ */
+
+namespace Automattic\WooCommerce\Pinterest\API;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * API V5 Methods
+ */
+class APIV5 extends Base {
+
+	const API_DOMAIN      = 'https://api.pinterest.com/v5';
+
+	/**
+	 * Prepare request
+	 *
+	 * @param string $endpoint        the endpoint to perform the request on.
+	 * @param string $method          eg, POST, GET, PUT etc.
+	 * @param array  $payload         Payload to be sent on the request's body.
+	 * @param string $api             The specific Endpoints subset.
+	 *
+	 * @return array
+	 */
+	public static function prepare_request( $endpoint, $method = 'POST', $payload = array(), $api = '' ) {
+
+		$request = array(
+			'url'     => self::API_DOMAIN . "/{$endpoint}",
+			'method'  => $method,
+			'args'    => $payload,
+			'headers' => array(
+				'Pinterest-Woocommerce-Version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+			),
+		);
+
+		return $request;
+	}
+
+}

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -91,25 +91,8 @@ class Base {
 		}
 
 		try {
-			$api         = empty( $api ) ? '' : trailingslashit( $api );
-			$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
 
-			$request = array(
-				'url'     => self::API_DOMAIN . "/{$api}v{$api_version}/{$endpoint}",
-				'method'  => $method,
-				'args'    => $payload,
-				'headers' => array(
-					'Pinterest-Woocommerce-Version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
-				),
-			);
-
-			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
-				// Force json content-type header and json encode payload.
-				$request['headers']['Content-Type'] = 'application/json';
-
-				$request['args'] = wp_json_encode( $payload );
-			}
-
+			$request  = self::prepare_request( $endpoint, $method, $payload, $api );
 			$response = self::handle_request( $request );
 
 			if ( ! empty( $cache_expiry ) ) {
@@ -163,6 +146,39 @@ class Base {
 			throw $e;
 		}
 
+	}
+
+	/**
+	 * Prepare request
+	 *
+	 * @param string $endpoint        the endpoint to perform the request on.
+	 * @param string $method          eg, POST, GET, PUT etc.
+	 * @param array  $payload         Payload to be sent on the request's body.
+	 * @param string $api             The specific Endpoints subset.
+	 *
+	 * @return array
+	 */
+	public static function prepare_request( $endpoint, $method = 'POST', $payload = array(), $api = '' ) {
+		$api         = empty( $api ) ? '' : trailingslashit( $api );
+		$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
+
+		$request = array(
+			'url'     => self::API_DOMAIN . "/{$api}v{$api_version}/{$endpoint}",
+			'method'  => $method,
+			'args'    => $payload,
+			'headers' => array(
+				'Pinterest-Woocommerce-Version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+			),
+		);
+
+		if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
+			// Force json content-type header and json encode payload.
+			$request['headers']['Content-Type'] = 'application/json';
+
+			$request['args'] = wp_json_encode( $payload );
+		}
+
+		return $request;
 	}
 
 	/**


### PR DESCRIPTION
### Description

This PR introduces support for the Pinterest API V5 in the Pinterest for WooCommerce plugin by adding a new class `APIV5`. The PR also includes a refactoring of the `Base` class by moving the `prepare_request` method from `Base` to both `APIV5` and `Base` classes.

### Changes

1. Created a new file `APIV5.php` which defines the `APIV5` class that extends the `Base` class.
   - Set the API domain for V5 in the `APIV5` class
   - Implemented the `prepare_request` method in the `APIV5` class to handle requests to the V5 API

2. Refactored the `Base` class in `Base.php`.
   - Moved the `prepare_request` method out of the `send` method and made it a separate public static method.
   - Updated the `send` method to use the `prepare_request` method to prepare the request before handling it.

### Impact

This update will allow the plugin to communicate with the latest Pinterest API (V5) while still maintaining backward compatibility with previous versions of the API. This will enable users to take advantage of new features and improvements provided by Pinterest's API V5.

### Testing

1. Verify that existing functionality using the `Base` class is not affected by the refactoring.
2. Test the new `APIV5` class by making requests to the V5 API and ensuring they are processed correctly.