### PR TITLE
Handle API 401 responses.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -286,9 +286,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
-			// Renders `Reconnect your Pinterest account.` error message on admin pages if the token is invalid.
-			add_action( 'admin_init', array( UnauthorizedAccessMonitor::class, 'maybe_show_error' ) );
-
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 
@@ -714,6 +711,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				}
 
 				self::flush_options();
+
+				// Reset the Unauthorized Access Monitor.
+				UnauthorizedAccessMonitor::reset();
 
 				// At this point we're disconnected.
 				return true;

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Pinterest\Billing;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\Notes\MarketingNotifications;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
+use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
 use Automattic\WooCommerce\Pinterest\Utilities\Tracks;
 use Automattic\WooCommerce\Pinterest\API\UserInteraction;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
@@ -285,12 +286,8 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
-			add_action(
-				'admin_init',
-				function () {
-					//( new Pinterest\Notes\Collection\ReconnectMerchant() )->prepare_note()->save();
-				}
-			);
+			// Renders `Reconnect your Pinterest account.` error message on admin pages if the token is invalid.
+			add_action('admin_init', array( UnauthorizedAccessMonitor::class, 'maybe_show_error' ) );
 
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -285,6 +285,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
+			add_action(
+				'admin_init',
+				function () {
+					//( new Pinterest\Notes\Collection\ReconnectMerchant() )->prepare_note()->save();
+				}
+			);
+
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -287,7 +287,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
 
 			// Renders `Reconnect your Pinterest account.` error message on admin pages if the token is invalid.
-			add_action('admin_init', array( UnauthorizedAccessMonitor::class, 'maybe_show_error' ) );
+			add_action( 'admin_init', array( UnauthorizedAccessMonitor::class, 'maybe_show_error' ) );
 
 			// Disconnect advertiser if advertiser or tag change.
 			add_action( 'update_option_pinterest_for_woocommerce', array( $this, 'maybe_disconnect_advertiser' ), 10, 2 );

--- a/i18n/languages/pinterest-for-woocommerce.pot
+++ b/i18n/languages/pinterest-for-woocommerce.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-06-09T12:34:35+00:00\n"
+"POT-Creation-Date: 2023-06-15T17:53:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: pinterest-for-woocommerce\n"
@@ -36,69 +36,69 @@ msgstr ""
 msgid "https://woocommerce.com"
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:153
+#: class-pinterest-for-woocommerce.php:154
 msgid "Cloning this class is forbidden."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:162
+#: class-pinterest-for-woocommerce.php:163
 msgid "Unserializing instances of this class is forbidden."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:170
+#: class-pinterest-for-woocommerce.php:171
 msgid "Only a single instance of this class is allowed. Use singleton."
 msgstr ""
 
 #. Translators: The minimum PHP version
-#: class-pinterest-for-woocommerce.php:355
+#: class-pinterest-for-woocommerce.php:359
 msgid "Pinterest for WooCommerce requires a minimum PHP version of %s."
 msgstr ""
 
 #. Translators: The minimum WP version
-#: class-pinterest-for-woocommerce.php:360
+#: class-pinterest-for-woocommerce.php:364
 msgid "Pinterest for WooCommerce requires a minimum WordPress version of %s."
 msgstr ""
 
 #. Translators: The minimum WC version
-#: class-pinterest-for-woocommerce.php:365
+#: class-pinterest-for-woocommerce.php:369
 msgid "Pinterest for WooCommerce requires a minimum WooCommerce version of %s."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:369
+#: class-pinterest-for-woocommerce.php:373
 msgid "Pinterest for WooCommerce requires WooCommerce Admin to be enabled."
 msgstr ""
 
 #. Translators: The minimum Action Scheduler version
-#: class-pinterest-for-woocommerce.php:374
+#: class-pinterest-for-woocommerce.php:378
 msgid "Pinterest for WooCommerce requires a minimum Action Scheduler package of %s. It can be caused by old version of the WooCommerce extensions."
 msgstr ""
 
 #. Translators: The error description
-#: class-pinterest-for-woocommerce.php:640
+#: class-pinterest-for-woocommerce.php:644
 msgid "Could not decrypt the Pinterest API access token. Try reconnecting to Pinterest. [%s]"
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:691
+#: class-pinterest-for-woocommerce.php:695
 msgid "Response error on disconnect merchant."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:706
+#: class-pinterest-for-woocommerce.php:710
 msgid "There was an error disconnecting the Advertiser."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:708
-#: class-pinterest-for-woocommerce.php:791
+#: class-pinterest-for-woocommerce.php:712
+#: class-pinterest-for-woocommerce.php:795
 msgid "There was an error disconnecting the Advertiser. Please try again."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:720
+#: class-pinterest-for-woocommerce.php:724
 msgid "Trying to disconnect while the merchant (id) was not found."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:925
+#: class-pinterest-for-woocommerce.php:929
 msgid "There was an error getting the account data."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:1173
+#: class-pinterest-for-woocommerce.php:1177
 msgid "Pinterest for WooCommerce verification page"
 msgstr ""
 
@@ -200,25 +200,25 @@ msgstr ""
 msgid "20 minutes"
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:58
+#: src/API/AdvertiserConnect.php:59
 msgid "Missing advertiser or tag parameters."
 msgstr ""
 
 #. Translators: The error description as returned from the API
-#: src/API/AdvertiserConnect.php:81
+#: src/API/AdvertiserConnect.php:82
 msgid "Could not connect advertiser with Pinterest. [%s]"
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:101
+#: src/API/AdvertiserConnect.php:102
 msgid "The advertiser could not be connected to Pinterest."
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:105
+#: src/API/AdvertiserConnect.php:106
 msgid "Incorrect advertiser ID."
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:154
-#: src/API/AdvertiserConnect.php:168
+#: src/API/AdvertiserConnect.php:158
+#: src/API/AdvertiserConnect.php:172
 msgid "The advertiser could not be disconnected from Pinterest."
 msgstr ""
 
@@ -250,7 +250,7 @@ msgid "There was an error getting the account data. Please try again later."
 msgstr ""
 
 #. Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message 5: Pinterest code
-#: src/API/Base.php:131
+#: src/API/Base.php:134
 msgid ""
 "%1$s Request: %2$s\n"
 "Status Code: %3$s\n"
@@ -259,23 +259,19 @@ msgid ""
 msgstr ""
 
 #. Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message
-#: src/API/Base.php:153
+#: src/API/Base.php:156
 msgid ""
 "%1$s Request: %2$s\n"
 "Status Code: %3$s\n"
 "API response: %4$s"
 msgstr ""
 
-#: src/API/Base.php:289
-msgid "Reconnect to your Pinterest account"
-msgstr ""
-
-#: src/API/Base.php:344
+#: src/API/Base.php:343
 msgid "Empty body"
 msgstr ""
 
-#: src/API/Base.php:415
-#: src/API/Base.php:516
+#: src/API/Base.php:414
+#: src/API/Base.php:515
 #: src/Merchants.php:139
 msgid "Auto-created by Pinterest for WooCommerce"
 msgstr ""
@@ -512,52 +508,52 @@ msgid "Could not rename %1$s to %2$s"
 msgstr ""
 
 #. Translators: 1. Action Scheduler hook name.
-#: src/FeedGenerator.php:152
+#: src/FeedGenerator.php:157
 msgid "Feed Generator `%s` Action reschedule threshold has been reached. Quit."
 msgstr ""
 
 #. Translators: Action Scheduler hook name.
-#: src/FeedGenerator.php:165
+#: src/FeedGenerator.php:170
 msgid "Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it."
 msgstr ""
 
 #. Translators: 1: Action Scheduler hook name, 2: New products number to process next action run.
-#: src/FeedGenerator.php:182
+#: src/FeedGenerator.php:187
 msgid "Feed Generator `%1$s` Action product batch size decreased to %2$d."
 msgstr ""
 
 #. translators: time in the format hours:minutes:seconds
-#: src/FeedGenerator.php:227
+#: src/FeedGenerator.php:232
 msgid "Feed scheduled to run at %s."
 msgstr ""
 
-#: src/FeedGenerator.php:249
+#: src/FeedGenerator.php:254
 msgid "Feed generation queued."
 msgstr ""
 
-#: src/FeedGenerator.php:260
+#: src/FeedGenerator.php:265
 msgid "Feed generation start. Preparing temporary files."
 msgstr ""
 
-#: src/FeedGenerator.php:307
+#: src/FeedGenerator.php:312
 msgid "Feed generation end. Moving files to the final destination."
 msgstr ""
 
-#: src/FeedGenerator.php:322
+#: src/FeedGenerator.php:327
 msgid "Feed generated successfully."
 msgstr ""
 
 #. translators: number of products
-#: src/FeedGenerator.php:411
+#: src/FeedGenerator.php:416
 msgid "Feed batch generated. Wrote %s products to the feed file."
 msgstr ""
 
 #. Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
-#: src/FeedGenerator.php:524
+#: src/FeedGenerator.php:529
 msgid "Feed Generator `%1$s` Action failed to execute due to an error thrown `%2$s.`. A complete feed generation retry has been scheduled."
 msgstr ""
 
-#: src/FeedRegistration.php:96
+#: src/FeedRegistration.php:104
 msgid "Could not register feed."
 msgstr ""
 
@@ -655,6 +651,18 @@ msgstr ""
 
 #: src/Notes/Collection/EnableCatalogSync.php:84
 msgid "Enable Sync"
+msgstr ""
+
+#: src/Notes/Collection/ReconnectMerchant.php:63
+msgid "Reconnect your Pinterest account."
+msgstr ""
+
+#: src/Notes/Collection/ReconnectMerchant.php:74
+msgid "Pinterest did not authorize the request. Please, reconnect your Pinterest account. Meanwhile all the scheduled tasks like feed generation and synchronization were put on hold until the access is restored."
+msgstr ""
+
+#: src/Notes/Collection/ReconnectMerchant.php:90
+msgid "Reconnect"
 msgstr ""
 
 #: src/PinterestSyncSettings.php:85

