### PR TITLE
Connection flow not redirection the wizard view

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -830,6 +830,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			set_transient( PINTEREST_FOR_WOOCOMMERCE_AUTH, $control_key, MINUTE_IN_SECONDS * 5 );
 
+			// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 			// nosemgrep: audit.php.wp.security.xss.query-arg
 			return self::get_connection_proxy_url() . 'login/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE . '?' . $state;
 		}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -830,7 +830,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			set_transient( PINTEREST_FOR_WOOCOMMERCE_AUTH, $control_key, MINUTE_IN_SECONDS * 5 );
 
-			return esc_url( self::get_connection_proxy_url() . 'login/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE . '?' . $state );
+			// nosemgrep: audit.php.wp.security.xss.query-arg
+			return self::get_connection_proxy_url() . 'login/' . PINTEREST_FOR_WOOCOMMERCE_WOO_CONNECT_SERVICE . '?' . $state;
 		}
 
 

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -144,10 +144,11 @@ class Auth extends VendorAPI {
 			$query_args['view'] = sanitize_key( $view );
 		}
 
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 		// nosemgrep: audit.php.wp.security.xss.query-arg
 		return add_query_arg(
-				$query_args,
-				admin_url( 'admin.php' )
-			);
+			$query_args,
+			admin_url( 'admin.php' )
+		);
 	}
 }

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -144,11 +144,10 @@ class Auth extends VendorAPI {
 			$query_args['view'] = sanitize_key( $view );
 		}
 
-		return esc_url(
-			add_query_arg(
+		// nosemgrep: audit.php.wp.security.xss.query-arg
+		return add_query_arg(
 				$query_args,
 				admin_url( 'admin.php' )
-			)
-		);
+			);
 	}
 }

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -609,6 +609,7 @@ class Base {
 	 */
 	public static function update_merchant_feed( $merchant_id, $feed_id, $args ) {
 
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 		// nosemgrep: audit.php.wp.security.xss.query-arg
 		return self::make_request(
 			add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ),

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -609,8 +609,9 @@ class Base {
 	 */
 	public static function update_merchant_feed( $merchant_id, $feed_id, $args ) {
 
+		// nosemgrep: audit.php.wp.security.xss.query-arg
 		return self::make_request(
-			esc_url( add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ) ),
+			add_query_arg( $args, 'commerce/product_pin_merchants/' . $merchant_id . '/feed/' . $feed_id . '/' ),
 			'PUT'
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The use of esc_url isn't necessarily when the URL is not displayed back to the UI. This caused some issues. This PR removes the escape opting instead to silence the semgrep security warning.

Closes #760.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1.  Use the steps described in #760 and observe the expected behavior.


### Changelog entry

> Fix - Connection flow not redirection the wizard view
