### PR TITLE
Add missing allowed countries.

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -59,8 +59,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 					'FR', // France.
 					'DE', // Germany.
 					'GR', // Greece.
+					'HK', // Hong Kong.
 					'HU', // Hungary.
 					'IE', // Ireland.
+					'IL', // Israel.
 					'IT', // Italy.
 					'JP', // Japan.
 					'LU', // Luxembourg.
@@ -72,7 +74,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 					'PL', // Poland.
 					'PT', // Portugal.
 					'RO', // Romania.
+					'SG', // Singapore.
 					'SK', // Slovakia.
+					'KR', // South Korea.
 					'ES', // Spain.
 					'SE', // Sweden.
 					'CH', // Switzerland.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As mentioned in #803 the API response has more countries then the list used as fallback. This PR adds the missing countries.

Closes #803 .


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Setup debug trap for `get_list_of_ads_supported_countries`
2. Connect the plugin, until the plugin gets connected the `get_list_of_ads_supported_countries` should use fallback
3. After the connection that function should return the list from the API
4. The lists should be the same.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Update - Add missing countries to the allowed countries list.