--- a/i18n/languages/pinterest-for-woocommerce.pot
+++ b/i18n/languages/pinterest-for-woocommerce.pot
@@ -1,20 +1,21 @@
-# Copyright (C) 2022 WooCommerce
+# Copyright (C) 2023 WooCommerce
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pinterest for WooCommerce 1.2.2\n"
+"Project-Id-Version: Pinterest for WooCommerce 1.3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/pinterest-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-10-11T13:35:03+00:00\n"
+"POT-Creation-Date: 2023-06-09T12:34:35+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: pinterest-for-woocommerce\n"
 
 #. Plugin Name of the plugin
+#: src/MultichannelMarketing/PinterestChannel.php:62
 msgid "Pinterest for WooCommerce"
 msgstr ""
 
@@ -23,6 +24,7 @@ msgid "https://woocommerce.com/products/pinterest-for-woocommerce/"
 msgstr ""
 
 #. Description of the plugin
+#: src/MultichannelMarketing/PinterestChannel.php:71
 msgid "Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest."
 msgstr ""
 
@@ -34,117 +36,144 @@ msgstr ""
 msgid "https://woocommerce.com"
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:143
+#: class-pinterest-for-woocommerce.php:153
 msgid "Cloning this class is forbidden."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:152
+#: class-pinterest-for-woocommerce.php:162
 msgid "Unserializing instances of this class is forbidden."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:160
+#: class-pinterest-for-woocommerce.php:170
 msgid "Only a single instance of this class is allowed. Use singleton."
 msgstr ""
 
 #. Translators: The minimum PHP version
-#: class-pinterest-for-woocommerce.php:326
+#: class-pinterest-for-woocommerce.php:355
 msgid "Pinterest for WooCommerce requires a minimum PHP version of %s."
 msgstr ""
 
 #. Translators: The minimum WP version
-#: class-pinterest-for-woocommerce.php:331
+#: class-pinterest-for-woocommerce.php:360
 msgid "Pinterest for WooCommerce requires a minimum WordPress version of %s."
 msgstr ""
 
 #. Translators: The minimum WC version
-#: class-pinterest-for-woocommerce.php:336
+#: class-pinterest-for-woocommerce.php:365
 msgid "Pinterest for WooCommerce requires a minimum WooCommerce version of %s."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:340
+#: class-pinterest-for-woocommerce.php:369
 msgid "Pinterest for WooCommerce requires WooCommerce Admin to be enabled."
 msgstr ""
 
 #. Translators: The minimum Action Scheduler version
-#: class-pinterest-for-woocommerce.php:345
+#: class-pinterest-for-woocommerce.php:374
 msgid "Pinterest for WooCommerce requires a minimum Action Scheduler package of %s. It can be caused by old version of the WooCommerce extensions."
 msgstr ""
 
 #. Translators: The error description
-#: class-pinterest-for-woocommerce.php:595
+#: class-pinterest-for-woocommerce.php:640
 msgid "Could not decrypt the Pinterest API access token. Try reconnecting to Pinterest. [%s]"
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:646
+#: class-pinterest-for-woocommerce.php:691
 msgid "Response error on disconnect merchant."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:661
+#: class-pinterest-for-woocommerce.php:706
 msgid "There was an error disconnecting the Advertiser."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:663
-#: class-pinterest-for-woocommerce.php:745
+#: class-pinterest-for-woocommerce.php:708
+#: class-pinterest-for-woocommerce.php:791
 msgid "There was an error disconnecting the Advertiser. Please try again."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:675
+#: class-pinterest-for-woocommerce.php:720
 msgid "Trying to disconnect while the merchant (id) was not found."
 msgstr ""
 
-#: class-pinterest-for-woocommerce.php:963
+#: class-pinterest-for-woocommerce.php:925
+msgid "There was an error getting the account data."
+msgstr ""
+
+#: class-pinterest-for-woocommerce.php:1173
 msgid "Pinterest for WooCommerce verification page"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:63
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:67
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:94
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:98
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:216
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:223
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:64
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:68
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:95
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:99
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:217
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:224
 #: views/attributes/variations-form.php:32
 #: assets/source/setup-guide/index.js:52
 msgid "Pinterest"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:78
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:79
 #: assets/source/components/navigation-classic/main-tab-nav.js:16
 msgid "Catalog"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:109
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:157
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:110
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:158
 msgid "Setup Pinterest"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:126
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:127
 #: assets/source/components/navigation-classic/main-tab-nav.js:26
 #: assets/source/setup-guide/index.js:82
 msgid "Connection"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:139
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:140
 #: assets/source/components/navigation-classic/main-tab-nav.js:21
 #: assets/source/setup-guide/index.js:95
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:169
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:170
 msgid "Landing page"
 msgstr ""
 
-#: includes/admin/class-pinterest-for-woocommerce-admin.php:492
+#: includes/admin/class-pinterest-for-woocommerce-admin.php:488
 msgid "Cheatin' huh?"
 msgstr ""
 
 #. translators: 1: composer command. 2: plugin directory
-#: pinterest-for-woocommerce.php:67
-#: pinterest-for-woocommerce.php:85
+#: pinterest-for-woocommerce.php:79
+#: pinterest-for-woocommerce.php:97
 msgid "Your installation of the Pinterest for WooCommerce plugin is incomplete. Please run %1$s within the %2$s directory."
+msgstr ""
+
+#: src/AdCredits.php:98
+#: src/AdCredits.php:237
+#: src/Billing.php:134
+msgid "Advertiser connected but the connection id is missing."
+msgstr ""
+
+#: src/AdCredits.php:112
+msgid "There is no available data for the requested offer code."
+msgstr ""
+
+#. translators: API error message
+#: src/AdCredits.php:200
+msgid "Could not fetch ads campaign status due to: %s"
 msgstr ""
 
 #: src/Admin/Product/Attributes/AttributesForm.php:128
 msgid "Default"
+msgstr ""
+
+#: src/Admin/Product/Attributes/AttributesTab.php:188
+msgid "Simple product"
+msgstr ""
+
+#: src/Admin/Product/Attributes/AttributesTab.php:189
+msgid "Variable product"
 msgstr ""
 
 #: src/Admin/Product/Attributes/Input/ConditionInput.php:27
@@ -163,25 +192,33 @@ msgstr ""
 msgid "Categorization of the product based on the standardized Google Product Taxonomy."
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:55
+#: src/Admin/Tasks/Onboarding.php:35
+msgid "Get your products in front of engaged shoppers with Pinterest for WooCommerce"
+msgstr ""
+
+#: src/Admin/Tasks/Onboarding.php:53
+msgid "20 minutes"
+msgstr ""
+
+#: src/API/AdvertiserConnect.php:58
 msgid "Missing advertiser or tag parameters."
 msgstr ""
 
 #. Translators: The error description as returned from the API
-#: src/API/AdvertiserConnect.php:74
+#: src/API/AdvertiserConnect.php:81
 msgid "Could not connect advertiser with Pinterest. [%s]"
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:94
+#: src/API/AdvertiserConnect.php:101
 msgid "The advertiser could not be connected to Pinterest."
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:98
+#: src/API/AdvertiserConnect.php:105
 msgid "Incorrect advertiser ID."
 msgstr ""
 
-#: src/API/AdvertiserConnect.php:131
-#: src/API/AdvertiserConnect.php:137
+#: src/API/AdvertiserConnect.php:154
+#: src/API/AdvertiserConnect.php:168
 msgid "The advertiser could not be disconnected from Pinterest."
 msgstr ""
 
@@ -191,6 +228,7 @@ msgstr ""
 
 #: src/API/Advertisers.php:59
 #: src/API/Tags.php:58
+#: src/PinterestSyncSettings.php:113
 msgid "Response error"
 msgstr ""
 
@@ -205,6 +243,10 @@ msgstr ""
 
 #: src/API/Auth.php:97
 msgid "Empty response, please try again later."
+msgstr ""
+
+#: src/API/Auth.php:113
+msgid "There was an error getting the account data. Please try again later."
 msgstr ""
 
 #. Translators: 1: Request method 2: Request endpoint 3: Response status code 4: Response message 5: Pinterest code
@@ -224,17 +266,17 @@ msgid ""
 "API response: %4$s"
 msgstr ""
 
-#: src/API/Base.php:243
+#: src/API/Base.php:289
 msgid "Reconnect to your Pinterest account"
 msgstr ""
 
-#: src/API/Base.php:298
+#: src/API/Base.php:344
 msgid "Empty body"
 msgstr ""
 
-#: src/API/Base.php:369
-#: src/API/Base.php:457
-#: src/Merchants.php:133
+#: src/API/Base.php:415
+#: src/API/Base.php:516
+#: src/Merchants.php:139
 msgid "Auto-created by Pinterest for WooCommerce"
 msgstr ""
 
@@ -243,200 +285,192 @@ msgstr ""
 msgid "Could not fetch linked business accounts for Pinterest account ID. [%s]"
 msgstr ""
 
-#: src/API/FeedIssues.php:86
+#: src/API/FeedIssues.php:88
 msgid "Error downloading feed issues file from Pinterest."
 msgstr ""
 
 #. Translators: The error description as returned from the API
-#: src/API/FeedIssues.php:112
+#: src/API/FeedIssues.php:114
 msgid "Could not get current feed's issues. [%s]"
 msgstr ""
 
-#: src/API/FeedIssues.php:130
+#: src/API/FeedIssues.php:132
 msgid "Invalid product"
 msgstr ""
 
-#: src/API/FeedIssues.php:137
+#: src/API/FeedIssues.php:139
 msgid "(Variation)"
 msgstr ""
 
-#: src/API/FeedIssues.php:286
-msgid "Could not get feed report from Pinterest."
-msgstr ""
-
-#: src/API/FeedState.php:126
-#: src/API/FeedState.php:231
+#: src/API/FeedState.php:95
+#: src/API/FeedState.php:200
 msgid "XML feed"
 msgstr ""
 
