### PR TITLE
Add automerge-released-trunk workflow

### DIFF
--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -1,0 +1,19 @@
+name: 'Merge the release to develop'
+run-name:  Merge the released `${{ github.head_ref }}` from `trunk` to `develop`
+
+# **What it does**: Merges trunk to develop after `release/*` is merged to `trunk`.
+# **Why we have it**: To automate the release process and follow git-flow.
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - trunk
+
+jobs:
+  automerge_trunk:
+    name: Automerge released trunk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: woocommerce/grow/automerge-released-trunk@actions-v1


### PR DESCRIPTION
_This PR is a copy of https://github.com/woocommerce/automatewoo/pull/1509_

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Add automerge-released-trunk workflow to automate merging trunk to develop after a release.

This is to remove the need for manual work like this one https://github.com/woocommerce/automatewoo/pull/1506




### Screenshots:

![image](https://github.com/woocommerce/automatewoo/assets/17435/467e7fc2-c622-4b8b-b8a5-95ea768b8c0b)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Merge this PR :see_no_evil: or fork repo with this branch merged
2. Create a release PR with `woocommerce/grow/prepare-extension-release` action
3. Merge the release PR
4. Check that release was merged from trunk to develop


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - automate merging trunk to develop after a release.
