### PR TITLE
Ensure feed IDs is an array, even if it has not been saved before

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,7 @@
 		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary"/>
 	</rule>
 
 	<!-- Specific excludes -->

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -67,7 +67,7 @@ class LocalFeedConfigs {
 	 */
 	private function initialize_local_feeds_config( $locations ) {
 
-		$feed_ids = Pinterest_For_Woocommerce()::get_data( 'local_feed_ids' ) ?? array();
+		$feed_ids = (array) Pinterest_For_Woocommerce()::get_data( 'local_feed_ids' ) ?: array();
 
 		foreach ( $locations as $location ) {
 			if ( array_key_exists( $location, $feed_ids ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #767.

This ensures that the `$feed_ids` variable is always an array, so that there is no error when it is used within `array_key_exists()`.

### Detailed test instructions:
1. With PHP 8+, install and activate Pinterest for WooCommerce
2. After activation, there should be no fatal error


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - ensure there is no fatal error for PHP 8+ during activation