-#: src/API/FeedState.php:128
+#: src/API/FeedState.php:97
 msgid "Product sync is disabled."
 msgstr ""
 
 #. Translators: The error description as returned from the API
-#: src/API/FeedState.php:146
+#: src/API/FeedState.php:115
 msgid "Error getting feed's state. [%s]"
 msgstr ""
 
-#: src/API/FeedState.php:170
+#: src/API/FeedState.php:139
 msgid "Feed generation in progress."
 msgstr ""
 
 #. translators: 1: Time string, 2: number of products, 3: opening anchor tag, 4: closing anchor tag
-#: src/API/FeedState.php:174
+#: src/API/FeedState.php:143
 msgid "Last activity: %1$s ago - Wrote %2$s product to %3$sfeed file%4$s."
 msgid_plural "Last activity: %1$s ago - Wrote %2$s products to %3$sfeed file%4$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/API/FeedState.php:190
+#: src/API/FeedState.php:159
 msgid "Up to date"
 msgstr ""
 
 #. translators: 1: Time string, 2: total number of products, 3: opening anchor tag, 4: closing anchor tag
-#: src/API/FeedState.php:194
+#: src/API/FeedState.php:163
 msgid "Successfully generated %1$s ago - Wrote %2$s product to %3$sfeed file%4$s"
 msgid_plural "Successfully generated %1$s ago - Wrote %2$s products to %3$sfeed file%4$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/API/FeedState.php:210
+#: src/API/FeedState.php:179
 msgid "Feed generation will start shortly."
 msgstr ""
 
-#: src/API/FeedState.php:215
+#: src/API/FeedState.php:184
 msgid "Feed configuration will start shortly."
 msgstr ""
 
-#: src/API/FeedState.php:220
-#: src/API/FeedState.php:272
-#: src/Feeds.php:41
-#: src/Feeds.php:86
+#: src/API/FeedState.php:189
+#: src/API/FeedState.php:234
+#: src/Feeds.php:42
+#: src/Feeds.php:84
 msgid "Could not get feed info."
 msgstr ""
 
 #. Translators: %1$s Time string, %2$s error message
-#: src/API/FeedState.php:223
+#: src/API/FeedState.php:192
 msgid "Last activity: %1$s ago - %2$s"
 msgstr ""
 
-#: src/API/FeedState.php:260
-#: src/API/FeedState.php:309
+#: src/API/FeedState.php:226
+#: src/API/FeedState.php:270
 msgid "Product feed not yet configured on Pinterest."
 msgstr ""
 
-#: src/API/FeedState.php:266
+#: src/API/FeedState.php:230
 msgid "Could not get merchant info."
 msgstr ""
 
-#: src/API/FeedState.php:276
+#: src/API/FeedState.php:238
 msgid "Product feed not active."
 msgstr ""
 
-#: src/API/FeedState.php:284
+#: src/API/FeedState.php:242
 msgid "Product feed configured for ingestion on Pinterest"
 msgstr ""
 
 #. Translators: %1$s The URL of the product feed, %2$s Time string
-#: src/API/FeedState.php:290
+#: src/API/FeedState.php:251
 msgid "Pinterest will fetch your <a href=\"%1$s\" target=\"_blank\">product feed</a> every %2$s"
 msgstr ""
 
-#: src/API/FeedState.php:301
+#: src/API/FeedState.php:262
 msgid "Product feed pending approval on Pinterest."
 msgstr ""
 
-#: src/API/FeedState.php:305
+#: src/API/FeedState.php:266
 msgid "Product feed declined by Pinterest"
 msgstr ""
 
-#: src/API/FeedState.php:317
+#: src/API/FeedState.php:275
 msgid "Remote feed setup"
 msgstr ""
 
-#: src/API/FeedState.php:358
+#: src/API/FeedState.php:316
 msgid "Pinterest tag"
 msgstr ""
 
-#: src/API/FeedState.php:360
+#: src/API/FeedState.php:318
+#: src/API/FeedState.php:349
 msgid "Potential conflicting plugins"
 msgstr ""
 
-#: src/API/FeedState.php:382
+#: src/API/FeedState.php:347
+msgid "Pinterest Rich Pins"
+msgstr ""
+
+#: src/API/FeedState.php:371
 msgid "Feed is not registered with Pinterest."
 msgstr ""
 
-#: src/API/FeedState.php:394
-msgid "Response error when trying to get feed report from Pinterest."
-msgstr ""
-
-#: src/API/FeedState.php:398
+#: src/API/FeedState.php:380
 msgid "Response error. Feed report contains no feed workflow."
 msgstr ""
 
-#: src/API/FeedState.php:414
+#: src/API/FeedState.php:387
 msgid "Automatically pulled by Pinterest"
 msgstr ""
 
 #. Translators: %1$s Time string, %2$s number of products
-#: src/API/FeedState.php:417
-#: src/API/FeedState.php:428
+#: src/API/FeedState.php:390
+#: src/API/FeedState.php:400
 msgid "Last pulled: %1$s ago, containing %2$d products"
 msgstr ""
 
-#: src/API/FeedState.php:425
+#: src/API/FeedState.php:397
 msgid "Processing"
 msgstr ""
 
-#: src/API/FeedState.php:436
+#: src/API/FeedState.php:407
 msgid "Feed is under review."
 msgstr ""
 
-#: src/API/FeedState.php:441
+#: src/API/FeedState.php:411
 msgid "The feed is queued for processing."
 msgstr ""
 
-#: src/API/FeedState.php:447
+#: src/API/FeedState.php:415
 msgid "Feed ingestion failed."
 msgstr ""
 
 #. Translators: %1$s Time difference string
-#: src/API/FeedState.php:450
+#: src/API/FeedState.php:418
 msgid "Last attempt: %1$s ago"
 msgstr ""
 
-#: src/API/FeedState.php:460
+#: src/API/FeedState.php:429
 msgid "Unknown status in workflow."
 msgstr ""
 
 #. Translators: The status text returned by the API.
-#: src/API/FeedState.php:463
+#: src/API/FeedState.php:432
 msgid "API returned an unknown status: %1$s"
 msgstr ""
 
-#: src/API/FeedState.php:486
+#: src/API/FeedState.php:456
 msgid "Remote sync status"
 msgstr ""
 
-#. Translators: The error message as returned by the Pinterest API
-#: src/API/FeedState.php:555
-msgid "Pinterest returned: %1$s"
-msgstr ""
-
-#: src/API/HealthCheck.php:60
+#: src/API/HealthCheck.php:65
 msgid "Could not get approval status from Pinterest."
 msgstr ""
 
 #. Translators: The error description as returned from the API
-#: src/API/HealthCheck.php:74
+#: src/API/HealthCheck.php:79
 msgid "Could not fetch account status. [%s]"
 msgstr ""
 
-#: src/API/Options.php:61
+#: src/API/Options.php:62
 msgid "Missing option parameters."
 msgstr ""
 
-#: src/API/Options.php:67
+#: src/API/Options.php:68
 msgid "There was an error saving the settings."
 msgstr ""
 
@@ -453,67 +487,101 @@ msgstr ""
 msgid "No tracking tag available. [%s]"
 msgstr ""
 
+#: src/API/UserInteraction.php:92
+msgid "Unrecognized interaction parameter"
+msgstr ""
+
 #: src/Crypto.php:95
 #: src/Crypto.php:139
 msgid "Could not decrypt key value. Try reconnecting to Pinterest."
 msgstr ""
 
-#. translators: time in the format hours:minutes:seconds
-#: src/FeedGenerator.php:97
-msgid "Feed scheduled to run at %s."
-msgstr ""
-
-#: src/FeedGenerator.php:119
-msgid "Feed generation queued."
-msgstr ""
-
-#: src/FeedGenerator.php:130
-msgid "Feed generation start. Preparing temporary files."
-msgstr ""
-
-#: src/FeedGenerator.php:154
-msgid "Feed generation end. Moving files to the final destination."
-msgstr ""
-
-#: src/FeedGenerator.php:165
-msgid "Feed generated successfully."
-msgstr ""
-
-#. translators: number of products
-#: src/FeedGenerator.php:302
-msgid "Feed batch generated. Wrote %s products to the feed file."
-msgstr ""
-
 #. translators: error message with file path
-#: src/FeedGenerator.php:410
+#: src/FeedFileOperations.php:104
 msgid "Could not open temporary file %s for writing"
 msgstr ""
 
 #. translators: error message with file path
-#: src/FeedGenerator.php:420
+#: src/FeedFileOperations.php:115
 msgid "Temporary file: %s is not writeable."
 msgstr ""
 
 #. translators: 1: temporary file name 2: final file name
-#: src/FeedGenerator.php:459
+#: src/FeedFileOperations.php:137
 msgid "Could not rename %1$s to %2$s"
 msgstr ""
 
-#: src/FeedRegistration.php:95
+#. Translators: 1. Action Scheduler hook name.
+#: src/FeedGenerator.php:152
+msgid "Feed Generator `%s` Action reschedule threshold has been reached. Quit."
+msgstr ""
+
+#. Translators: Action Scheduler hook name.
+#: src/FeedGenerator.php:165
+msgid "Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it."
+msgstr ""
+
+#. Translators: 1: Action Scheduler hook name, 2: New products number to process next action run.
+#: src/FeedGenerator.php:182
+msgid "Feed Generator `%1$s` Action product batch size decreased to %2$d."
+msgstr ""
+
+#. translators: time in the format hours:minutes:seconds
+#: src/FeedGenerator.php:227
+msgid "Feed scheduled to run at %s."
+msgstr ""
+
+#: src/FeedGenerator.php:249
+msgid "Feed generation queued."
+msgstr ""
+
+#: src/FeedGenerator.php:260
+msgid "Feed generation start. Preparing temporary files."
+msgstr ""
+
+#: src/FeedGenerator.php:307
+msgid "Feed generation end. Moving files to the final destination."
+msgstr ""
+
+#: src/FeedGenerator.php:322
+msgid "Feed generated successfully."
+msgstr ""
+
+#. translators: number of products
+#: src/FeedGenerator.php:411
+msgid "Feed batch generated. Wrote %s products to the feed file."
+msgstr ""
+
+#. Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
+#: src/FeedGenerator.php:524
+msgid "Feed Generator `%1$s` Action failed to execute due to an error thrown `%2$s.`. A complete feed generation retry has been scheduled."
+msgstr ""
+
+#: src/FeedRegistration.php:96
 msgid "Could not register feed."
 msgstr ""
 
