### PR TITLE
Add GH workflow for release PR & checklist

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,39 @@
+name: 'Prepare New Release'
+run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+
+# **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
+# **Why we have it**: To support devs automating a few manual steps, and to leave a nice reference for consumers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
+      version:
+        description: 'Version number to be released'
+        required: true
+      type:
+        description: 'Type of the release (release|hotfix)'
+        required: true
+        default: 'release'
+      wp-version:
+        description: 'WordPress tested up to'
+      wc-version:
+        description: 'WooCommerce tested up to'
+
+
+jobs:
+  PrepareRelease:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create branch & PR
+        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          type: ${{ github.event.inputs.type }}
+          wp-version: ${{ github.event.inputs.wp-version }}
+          wc-version: ${{ github.event.inputs.wc-version }}
+          main-branch: 'trunk'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a manual [GH workflow](https://github.com/woocommerce/grow/tree/trunk/packages/github-actions/actions/prepare-extension-release) that takes versions, then starts a branch and creates a PR with the checklist.
The aim is to automate and unify the release process across Grow repos.

IMHO, it's better than P2 & wiki instructions, as it is:
1. Does not require context switching (GitHub <-> P2, Wiki <-> PR <->console)
1. More unified than wikis
2. UI input fields to provide versions, are less typo-prone than typing in CLI
1. Gives exact generated `woorelease` commands reducing the typo risk, brain + time cost
2. Gives a checklist just to follow and tick.
3. It's a step towards more automation :sunglasses: (like running `woorelease` in GHA, etc.)



### Screenshots:

![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/685aaa36-0165-4164-8346-cda3a6ba8b69)




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Unfortunately, you cannot test a manually triggered workflow, until it's merged to the default branch :( 
But this PR follows,
 https://github.com/woocommerce/automatewoo/pull/1435/ and https://github.com/woocommerce/google-listings-and-ads/pull/1982

#### Manual test
1. Create a test repo with proposed workflow merged to the main branch.
4. Go to `https://github.com/{org}/{repo}/actions/workflows/prepare-release.yml`, like https://github.com/woocommerce/automatewoo/actions/workflows/prepare-release.yml
5. Click the "Run workflow" dropdown, fill in the details, and click "Run..."
6. Wait for the workflow to finish
7. Check the created PR


### Additional details:

1. Once the PR is merged, we can update the wiki, to remove the redundant parts, and just state something like we [did in GLA](https://github.com/woocommerce/google-listings-and-ads/wiki/Release-Process#release-basics):

> 1. Go to [Actions > Prepare New Release](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/prepare-release.yml).
> 2. Open the _"Run workflow"_ dropdown, fill in the details, and click _"Run workflow"_ button.
>    ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/782fafa1-eef0-464b-ad43-8caf87d9d00f)
> 
> 
> 3. Wait for the new release PR to be created by the _github-actions[bot]_.
> 4. Follow the steps from the new PR. Some more hints and troubleshooting are provided below.




<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add release preparation GH workflow.
