### PR TITLE
Add `users/me/businesses` exception handling.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -1109,7 +1109,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				array_key_exists( 'is_partner', $account_data ) &&
 				! $account_data['is_partner'];
 
-			$fetched_businesses = $fetch_linked_businesses ? Pinterest\API\Base::get_linked_businesses() : array();
+			try {
+				$fetched_businesses = $fetch_linked_businesses ? Pinterest\API\Base::get_linked_businesses() : array();
+			} catch ( Exception $e ) {
+				$fetched_businesses = array();
+			}
 
 			if ( ! empty( $fetched_businesses ) && 'success' === $fetched_businesses['status'] ) {
 				$linked_businesses = $fetched_businesses['data'];

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -398,7 +398,7 @@ class Base {
 	 *
 	 * @return array
 	 *
-	 * @throws ApiException|Exception
+	 * @throws ApiException|Exception Pinterest API or PHP exceptions.
 	 */
 	public static function get_linked_businesses() {
 		return self::make_request( 'users/me/businesses', 'GET' );

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -396,7 +396,9 @@ class Base {
 	/**
 	 * Get the linked business accounts from the API.
 	 *
-	 * @return mixed
+	 * @return array
+	 *
+	 * @throws ApiException|Exception
 	 */
 	public static function get_linked_businesses() {
 		return self::make_request( 'users/me/businesses', 'GET' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adding exception handling on a API call. Since there is still a check for businesses to be empty or not we can fallback to empty array in case of API call exception instead of throwing the exception and disconnect the user because of a failure up above in the code which is making the request.

### Additional details:

When user is onboarding, after the successful token save procedure we run two Pinterest API calls to fetch user information and businesses. If any of those two calls fail with exception we disconnect the user and reset the onboarding. Instead of throwing an exception when making a call to `users/me/businesses` we could handle the exception properly and introduce a fallback to an empty array of businesses. That is what this PR is doing.

### Changelog entry

> Tweak - Add Pinterest businesses API exception handling.