-#: src/Feeds.php:45
-#: src/Feeds.php:90
+#: src/Feeds.php:46
+#: src/Feeds.php:88
 msgid "Wrong feed info."
 msgstr ""
 
-#: src/Feeds.php:57
+#: src/Feeds.php:58
 msgid "No feed found with the requested ID."
 msgstr ""
 
-#: src/Feeds.php:102
-msgid "No feed found with the requested location."
+#: src/Feeds.php:219
+msgid "Could not get feed report from Pinterest."
+msgstr ""
+
+#. Translators: The error message as returned by the Pinterest API
+#: src/FeedStatusService.php:223
+msgid "Pinterest returned: %1$s"
+msgstr ""
+
+#. translators: %s is the locale code.
+#: src/LocaleMapper.php:105
+msgid "No matching Pinterest API locale found for %s"
 msgstr ""
 
 #: src/Merchants.php:71
@@ -525,7 +593,7 @@ msgid "There was an error trying to get the merchant object."
 msgstr ""
 
 #: src/Merchants.php:84
-#: src/Merchants.php:149
+#: src/Merchants.php:172
 msgid "Response error when trying to create a merchant or update the existing one."
 msgstr ""
 
@@ -537,19 +605,27 @@ msgstr ""
 msgid "No merchant returned in the advertiser's response."
 msgstr ""
 
+#: src/Merchants.php:155
+msgid "There was a previous error trying to create or update merchant."
+msgstr ""
+
+#: src/MultichannelMarketing/MarketingChannelRegistrar.php:34
+msgid "Marketing channel registration failed: "
+msgstr ""
+
 #: src/Notes/Collection/AbstractCompleteOnboarding.php:72
 msgid "Complete setup"
 msgstr ""
 
-#: src/Notes/Collection/CatalogSyncErrors.php:87
+#: src/Notes/Collection/CatalogSyncErrors.php:88
 msgid "Review issues affecting your connection with Pinterest"
 msgstr ""
 
-#: src/Notes/Collection/CatalogSyncErrors.php:97
+#: src/Notes/Collection/CatalogSyncErrors.php:98
 msgid "Your product sync to Pinterest was unsuccessful. To complete your connection, Review and resolve issues in the extension."
 msgstr ""
 
-#: src/Notes/Collection/CatalogSyncErrors.php:109
+#: src/Notes/Collection/CatalogSyncErrors.php:110
 msgid "Review issues"
 msgstr ""
 
@@ -581,14 +657,22 @@ msgstr ""
 msgid "Enable Sync"
 msgstr ""
 
+#: src/PinterestSyncSettings.php:85
+msgid "Missing method to sync the setting."
+msgstr ""
+
+#: src/PinterestSyncSettings.php:107
+msgid "Tracking advertiser or tag missing"
+msgstr ""
+
 #. translators: plugin version.
-#: src/PluginUpdate.php:141
+#: src/PluginUpdate.php:157
 msgid "Plugin updated to version: %s."
 msgstr ""
 
-#. translators: 1: plugin version, 2: error message.
-#: src/PluginUpdate.php:163
-msgid "Plugin update to version %1$s error: %2$s"
+#. translators: 1: plugin version, 2: failed procedure, 3: error message.
+#: src/PluginUpdate.php:180
+msgid "Plugin update to version %1$s. Procedure: %2$s. Error: %3$s"
 msgstr ""
 
 #: src/Product/Attributes/Condition.php:48
@@ -623,6 +707,11 @@ msgstr ""
 msgid "Visit the <a href=\"%1$s\">settings</a> page to enable it."
 msgstr ""
 
+#. Translators: 1: Conflicting plugins, 2: Plugins Admin page opening tag, 3: Pinterest settings opening tag, 4: Closing anchor tag
+#: src/RichPins.php:293
+msgid "The following installed plugin(s) can potentially cause problems with Rich Pins: %1$s. %2$sRemove conflicting plugins%4$s or %3$smanage Rich Pins settings%4$s."
+msgstr ""
+
 #. translators: 1: error message.
 #: src/Shipping.php:88
 msgid ""
@@ -631,17 +720,17 @@ msgid ""
 msgstr ""
 
 #. Translators: The error description
-#: src/Tracking.php:553
+#: src/Tracking.php:617
 msgid "Advertiser connected successfully"
 msgstr ""
 
 #. Translators: The error description
-#: src/Tracking.php:558
+#: src/Tracking.php:622
 msgid "Could not connect the advertiser. Try to connect from the connection tab. [%s]"
 msgstr ""
 
 #. Translators: 1: Conflicting plugins, 2: Plugins Admin page opening tag, 3: Pinterest settings opening tag, 4: Closing anchor tag
-#: src/Tracking.php:620
+#: src/Tracking.php:684
 msgid "The following installed plugin(s) can potentially cause problems with tracking: %1$s. %2$sRemove conflicting plugins%4$s or %3$smanage tracking settings%4$s."
 msgstr ""
 
@@ -655,6 +744,75 @@ msgstr ""
 
 #: views/inputs/google-category.php:36
 msgid "Search for a category…"
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:25
+msgid "You are eligible for $125 of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend $15 on Pinterest ads.</strong>"
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:39
+msgid "You are eligible for $125 of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and "
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:44
+msgid "spend $15 on Pinterest ads."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:86
+msgid "You are one step away from claiming $125 of Pinterest ad credits."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:92
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingModal.js:43
+msgid "You have successfully set up your Pinterest integration! Your product catalog is being synced and reviewed. This could take up to 2 days."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:99
+msgid "*Ad credits may take up to 24 hours to be credited to account."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:107
+msgid "Got it"
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:112
+msgid "Do this later"
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js:126
+msgid "Add billing details"
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js:38
+msgid "Advertiser already has a redeemed offer."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js:46
+msgid "The merchant already redeemed the offer on another advertiser."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js:54
+msgid "Unable to claim Pinterest ads credits as the offer has expired."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js:62
+msgid "Unable to claim Pinterest ads credits as the offer code is not available for your country."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingErrorModal.js:70
+msgid "Offer code can only be redeemed by an advertiser with a credit card billing profile."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingModal.js:37
+msgid "You have successfully set up your Pinterest integration."
+msgstr ""
+
+#: assets/source/catalog-sync/components/OnboardingModals/OnboardingModal.js:51
+msgid "View catalog"
+msgstr ""
+
+#: assets/source/catalog-sync/sections/AdCreditsNotice.js:89
+msgid "Spend $15 to get $125 in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>"
 msgstr ""
 
 #: assets/source/catalog-sync/sections/SyncIssuesTable.js:23
@@ -677,12 +835,17 @@ msgstr ""
 msgid "Issues"
 msgstr ""
 
-#: assets/source/catalog-sync/sections/SyncState.js:45
+#. translators: %s credits value with currency formatted using wc_price
+#: assets/source/catalog-sync/sections/SyncState.js:49
+msgid "You have %s of free ad credits left to use"
+msgstr ""
+
+#: assets/source/catalog-sync/sections/SyncState.js:60
 msgid "Overview"
 msgstr ""
 
-#: assets/source/catalog-sync/sections/SyncState.js:54
-msgid "Set up and manage ads to increase your reach with <adsManagerLink>Pinterest ads manager</adsManagerLink>"
+#: assets/source/catalog-sync/sections/SyncState.js:74
+msgid "Create ads to increase your reach with the <adsManagerLink>Pinterest ads manager</adsManagerLink>"
 msgstr ""
 
 #: assets/source/catalog-sync/sections/SyncStateSummary.js:13
@@ -782,166 +945,126 @@ msgstr ""
 msgid "Connect your Pinterest Account"
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:20
-msgid "Merchant is an affiliate or resale marketplace"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:24
-msgid "Merchant does not meet our policy on prohibited products"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:28
-msgid "Merchant offers services rather than products"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:32
-msgid "Merchant's domain age does not meet minimum requirement"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:36
-msgid "Merchant domain mismatched with merchant account"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:40
-msgid "Merchant's URL is broken or requires registration"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:44
-msgid "Merchant's URL is incomplete or inaccessible"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:48
-msgid "Merchant's shipping policy is unclear or unavailable"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:52
-msgid "Merchant's returns policy is unclear or unavailable"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:56
-msgid "Merchant's information is incomplete or plagiarized"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:60
-msgid "Merchant's products are out of stock"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:64
-msgid "Merchant's website includes banner or pop-up ads"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:68
-msgid "Merchant's products do not meet image quality requirements"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:72
-msgid "Merchant's product images include watermarks"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:76
-msgid "Merchant's products are always on sale"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:80
-msgid "Merchant's products refer to outdated content"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:84
-msgid "Merchant's website uses generic product descriptions"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:88
-msgid "Merchant's website displays several pop-up messages"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:92
-msgid "Merchant's product images are unavailable or mismatched"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:96
-msgid "Resale marketplaces are not allowed"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:100
-msgid "Affiliate links are not allowed"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:104
-msgid "Account does not meet the website requirements for verification"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:108
-msgid "Account does not meet the product requirements for verification"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:112
-msgid "Account does not meet the brand reputation criteria for verification"
-msgstr ""
-
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:150
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:66
 msgid "Couldn’t retrieve the health status of your account."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:169
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:85
 msgid "The feed is being configured. Depending on the number of products this may take a while as the feed needs to be fully generated before it is been sent to Pinterest for registration. You can check the status of the generation process in the Catalog tab."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:177
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:93
 msgid "Please hold on tight as your account is pending approval from Pinterest. This may take up to 5 business days."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:185
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:212
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:101
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:128
 msgid "Your merchant account is disapproved."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:189
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:105
 msgid "If you have a valid reason for appealing a merchant review decision (such as having corrected the violations that resulted in the disapproval), you can submit an appeal."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:197
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:113
 msgid "Submit an appeal"
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:216
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:132
 msgid "Please hold on tight as there is an Appeal pending for your Pinterest account."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:224
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:140
 msgid "Unable to upload catalog."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:228
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:144
 msgid "It looks like your Pinterest business account is connected to another e-commerce platform. Only one platform can be linked to a business account. To upload your catalog, disconnect your business account from the other platform and try again."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/HealthCheck/index.js:244
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:152
+msgid "Unable to register feed."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:156
+msgid "It looks like your WordPress language settings are not supported by Pinterest."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/HealthCheck/index.js:172
 msgid "Could not fetch account status."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/SaveSettingsButton.js:70
