### PR TITLE
Add Access Token refresh action.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -268,6 +268,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\Billing::class, 'schedule_event' ) );
 			add_action( 'init', array( Pinterest\AdCredits::class, 'schedule_event' ) );
+			add_action( 'init', array( Pinterest\RefreshToken::class, 'schedule_event' ) );
 
 			// Verify that the ads_campaign is active or not.
 			add_action( 'admin_init', array( Pinterest\AdCredits::class, 'check_if_ads_campaign_is_active' ) );
@@ -637,6 +638,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$token['access_token']  = empty( $token['access_token'] ) ? '' : Pinterest\Crypto::encrypt( $token['access_token'] );
 			$token['refresh_token'] = empty( $token['refresh_token'] ) ? '' : Pinterest\Crypto::encrypt( $token['refresh_token'] );
+			$token['refresh_date']  = time();
 			return self::save_data( 'token_data', $token );
 		}
 

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Pinterest for WooCommerce Refresh Token.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ * @version x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Exception;
+use Pinterest_For_Woocommerce;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Handling Token Refresh.
+ */
+class RefreshToken {
+
+	/**
+	 * Initialize Refresh Token actions and Action Scheduler hooks.
+	 *
+	 * @since x.x.x
+	 */
+	public static function schedule_event() {
+		if ( ! has_action( Heartbeat::DAILY, array( self::class, 'handle_refresh' ) ) ) {
+			add_action( Heartbeat::DAILY, array( self::class, 'handle_refresh' ), 20 );
+		}
+	}
+
+	/**
+	 * Checks if it is time to refresh the token and refreshes it if needed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return true
+	 */
+	public static function handle_refresh(): bool {
+		$token_data   = Pinterest_For_Woocommerce::get_data( 'token_data', true );
+		$expires_in   = intval( $token_data['expires_in'] );
+		$refresh_date = intval( $token_data['refresh_date'] );
+
+		if ( $refresh_date + $expires_in - 2 * DAY_IN_SECONDS <= time() ) {
+			try {
+				$endpoint = Pinterest_For_Woocommerce::get_connection_proxy_url() . 'renew/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE;
+				$response = wp_safe_remote_post(
+					$endpoint,
+					array(
+						'headers' => array(
+							'Content-Type' => 'application/x-www-form-urlencoded',
+						),
+						'body'    => array(
+							'refresh_token' => Crypto::decrypt( $token_data['refresh_token'] ),
+						),
+						'sslverify' => false,
+					)
+				);
+				$body = trim( wp_remote_retrieve_body( $response ) );
+				$body = json_decode( $body, true );
+				Pinterest_For_Woocommerce::save_token_data( $body );
+			} catch ( Exception $e ) {
+				// Log the error.
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Pinterest;
 
 use Exception;
 use Pinterest_For_Woocommerce;
+use WC_Log_Levels;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -43,26 +44,48 @@ class RefreshToken {
 		$expires_in   = intval( $token_data['expires_in'] );
 		$refresh_date = intval( $token_data['refresh_date'] );
 
-		if ( $refresh_date + $expires_in - 2 * DAY_IN_SECONDS <= time() ) {
+		/**
+		 * Filters to determine if it is time to start refreshing the token.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $maybe_refresh - True if it is time to refresh the token.
+		 */
+		$maybe_refresh = apply_filters(
+			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_maybe_refresh_token',
+			$refresh_date + $expires_in - 2 * DAY_IN_SECONDS <= time()
+		);
+
+		// Translators: %s is the value of $maybe_refresh.
+		$refresh_log = sprintf( 'Should refresh pinterest access token: %s', wc_bool_to_string( $maybe_refresh ) );
+		Logger::log( $refresh_log, WC_Log_Levels::DEBUG, 'pinterest-for-woocommerce' );
+
+		if ( $maybe_refresh ) {
 			try {
 				$endpoint = Pinterest_For_Woocommerce::get_connection_proxy_url() . 'renew/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE;
-				$response = wp_safe_remote_post(
-					$endpoint,
-					array(
-						'headers' => array(
-							'Content-Type' => 'application/x-www-form-urlencoded',
-						),
-						'body'    => array(
-							'refresh_token' => Crypto::decrypt( $token_data['refresh_token'] ),
-						),
-						'sslverify' => false,
-					)
+				$options  = array(
+					'headers' => array(
+						'Content-Type' => 'application/x-www-form-urlencoded',
+					),
+					'body'    => array(
+						'refresh_token' => Crypto::decrypt( $token_data['refresh_token'] ),
+					),
+					'sslverify' => false,
 				);
-				$body = trim( wp_remote_retrieve_body( $response ) );
+
+				// Translators: %1$s is the endpoint, %2$s is the options.
+				$request_log = sprintf( 'Refresh token request to %1$s with %2$s', $endpoint, json_encode( $options ) );
+				Logger::log( $request_log, WC_Log_Levels::DEBUG, 'pinterest-for-woocommerce' );
+
+				$response = wp_safe_remote_post( $endpoint, $options );
+				$body     = trim( wp_remote_retrieve_body( $response ) );
+
+				Logger::log( $body, WC_Log_Levels::DEBUG, 'pinterest-for-woocommerce' );
+
 				$body = json_decode( $body, true );
 				Pinterest_For_Woocommerce::save_token_data( $body );
 			} catch ( Exception $e ) {
-				// Log the error.
+				Logger::log( $e->getMessage(), WC_Log_Levels::ERROR, 'pinterest-for-woocommerce' );
 				return false;
 			}
 		}

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Automattic\WooCommerce\Pinterest\RefreshToken;
+
+class PinterestForWoocommerceTest extends \WP_UnitTestCase {
+
+	/**
+	 * Test of the plugin has refresh token action initialised.
+	 *
+	 * @return void
+	 */
+	public function test_pinterest_api_access_token_scheduled_for_refresh() {
+		Pinterest_For_Woocommerce();
+		$this->assertEquals( 10, has_action( 'init', [ RefreshToken::class, 'schedule_event' ] ) );
+	}
+}

--- a/tests/Unit/RefreshTokenTest.php
+++ b/tests/Unit/RefreshTokenTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\Crypto;
+use Automattic\WooCommerce\Pinterest\Heartbeat;
+use Automattic\WooCommerce\Pinterest\RefreshToken;
+use Pinterest_For_Woocommerce;
+
+class RefreshTokenTest extends \WP_UnitTestCase {
+
+	/**
+	 * Test daily refresh token action is added.
+	 *
+	 * @return void
+	 */
+	public function test_schedule_event_added_with_plugin() {
+		$pinterest = Pinterest_For_Woocommerce();
+		$this->assertEquals( 10, has_action( 'plugins_loaded', array( $pinterest, 'init_plugin' ) ) );
+		$pinterest->init_plugin();
+		$this->assertEquals( 10, has_action( 'init', [ RefreshToken::class, 'schedule_event' ] ) );
+	}
+
+	public function test_schedule_event_adds_daily_action() {
+		RefreshToken::schedule_event();
+		$this->assertEquals( 20, has_action( Heartbeat::DAILY, array( RefreshToken::class, 'handle_refresh' ) ) );
+	}
+
+	/**
+	 * Tests call to refresh a token is made if token is about to expire in two days.
+	 *
+	 * @return void
+	 */
+	public function test_handle_refresh_does_a_call_to_refresh_a_token_if_token_about_to_expire_in_two_days() {
+		$expires_in   = 30 * DAY_IN_SECONDS;
+		$refresh_date = time() - 28 * DAY_IN_SECONDS - 10;
+
+		update_option(
+			PINTEREST_FOR_WOOCOMMERCE_DATA_NAME,
+			array(
+				'token_data' => array(
+					'refresh_token' => Crypto::encrypt( 'pinr.refresh_token' ),
+					'expires_in'    => $expires_in, // Access Token expires in 30 days.
+					'refresh_date'  => $refresh_date, // Token was refreshed more than 28 days ago. Refresh.
+				),
+			)
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				$this->assertEquals(
+					Pinterest_For_Woocommerce::get_connection_proxy_url() . 'renew/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE,
+					$url
+				);
+				$this->assertEquals( 'pinr.refresh_token', $parsed_args['body']['refresh_token'] ?? '' );
+				return true;
+			},
+			10,
+			3
+		);
+
+		RefreshToken::handle_refresh();
+	}
+
+	/**
+	 * Tests data returned from refresh token call is saved.
+	 *
+	 * @return void
+	 */
+	public function test_handle_refresh_updates_option_with_new_tokens() {
+		$expires_in   = 30 * DAY_IN_SECONDS;
+		$refresh_date = time() - 28 * DAY_IN_SECONDS - 10;
+
+		update_option(
+			PINTEREST_FOR_WOOCOMMERCE_DATA_NAME,
+			array(
+				'token_data' => array(
+					'refresh_token' => Crypto::encrypt( 'pinr.refresh_token' ),
+					'expires_in'    => $expires_in, // Access Token expires in 30 days.
+					'refresh_date'  => $refresh_date, // Token was refreshed more than 28 days ago. Refresh.
+				),
+			)
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				return array(
+					'body' => json_encode(
+						array(
+							'token_type'    => 'bearer',
+							'access_token'  => 'pina.access_token_new',
+							'expires_in'    => 30 * DAY_IN_SECONDS,
+							'refresh_token' => 'pinr.refresh_token_new',
+							'scope'         => 'ads:read ads:write catalogs:read catalogs:write pins:read pins:write user_accounts:read user_accounts:write',
+						),
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		RefreshToken::handle_refresh();
+
+		$token_data = Pinterest_For_Woocommerce::get_data( 'token_data', true );
+
+		$this->assertEquals( 'bearer', $token_data['token_type'] );
+		$this->assertEquals( 'pina.access_token_new', Crypto::decrypt( $token_data['access_token'] ) );
+		$this->assertEquals( 'pinr.refresh_token_new', Crypto::decrypt( $token_data['refresh_token'] ) );
+		$this->assertEquals( 'ads:read ads:write catalogs:read catalogs:write pins:read pins:write user_accounts:read user_accounts:write', $token_data['scope'] );
+	}
+}


### PR DESCRIPTION
Closes #748 

### Changes proposed in this Pull Request:

PR adds an action to run daily checking for access token expiration and refreshing it if needed two days before the end date.

### Detailed test instructions:

1. Checkout the PR.
2. See daily action added.
3. Force run it and see data is updated inside the database options table.

### Changelog entry

> Add - Refresh Access Token daily action.
