### PR TITLE
Remove Ads Campaign from readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,10 +16,6 @@ Pinterest gives people their next great idea. Part collection, part marketplace,
 
 With the Pinterest for WooCommerce extension, you can put your products in front of Pinterest users who are already looking for ideas and things to buy. Connect your WooCommerce store to your *[Pinterest business account](https://business.pinterest.com/)* directly in the WooCommerce app. Your entire catalog will become browsable on Pinterest in just a few clicks.
 
-= Pinterest Ads =
-
-Get started with Pinterest Ads with **$125 free ad credit\*** from Pinterest when you set up Pinterest for WooCommerce and spend $15 on ads! Pinterest *[terms and conditions](https://business.pinterest.com/en-us/business-terms-of-service/)* apply.
-
 = Open-minded and undecided =
 
 People on Pinterest are eager for new ideas, which means they want to hear from you. In fact, 97% of top Pinterest searches are unbranded. Content from brands doesn’t interrupt on Pinterest—it inspires. Shopping features are built into both the organic Pinner experience, and our ad solutions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the Pinterest Ads Campaign information from wordpress.org.

### Screenshots:
Preview generated using:
<img width="548" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/f96caa01-304e-4f57-a9ef-61aa30e08d2f">


Current wordpress.org:

<img width="443" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/456c6dbd-5ac7-4f66-b648-f149e50badc3">

<!--- Optional --->


### Detailed test instructions:

No test instructions.