-#: assets/source/setup-guide/app/steps/SetupTracking.js:298
+#: assets/source/setup-guide/app/components/SaveSettingsButton.js:75
+#: assets/source/setup-guide/app/steps/SetupTracking.js:301
 msgid "The advertiser was connected successfully."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/SaveSettingsButton.js:80
+#: assets/source/setup-guide/app/components/SaveSettingsButton.js:93
 msgid "Your settings have been saved successfully."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/SaveSettingsButton.js:88
+#: assets/source/setup-guide/app/components/SaveSettingsButton.js:101
 #: assets/source/setup-guide/app/steps/AdvancedSettings.js:36
-#: assets/source/setup-guide/app/steps/SetupPins.js:47
+#: assets/source/setup-guide/app/steps/SetupPins.js:60
 #: assets/source/setup-guide/app/steps/SetupProductSync.js:36
-#: assets/source/setup-guide/app/steps/SetupTracking.js:234
+#: assets/source/setup-guide/app/steps/SetupTracking.js:236
 msgid "There was a problem saving your settings."
 msgstr ""
 
-#: assets/source/setup-guide/app/components/SaveSettingsButton.js:100
+#: assets/source/setup-guide/app/components/SaveSettingsButton.js:113
 msgid "Saving settings…"
 msgstr ""
 
-#: assets/source/setup-guide/app/components/SaveSettingsButton.js:101
+#: assets/source/setup-guide/app/components/SaveSettingsButton.js:114
 msgid "Save changes"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/SyncSettings/index.js:43
+msgid "Settings successfully synced with Pinterest Ads Manager."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/SyncSettings/index.js:54
+msgid "Failed to sync settings with Pinterest Ads Manager."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/SyncSettings/index.js:92
+msgid "Syncing settings"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/SyncSettings/index.js:100
+msgid "Sync to get latest settings from Pinterest Ads Manager"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/SyncSettings/index.js:107
+msgid "Sync"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:37
+msgid "Pinterest Terms & Conditions"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:47
+msgid "To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Credits may take up to 24 hours to be credited to the user."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:53
+msgid "Each user is only eligible to receive the credits once. Ad credits may vary by country and is subject to availability."
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:59
+msgid "The following terms and conditions apply:"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:65
+msgid "<link>Business Terms of Service</link>"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:83
+msgid "<link>Privacy Policy</link>"
+msgstr ""
+
+#: assets/source/setup-guide/app/components/TermsAndConditionsModal.js:101
+msgid "<link>Pinterest Advertising Services Agreement</link>"
 msgstr ""
 
 #: assets/source/setup-guide/app/components/ThirdPartyTagsNotice.js:12
@@ -954,6 +1077,174 @@ msgstr ""
 
 #: assets/source/setup-guide/app/components/UnsupportedCountryNotice/index.js:45
 msgid "Your store’s country is <country />. This country is currently not supported by Pinterest for WooCommerce. However, you can still choose to list your products in supported countries, if you are able to sell your products to customers there. <settingsLink>Change your store’s country here</settingsLink>. <supportedCountriesLink>Read more about supported countries</supportedCountriesLink>"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:39
+msgid "Merchant is an affiliate or resale marketplace"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:43
+msgid "Merchant is a resale marketplace"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:47
+msgid "Merchant is an affiliate marketplace or marketer"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:51
+msgid "Merchant is a wholesale seller"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:55
+msgid "Merchant does not meet our policy on prohibited products"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:59
+msgid "Merchant offers services rather than products"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:63
+msgid "Merchant's domain age does not meet minimum requirement"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:67
+msgid "Merchant domain mismatched with merchant account"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:71
+#: assets/source/setup-guide/app/constants.js:75
+msgid "Merchant's shipping policy is unclear or unavailable"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:79
+#: assets/source/setup-guide/app/constants.js:83
+msgid "Merchant's returns policy is unclear or unavailable"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:87
+msgid "Merchant's URL is broken or requires registration"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:91
+msgid "Merchant's domain URL is broken"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:95
+msgid "Merchant's domain requires registration to view products"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:99
+msgid "Merchant's URL is incomplete"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:103
+msgid "Merchant's domain does not meet brand information requirements"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:107
+msgid "There is no 'About Us' page or no social information in your website"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:111
+msgid "There is no contact information in your website"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:115
+msgid "Merchant's products are out of stock"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:119
+msgid "Merchant's website includes banner or pop-up ads"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:123
+#: assets/source/setup-guide/app/constants.js:127
+msgid "Merchant's products do not meet image quality requirements"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:131
+msgid "Merchant's product images include watermarks"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:135
+msgid "Merchant's products are always on sale"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:139
+msgid "Merchant's products refer to outdated content"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:143
+msgid "Merchant's website uses generic product descriptions"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:147
+msgid "Merchant's product descriptions and categories do not meet requirements"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:151
+msgid "Merchant's website displays several pop-up messages"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:155
+#: assets/source/setup-guide/app/constants.js:233
+msgid "Merchant does not meet minimum website quality requirements"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:159
+msgid "Merchant's social media links are broken"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:163
+msgid "We're unable to include you as a merchant at this time. We determined your account doesn't comply with our guidelines. Your full catalog has been removed from Pinterest."
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:167
+msgid "Merchant's product images are unavailable or mismatched"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:172
+msgid "We recently updated our <merchantGuidelinesLink>merchant guidelines</merchantGuidelinesLink> and have found that your account is currently not in compliance with our guidelines. Merchants who do not comply with our guidelines will not be able to distribute or promote product Pins from their catalog on Pinterest. If you’d like to appeal this decision, review our guidelines for more detailed information on how you can get your products on Pinterest."
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:193
+msgid "Resale marketplaces are not allowed"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:197
+msgid "Affiliate links are not allowed"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:201
+msgid "Account does not meet the website requirements for verification"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:205
+msgid "Account does not meet the product requirements for verification"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:209
+msgid "Account does not meet the brand reputation criteria for verification"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:213
+msgid "The template of the website is incomplete"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:217
+msgid "Merchant does not meet community guidelines"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:221
+msgid "Merchant has exceeded number of reported ads"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:225
+msgid "Merchant has exceeded number of user reports"
+msgstr ""
+
+#: assets/source/setup-guide/app/constants.js:229
+msgid "Merchant does not meet minimum product requirements"
 msgstr ""
 
 #: assets/source/setup-guide/app/steps/AdvancedSettings.js:49
@@ -977,145 +1268,161 @@ msgid "Erase Plugin Data"
 msgstr ""
 
 #. translators: %s: error reason returned by Pinterest when verifying website claim fail.
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:51
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:52
 msgid "<strong>We were unable to verify this domain.</strong> %s"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:134
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:135
 msgid "Couldn’t verify your domain."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:151
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:152
 msgid "Start verification"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:155
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:156
 msgid "Verifying…"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:156
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:157
 msgid "Try again"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:157
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:158
 msgid "Verified"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:175
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:188
-#: assets/source/setup-guide/app/views/WizardApp.js:77
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:176
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:189
+#: assets/source/setup-guide/app/views/WizardApp.js:78
 msgid "Claim your website"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:179
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:180
 msgid "Step Two"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:192
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:193
 msgid "Verified domain"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:212
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:214
 msgid "Verify your domain to claim your website"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:218
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:220
 msgid "This will allow access to analytics for the Pins you publish from your site, the analytics on Pins that other people create from your site, and let people know where they can find more of your content."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/ClaimWebsite.js:247
-#: assets/source/setup-guide/app/steps/SetupAccount.js:243
-#: assets/source/setup-guide/app/steps/SetupTracking.js:270
+#: assets/source/setup-guide/app/steps/ClaimWebsite.js:249
+#: assets/source/setup-guide/app/steps/SetupAccount.js:247
+#: assets/source/setup-guide/app/steps/SetupTracking.js:272
 msgid "Continue"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:94
+#: assets/source/setup-guide/app/steps/components/AdsCreditsPromo.js:57
+msgid "As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply."
+msgstr ""
+
+#: assets/source/setup-guide/app/steps/SetupAccount.js:97
 msgid "Couldn’t retrieve your linked business accounts."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:106
-#: assets/source/setup-guide/app/views/WizardApp.js:62
+#: assets/source/setup-guide/app/steps/SetupAccount.js:109
+#: assets/source/setup-guide/app/views/WizardApp.js:63
 msgid "Set up your business account"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:110
+#: assets/source/setup-guide/app/steps/SetupAccount.js:113
 msgid "Step One"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:119
+#: assets/source/setup-guide/app/steps/SetupAccount.js:122
 msgid "Pinterest business account"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:123
+#: assets/source/setup-guide/app/steps/SetupAccount.js:126
 msgid "Linked account"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:129
+#: assets/source/setup-guide/app/steps/SetupAccount.js:132
 msgid "Set up a free Pinterest business account to get access to analytics on your Pins and the ability to run ads. This requires agreeing to our <adGuidelinesLink>advertising guidelines</adGuidelinesLink> and following our <merchantGuidelinesLink>merchant guidelines</merchantGuidelinesLink>."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:204
+#: assets/source/setup-guide/app/steps/SetupAccount.js:208
 msgid "Or, create a new Pinterest account"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupAccount.js:231
+#: assets/source/setup-guide/app/steps/SetupAccount.js:235
 msgid "Or, convert your personal account"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:60
+#: assets/source/setup-guide/app/steps/SetupPins.js:73
 msgid "Publish Pins and Rich Pins"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:64
+#: assets/source/setup-guide/app/steps/SetupPins.js:77
 msgid "Rich Pins are a type of organic Pin that automatically sync information from your website to your Pins. You can identify Rich Pins by the extra information above and below the image on closeup and the bold title in your feed. If something changes on the original website, the Rich Pin updates to reflect that change."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:80
+#: assets/source/setup-guide/app/steps/SetupPins.js:93
 msgid "Tracking"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:86
+#: assets/source/setup-guide/app/steps/SetupPins.js:99
 msgid "Track conversions"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:92
+#: assets/source/setup-guide/app/steps/SetupPins.js:105
 msgid "Gather analytics for Pins you publish and Pins users create from your site."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:109
+#: assets/source/setup-guide/app/steps/SetupPins.js:122
 msgid "Enhanced Match support"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:115
-msgid "Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled."
+#: assets/source/setup-guide/app/steps/SetupPins.js:129
+msgid "Matches conversion data with the person responsible for the conversion and lets you track cross-device checkouts. Requires Track Conversion option to be enabled. <link>See more</link>"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:143
+#: assets/source/setup-guide/app/steps/SetupPins.js:176
+msgid "Automatic Enhanced Match support"
+msgstr ""
+
+#: assets/source/setup-guide/app/steps/SetupPins.js:182
+msgid "Uses hashed information that your customers have already provided to your business to help match more of your website visitors and conversions to people on Pinterest. Enabling it may improve the performance of your campaigns and can help increase the size of your Pinterest tag audiences."
+msgstr ""
+
+#: assets/source/setup-guide/app/steps/SetupPins.js:206
+msgid "Manage information shared on <linkAdsManager>Pinterest Ads Manager </linkAdsManager>"
+msgstr ""
+
+#: assets/source/setup-guide/app/steps/SetupPins.js:235
 msgid "Rich Pins"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:149
+#: assets/source/setup-guide/app/steps/SetupPins.js:241
 msgid "Add Rich Pins for Products"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:155
+#: assets/source/setup-guide/app/steps/SetupPins.js:247
 msgid "Automatically create and update rich pins on Pinterest for all synced products."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:172
+#: assets/source/setup-guide/app/steps/SetupPins.js:264
 msgid "Add Rich Pins for Posts"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:178
+#: assets/source/setup-guide/app/steps/SetupPins.js:270
 msgid "Automatically create and update rich pins on Pinterest for posts."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:198
-#: assets/source/setup-guide/app/steps/SetupPins.js:204
+#: assets/source/setup-guide/app/steps/SetupPins.js:290
+#: assets/source/setup-guide/app/steps/SetupPins.js:296
 msgid "Save to Pinterest"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupPins.js:210
+#: assets/source/setup-guide/app/steps/SetupPins.js:302
 msgid "Adds a ‘Save’ button on images allowing customers to save things straight from your website to Pinterest."
 msgstr ""
 
@@ -1131,146 +1438,154 @@ msgstr ""
 msgid "Enable Product Sync"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:127
+#: assets/source/setup-guide/app/steps/SetupTracking.js:129
 msgid "Couldn’t retrieve your advertisers."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:185
+#: assets/source/setup-guide/app/steps/SetupTracking.js:187
 msgid "Couldn’t retrieve your tags."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:271
+#: assets/source/setup-guide/app/steps/SetupTracking.js:273
 msgid "Try Again"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:272
+#: assets/source/setup-guide/app/steps/SetupTracking.js:274
 msgid "Complete Setup"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:317
+#: assets/source/setup-guide/app/steps/SetupTracking.js:320
 msgid "There was a problem connecting the advertiser."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:329
-#: assets/source/setup-guide/app/steps/SetupTracking.js:346
-#: assets/source/setup-guide/app/views/WizardApp.js:83
+#: assets/source/setup-guide/app/steps/SetupTracking.js:332
+#: assets/source/setup-guide/app/steps/SetupTracking.js:349
+#: assets/source/setup-guide/app/views/WizardApp.js:84
 msgid "Track conversions with the Pinterest tag"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:333
+#: assets/source/setup-guide/app/steps/SetupTracking.js:336
 msgid "Step Three"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:342
+#: assets/source/setup-guide/app/steps/SetupTracking.js:345
 msgid "Select your advertiser and tag"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:353
-msgid "The Pinterest tag is a piece of JavaScript code you put on your website to gather conversion insights and build audiences to target based on actions people have taken on your site."
+#: assets/source/setup-guide/app/steps/SetupTracking.js:357
+msgid "The <linkTag>Pinterest tag</linkTag> is a piece of JavaScript code you put on your website to gather conversion insights and build audiences to target based on actions people have taken on your site."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:359
-msgid "Using conversion tags means you agree to our"
+#: assets/source/setup-guide/app/steps/SetupTracking.js:381
+msgid "Using conversion tags means you agree to our <linkGuidelines>Ad Guidelines</linkGuidelines> and <linkTerms>Ad Data Terms</linkTerms>."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:373
-msgid "Ad Guidelines"
+#: assets/source/setup-guide/app/steps/SetupTracking.js:419
+msgid "<linkAem>Automatic Enhanced Match</linkAem> is enabled by default to match more of your website visitors and conversions to people on Pinterest. You can manage this in Settings."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:378
-msgid "and"
-msgstr ""
-
-#: assets/source/setup-guide/app/steps/SetupTracking.js:389
-msgid "Ad Data Terms"
-msgstr ""
-
-#: assets/source/setup-guide/app/steps/SetupTracking.js:415
+#: assets/source/setup-guide/app/steps/SetupTracking.js:456
 msgid "Advertiser"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:439
+#: assets/source/setup-guide/app/steps/SetupTracking.js:480
 msgid "Select the advertiser for which you would like to install a tracking snippet."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:452
+#: assets/source/setup-guide/app/steps/SetupTracking.js:493
 msgid "Tracking Tag"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:481
+#: assets/source/setup-guide/app/steps/SetupTracking.js:522
 msgid "Select the tracking tag to use."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:498
+#: assets/source/setup-guide/app/steps/SetupTracking.js:539
 msgid "In order to proceed you need to read and accept the contents of the Pinterest Advertising Agreement."
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:506
+#: assets/source/setup-guide/app/steps/SetupTracking.js:547
 msgid "I accept the <link>Pinterest Advertising Agreement</link>"
 msgstr ""
 
-#: assets/source/setup-guide/app/steps/SetupTracking.js:553
+#: assets/source/setup-guide/app/steps/SetupTracking.js:594
 msgid "An error occurred while attempting to fetch Advertisers & Tags from Pinterest. Please try again."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:69
+#: assets/source/setup-guide/app/views/LandingPageApp.js:75
 msgid "Get your products in front of more than 400M people on Pinterest"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:76
+#: assets/source/setup-guide/app/views/LandingPageApp.js:82
 msgid "Pinterest is a visual discovery engine people use to find inspiration for their lives! More than 400 million people have saved more than 300 billion Pins, making it easier to turn inspiration into their next purchase."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:84
+#: assets/source/setup-guide/app/views/LandingPageApp.js:90
 msgid "Get started"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:90
+#: assets/source/setup-guide/app/views/LandingPageApp.js:96
 msgid "By clicking ‘Get started’, you agree to our <a>Terms of Service</a>."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:134
+#: assets/source/setup-guide/app/views/LandingPageApp.js:176
+msgid "Try Pinterest for WooCommerce and get $125 in ad credits!"
+msgstr ""
+
+#: assets/source/setup-guide/app/views/LandingPageApp.js:183
+msgid "To help you get started with Pinterest Ads, new Pinterest customers can get $125 in ad credits when they have successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply."
+msgstr ""
+
+#: assets/source/setup-guide/app/views/LandingPageApp.js:219
 msgid "Sync your catalog"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:138
+#: assets/source/setup-guide/app/views/LandingPageApp.js:223
 msgid "Connect your store to seamlessly sync your product catalog with Pinterest and create rich pins for each item. Your pins are kept up to date with daily automatic updates."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:148
+#: assets/source/setup-guide/app/views/LandingPageApp.js:233
 msgid "Increase organic reach"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:152
+#: assets/source/setup-guide/app/views/LandingPageApp.js:237
 msgid "Pinterest users can easily discover, save and buy products from your website without any advertising spend from you. Track your performance with the Pinterest tag."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:162
+#: assets/source/setup-guide/app/views/LandingPageApp.js:247
 msgid "Create a storefront on Pinterest"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:166
+#: assets/source/setup-guide/app/views/LandingPageApp.js:251
 msgid "Syncing your catalog creates a Shop tab on your Pinterest profile which allows Pinterest users to easily discover your products."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:190
+#: assets/source/setup-guide/app/views/LandingPageApp.js:275
 msgid "Frequently asked questions"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:197
+#: assets/source/setup-guide/app/views/LandingPageApp.js:282
 msgid "Why am I getting an “Account not connected” error message?"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:201
+#: assets/source/setup-guide/app/views/LandingPageApp.js:286
 msgid "Your password might have changed recently. Click Reconnect Pinterest Account and follow the instructions on screen to restore the connection."
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:208
+#: assets/source/setup-guide/app/views/LandingPageApp.js:293
 msgid "I have more than one Pinterest Advertiser account. Can I connect my WooCommerce store to multiple Pinterest Advertiser accounts?"
 msgstr ""
 
-#: assets/source/setup-guide/app/views/LandingPageApp.js:212
+#: assets/source/setup-guide/app/views/LandingPageApp.js:297
 msgid "Only one Pinterest advertiser account can be linked to each WooCommerce store. If you want to connect a different Pinterest advertiser account you will need to either Disconnect the existing Pinterest Advertiser account from your current WooCommerce store and connect a different Pinterest Advertiser account, or Create another WooCommerce store and connect the additional Pinterest Advertiser account."
+msgstr ""
+
+#: assets/source/setup-guide/app/views/LandingPageApp.js:304
+msgid "How do I redeem the $125 ad credit from Pinterest?"
+msgstr ""
+
+#: assets/source/setup-guide/app/views/LandingPageApp.js:308
+msgid "To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once."
 msgstr ""
 
 #: assets/source/setup-guide/index.js:47
@@ -1283,16 +1598,4 @@ msgstr ""
 
 #: assets/source/setup-guide/index.js:108
 msgid "Products Catalog"
-msgstr ""
-
-#: assets/source/setup-task/index.js:19
-msgid "Setup Pinterest for WooCommerce"
-msgstr ""
-
-#: assets/source/setup-task/index.js:28
-msgid "Connect your store to Pinterest to sync products and track conversions."
-msgstr ""
-
-#: assets/source/setup-task/index.js:32
-msgid "5 minutes"
 msgstr ""

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -369,7 +369,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
 				'homeUrlToVerify'          => get_home_url(),
 				'storeCountry'             => $store_country,
-				'isAdsSupportedCountry'    => Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country(),
+				'isAdsSupportedCountry'    => ! Pinterest_For_Woocommerce::is_connected() || Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country(),
 				'isConnected'              => ! empty( Pinterest_For_Woocommerce()::is_connected() ),
 				'isBusinessConnected'      => ! empty( Pinterest_For_Woocommerce()::is_business_connected() ),
 				'businessAccounts'         => Pinterest_For_Woocommerce()::get_linked_businesses(),

--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
+use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
 use Automattic\WooCommerce\Pinterest\AdCredits;
 use Automattic\WooCommerce\Pinterest\Billing;
 use Automattic\WooCommerce\Pinterest\Utilities\Utilities;
@@ -128,6 +129,9 @@ class AdvertiserConnect extends VendorAPI {
 
 		// Reset UI state when the new advertiser is connected.
 		UserInteraction::flush_options();
+
+		// Update UnauthorizedAccessMonitor with information about token being renewed.
+		UnauthorizedAccessMonitor::unpause_as_tasks();
 
 		return array(
 			'connected'   => $response['data']->advertiser_id,

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -288,10 +288,6 @@ class Base {
 
 		$response_code = absint( wp_remote_retrieve_response_code( $response ) );
 
-		if ( 401 === $response_code ) {
-			throw new Exception( __( 'Reconnect to your Pinterest account', 'pinterest-for-woocommerce' ), 401 );
-		}
-
 		if ( ! in_array( absint( $response_code ), array( 200, 201, 204 ), true ) ) {
 
 			$message = '';

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -259,7 +259,7 @@ class AdCredits {
 
 		$remaining_discount_value = 0;
 		if ( array_key_exists( self::ADS_CREDIT_MARKETING_OFFER, $discounts ) ) {
-			// Sum all of the available coupons values.
+			// Sum of all the available coupons values.
 			foreach ( $discounts[ self::ADS_CREDIT_MARKETING_OFFER ] as $discount ) {
 				$discount_information      = (array) $discount;
 				$remaining_discount_value += ( (float) $discount_information['remaining_discount_in_micro_currency'] ) / 1000000;

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -24,7 +24,7 @@ class FeedRegistration {
 
 	use ProductFeedLogger;
 
-	const ACTION_HANDLE_FEED_REGISTRATION = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-handle-feed-registration';
+	const ACTION_HANDLE_FEED_REGISTRATION = 'pinterest-for-woocommerce-handle-feed-registration';
 
 	/**
 	 * Local Feed Configurations class.
@@ -58,8 +58,16 @@ class FeedRegistration {
 	 * @since 1.0.10
 	 */
 	public function init() {
+		// Check if Pinterest API denied access for us with 401 Unauthorized before.
+		$is_paused = UnauthorizedAccessMonitor::is_as_task_paused();
+		if ( $is_paused ) {
+			return;
+		}
+
 		add_action( self::ACTION_HANDLE_FEED_REGISTRATION, array( $this, 'handle_feed_registration' ) );
-		if ( false === as_has_scheduled_action( self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+
+		$not_scheduled = false === as_has_scheduled_action( self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( $not_scheduled ) {
 			as_schedule_recurring_action( time() + 10, 10 * MINUTE_IN_SECONDS, self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}
 	}

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -64,11 +64,11 @@ class FeedRegistration {
 			return;
 		}
 
-		add_action( self::ACTION_HANDLE_FEED_REGISTRATION, array( $this, 'handle_feed_registration' ) );
+		add_action( 'pinterest-for-woocommerce-handle-feed-registration', array( $this, 'handle_feed_registration' ) );
 
-		$not_scheduled = false === as_has_scheduled_action( self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
-		if ( $not_scheduled ) {
-			as_schedule_recurring_action( time() + 10, 10 * MINUTE_IN_SECONDS, self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		$is_scheduled = as_has_scheduled_action( 'pinterest-for-woocommerce-handle-feed-registration', array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( ! $is_scheduled ) {
+			as_schedule_recurring_action( time() + 10, 10 * MINUTE_IN_SECONDS, 'pinterest-for-woocommerce-handle-feed-registration', array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}
 	}
 
@@ -291,10 +291,13 @@ class FeedRegistration {
 	}
 
 	/**
-	 * Stop feed generator jobs.
+	 * Stop feed registration jobs and since the action might be in running state, we can not use as_unschedule_all_actions
+	 * here since it cancels only pending actions and ignores those in running state.
+	 *
+	 * @return void
 	 */
 	public static function cancel_jobs() {
-		as_unschedule_all_actions( self::ACTION_HANDLE_FEED_REGISTRATION, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-handle-feed-registration' );
 	}
 
 	/**

--- a/src/Notes/Collection/ReconnectMerchant.php
+++ b/src/Notes/Collection/ReconnectMerchant.php
@@ -64,9 +64,7 @@ class ReconnectMerchant extends AbstractNote {
 	 */
 	protected function get_note_content(): string {
 		return __(
-			'Pinterest did not authorize the request. Please, reconnect your Pinterest account.\n'
-			. 'Meanwhile all the scheduled tasks like feed generation and synchronization were put on '
-			. 'hold until the access is restored.',
+			'Pinterest did not authorize the request. Please, reconnect your Pinterest account. Meanwhile all the scheduled tasks like feed generation and synchronization were put on hold until the access is restored.',
 			'pinterest-for-woocommerce'
 		);
 	}

--- a/src/Notes/Collection/ReconnectMerchant.php
+++ b/src/Notes/Collection/ReconnectMerchant.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Pinterest\Notes\Collection;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
+use Exception;
 
 /**
  * Class ReconnectMerchant.
@@ -38,10 +39,11 @@ class ReconnectMerchant extends AbstractNote {
 	 *
 	 * @since x.x.x
 	 *
+	 * @throws Exception
 	 * @return bool
 	 */
 	public static function should_be_added(): bool {
-		return UnauthorizedAccessMonitor::is_as_task_paused();
+		return UnauthorizedAccessMonitor::is_as_task_paused() && ! self::note_exists();
 	}
 
 	/**

--- a/src/Notes/Collection/ReconnectMerchant.php
+++ b/src/Notes/Collection/ReconnectMerchant.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\WooCommerce\Pinterest\Notes\Collection;
 
-use UnauthorizedAccessMonitor;
 use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
 
 /**
  * Class ReconnectMerchant.

--- a/src/Notes/Collection/ReconnectMerchant.php
+++ b/src/Notes/Collection/ReconnectMerchant.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Pinterest\Notes\Collection;
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
 use Exception;
+use Throwable;
 
 /**
  * Class ReconnectMerchant.
@@ -39,11 +40,16 @@ class ReconnectMerchant extends AbstractNote {
 	 *
 	 * @since x.x.x
 	 *
-	 * @throws Exception
+	 * @throws Exception If note is not found.
 	 * @return bool
 	 */
 	public static function should_be_added(): bool {
-		return UnauthorizedAccessMonitor::is_as_task_paused() && ! self::note_exists();
+		$is_task_paused = UnauthorizedAccessMonitor::is_as_task_paused();
+		try {
+			return $is_task_paused && ! self::note_exists();
+		} catch ( Throwable $e ) {
+			return true;
+		}
 	}
 
 	/**

--- a/src/Notes/Collection/ReconnectMerchant.php
+++ b/src/Notes/Collection/ReconnectMerchant.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Pinterest for WooCommerce ReconnectMerchant class.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes\Collection;
+
+use UnauthorizedAccessMonitor;
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+/**
+ * Class ReconnectMerchant.
+ *
+ * Class responsible for admin reconnect account error notification after any of Pinterest API calls
+ * return 401 Unauthorized response.
+ *
+ * @since x.x.x
+ */
+class ReconnectMerchant extends AbstractNote {
+
+	const NOTE_NAME = 'pinterest-reconnect-merchant';
+
+	/**
+	 * Sets the note type.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	protected function get_type(): string {
+		return Note::E_WC_ADMIN_NOTE_ERROR;
+	}
+
+	/**
+	 * Should the note be added to the inbox.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public static function should_be_added(): bool {
+		return UnauthorizedAccessMonitor::is_as_task_paused();
+	}
+
+	/**
+	 * Get note title.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Note title.
+	 */
+	protected function get_note_title(): string {
+		return __( 'Reconnect your Pinterest account.', 'pinterest-for-woocommerce' );
+	}
+
+	/**
+	 * Get note content.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Note content.
+	 */
+	protected function get_note_content(): string {
+		return __(
+			'Pinterest did not authorize the request. Please, reconnect your Pinterest account.\n'
+			. 'Meanwhile all the scheduled tasks like feed generation and synchronization were put on '
+			. 'hold until the access is restored.',
+			'pinterest-for-woocommerce'
+		);
+	}
+
+	/**
+	 * Add button to Pinterest For WooCommerce landing page
+	 *
+	 * @since x.x.x
+	 *
+	 * @param Note $note Note to which we add an action.
+	 */
+	protected function add_action( $note ): void {
+		$note->add_action(
+			'goto-pinterest-connection',
+			__( 'Reconnect', 'pinterest-for-woocommerce' ),
+			wc_admin_url( '&path=/pinterest/connection' )
+		);
+	}
+}

--- a/src/UnauthorizedAccessMonitor.php
+++ b/src/UnauthorizedAccessMonitor.php
@@ -67,6 +67,10 @@ class UnauthorizedAccessMonitor {
 		}
 	}
 
+	public static function show_error() {
+		static::maybe_show_error();
+	}
+
 	/**
 	 * Marks that access token renewal is required and pause all corresponding Action Scheduler tasks.
 	 *
@@ -75,8 +79,12 @@ class UnauthorizedAccessMonitor {
 	public static function pause_as_tasks(): void {
 		set_transient( 'pinterest_for_woocommerce_renew_token_required', true, 2 * HOUR_IN_SECONDS );
 
+		// Cancel all Action Scheduler tasks.
 		FeedRegistration::cancel_jobs();
 		FeedGenerator::cancel_jobs();
+
+		// Show Notification.
+		self::show_error();
 	}
 
 	/**
@@ -99,5 +107,16 @@ class UnauthorizedAccessMonitor {
 	 */
 	public static function unpause_as_tasks(): bool {
 		return delete_transient( 'pinterest_for_woocommerce_renew_token_required' );
+	}
+
+	/**
+	 * Resets access token renewal status.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		static::unpause_as_tasks();
 	}
 }

--- a/src/UnauthorizedAccessMonitor.php
+++ b/src/UnauthorizedAccessMonitor.php
@@ -23,11 +23,11 @@ class UnauthorizedAccessMonitor {
 	 * If the exception is thrown by Pinterest API and the code is 401,
 	 * then it marks that access token renewal is required.
 	 *
-	 * @param Throwable $throwable
+	 * @param Throwable $throwable The exception thrown by Pinterest api call.
 	 *
 	 * @return void
 	 */
-	public static function monitor( Throwable $throwable): void {
+	public static function monitor( Throwable $throwable ): void {
 		if ( $throwable instanceof PinterestApiException && 401 === $throwable->getCode() ) {
 			self::pause_as_tasks();
 		}

--- a/src/UnauthorizedAccessMonitor.php
+++ b/src/UnauthorizedAccessMonitor.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Notes\Collection\ReconnectMerchant;
 use Throwable;
 
 /**
@@ -29,6 +30,19 @@ class UnauthorizedAccessMonitor {
 	public static function monitor( Throwable $throwable): void {
 		if ( $throwable instanceof PinterestApiException && 401 === $throwable->getCode() ) {
 			self::pause_as_tasks();
+		}
+	}
+
+	/**
+	 * Checks if access token renewal is required and shows the corresponding note.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function maybe_show_error(): void {
+		if ( self::is_as_task_paused() ) {
+			( new ReconnectMerchant() )->prepare_note()->save();
 		}
 	}
 

--- a/src/UnauthorizedAccessMonitor.php
+++ b/src/UnauthorizedAccessMonitor.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Pinterest for WooCommerce UnauthorizedAccessMonitor class.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use Throwable;
+
+/**
+ * Class UnauthorizedAccessMonitor responsible for monitoring unauthorized access to Pinterest API
+ * and perform actions accordingly.
+ *
+ * @since x.x.x
+ */
+class UnauthorizedAccessMonitor {
+
+	/**
+	 * Monitors unauthorized access to Pinterest API.
+	 * If the exception is thrown by Pinterest API and the code is 401,
+	 * then it marks that access token renewal is required.
+	 *
+	 * @param Throwable $throwable
+	 *
+	 * @return void
+	 */
+	public static function monitor( Throwable $throwable): void {
+		if ( $throwable instanceof PinterestApiException && 401 === $throwable->getCode() ) {
+			self::pause_as_tasks();
+		}
+	}
+
+	/**
+	 * Marks that access token renewal is required and pause all corresponding Action Scheduler tasks.
+	 *
+	 * @since x.x.x
+	 */
+	public static function pause_as_tasks(): void {
+		set_transient( 'pinterest_for_woocommerce_renew_token_required', true, 2 * HOUR_IN_SECONDS );
+
+		FeedGenerator::cancel_jobs();
+		FeedRegistration::cancel_jobs();
+	}
+
+	/**
+	 * Returns access token renewal status.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public static function is_as_task_paused(): bool {
+		return get_transient( 'pinterest_for_woocommerce_renew_token_required' );
+	}
+
+	/**
+	 * Removes access token renewal status.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool The result of operation.
+	 */
+	public static function unpause_as_tasks(): bool {
+		return delete_transient( 'pinterest_for_woocommerce_renew_token_required' );
+	}
+}

--- a/tests/Unit/Api/BaseTest.php
+++ b/tests/Unit/Api/BaseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Automattic\WooCommerce\Pinterest\API\Base;
+use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
+
+class BaseTest extends WP_UnitTestCase {
+
+	/**
+	 * If Pinterest API returns 401 Unauthorized response, then it should set token renewal required flag.
+	 *
+	 * @return void
+	 * @throws \Automattic\WooCommerce\Pinterest\PinterestApiException
+	 */
+	public function test_pinterest_401_unauthorized_response_sets_token_renewal_required_flag() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 401 );
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) {
+				return array(
+					'body'    => json_encode(
+						array(
+							'status'        => 'failure',
+							'code'          => 2,
+							'data'          => null,
+							'message'       => 'Authentication failed.',
+							'endpoint_name' => '{ENDPOINT_NAME}',
+							'error'         => array(
+								'message' => 'None',
+							),
+						)
+					),
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'response' => array(
+						'code'    => 401,
+						'message' => 'Unauthorized'
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$this->assertFalse( get_transient( 'pinterest_for_woocommerce_renew_token_required' ) );
+
+		Base::make_request( 'GET', '/v3/catalogs' );
+
+		$this->assertTrue( get_transient( 'pinterest_for_woocommerce_renew_token_required' ) );
+	}
+}

--- a/tests/Unit/FeedRegistrationTest.php
+++ b/tests/Unit/FeedRegistrationTest.php
@@ -10,7 +10,8 @@ use WP_UnitTestCase;
 
 class FeedRegistrationTest extends WP_UnitTestCase {
 
-	private FeedRegistration $feed_registration;
+	/** @var FeedRegistration */
+	private $feed_registration;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/Unit/FeedRegistrationTest.php
+++ b/tests/Unit/FeedRegistrationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\FeedFileOperations;
+use Automattic\WooCommerce\Pinterest\FeedRegistration;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\UnauthorizedAccessMonitor;
+use WP_UnitTestCase;
+
+class FeedRegistrationTest extends WP_UnitTestCase {
+
+	private FeedRegistration $feed_registration;
+
+	public function setUp() {
+		parent::setUp();
+		$local_feed_configs   = $this->createMock( LocalFeedConfigs::class );
+		$feed_file_operations = $this->createMock( FeedFileOperations::class );
+		$local_feed_configs
+			->method( 'get_configurations' )
+			->willReturn( array() );
+
+		$this->feed_registration = new FeedRegistration( $local_feed_configs, $feed_file_operations );
+	}
+
+	public function test_init_does_not_add_action_scheduler_action_if_action_is_on_pause() {
+		UnauthorizedAccessMonitor::pause_as_tasks();
+
+		$this->feed_registration->init();
+
+		$has_action = has_action(
+			'pinterest-for-woocommerce-handle-feed-registration',
+			array( $this->feed_registration, 'handle_feed_registration' )
+		);
+		$this->assertFalse( $has_action );
+
+		$has_action = as_has_scheduled_action( 'pinterest-for-woocommerce-handle-feed-registration' );
+		$this->assertFalse( $has_action );
+	}
+
+	public function test_init_adds_as_recurring_action() {
+		$this->feed_registration->init();
+
+		$this->assertEquals(
+			10,
+			has_action(
+				'pinterest-for-woocommerce-handle-feed-registration',
+				array( $this->feed_registration, 'handle_feed_registration' )
+			)
+		);
+
+		$has_action = as_has_scheduled_action( 'pinterest-for-woocommerce-handle-feed-registration' );
+		$this->assertTrue( $has_action );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The PR adds Pinterest API monitoring for 401 response to stop all the action scheduler tasks while user will not refresh Pinterest access token by reconnecting they account. There is also a message shown to the user asking to reconnect the account.

Closes #646 .

### Screenshots:

<img width="1286" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/3ca5f68c-140e-4019-a785-91025e826888">

### Detailed test instructions:

While there are unit tests to cover the logic added, it is also possible to manually test the PR

1. Connect to Pinterest account using standard connect procedure.
2. After successfully connected a filter into init_plugin() method to emulate 401 Pinterest API response code.
```PHP
add_filter(
	'pre_http_request',
	function ( $preempt, $r, $url ) {
		if ( false !== strpos( $url, "https://api.pinterest.com" ) ) {
			$preempt = array(
				'body'    => json_encode(
					array(
						'status'        => 'failure',
						'code'          => 2,
						'data'          => null,
						'message'       => 'Authentication failed.',
						'endpoint_name' => '{ENDPOINT_NAME}',
						'error'         => array(
							'message' => 'None',
						),
					)
				),
				'headers' => array(
					'content-type' => 'application/json',
				),
				'response' => array(
					'code'    => 401,
					'message' => 'Unauthorized'
				),
				'cookies'  => array(),
				'filename' => '',
			);
		}

		return $preempt;
	},
	10,
	3
);
```
3. It is enough to refresh the browser window after this code is added.
4. Observe error message appear on the page.
5. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
