### PR TITLE
Update/optimize calls to advertisers countries

### DIFF
--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\WooCommerce\Pinterest\API\Base;
-use \Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 				 * We throw an exception and use a fallback.
 				 */
 				if ( ! Pinterest_For_Woocommerce()::is_connected() ) {
-					throw new Exception( 'Pinterest user is not connected, using fallback.' );
+					throw new Exception( 'Pinterest user is not connected, using fallback list of supported countries.' );
 				}
 
 				$allowed_countries = Base::get_list_of_ads_supported_countries();

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -24,14 +24,15 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 		 * Get the alpha-2 country codes where Pinterest advertises.
 		 *
 		 * @see https://help.pinterest.com/en/business/availability/ads-availability
-		 * 
+		 *
 		 * @since x.x.x Don't fetch the list of supported countries if the user is not connected. Use a fallback instead.
+		 * 
+		 * @throws Exception If the user is not connected and the list of supported countries can't be fetched.
 		 *
 		 * @return string[]
 		 */
 		public static function get_countries() {
 			try {
-
 				/*
 				 * If the user is not connected, we can't get the list of supported countries.
 				 * We throw an exception and use a fallback.

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -6,7 +6,8 @@
  * @since 1.0.5
  */
 
-use  Automattic\WooCommerce\Pinterest\API\Base;
+use Automattic\WooCommerce\Pinterest\API\Base;
+use Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -23,11 +24,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 		 * Get the alpha-2 country codes where Pinterest advertises.
 		 *
 		 * @see https://help.pinterest.com/en/business/availability/ads-availability
+		 * 
+		 * @since x.x.x Don't fetch the list of supported countries if the user is not connected. Use a fallback instead.
 		 *
 		 * @return string[]
 		 */
 		public static function get_countries() {
 			try {
+
+				/*
+				 * If the user is not connected, we can't get the list of supported countries.
+				 * We throw an exception and use a fallback.
+				 */
+				if ( ! Pinterest_For_Woocommerce()::is_connected() ) {
+					throw new Exception( 'Pinterest user is not connected, using fallback.' );
+				}
 
 				$allowed_countries = Base::get_list_of_ads_supported_countries();
 				$get_country_code  = function( $country_object ) {
@@ -41,7 +52,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 				);
 
 				return $allowed_countries_codes;
-			} catch ( \Exception $th ) {
+			} catch ( Exception $th ) {
 				// A fallback in case of error.
 				return array(
 					'AR', // Argentina.

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Ads_Supported_Countries' ) ) :
 		 * @see https://help.pinterest.com/en/business/availability/ads-availability
 		 *
 		 * @since x.x.x Don't fetch the list of supported countries if the user is not connected. Use a fallback instead.
-		 * 
+		 *
 		 * @throws Exception If the user is not connected and the list of supported countries can't be fetched.
 		 *
 		 * @return string[]

--- a/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
+++ b/includes/class-pinterest-for-woocommerce-ads-supported-countries.php
@@ -7,7 +7,7 @@
  */
 
 use Automattic\WooCommerce\Pinterest\API\Base;
-use Exception;
+use \Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -803,6 +803,6 @@ class Base {
 	 */
 	public static function get_list_of_ads_supported_countries() {
 		$request_url = 'advertisers/countries';
-		return self::make_request( $request_url, 'GET', array(), 'ads', DAY_IN_SECONDS );
+		return self::make_request( $request_url, 'GET', array(), 'ads', 2 * DAY_IN_SECONDS );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #800 .

We have been notified that there are too many calls to the `advertisers/countries` endpoint. This PR helps to reduce the number of calls via two things:

1. Increase the time for which the response is cached from 1 to 2 days. This endpoint is basically static so we could increase the number even higher if we would be forced to.
2. Detect if we are connected and if not abort the API call - go straight to the fallback list.

### Detailed test instructions:

The plugin should not be connected.

1. Set a breakpoint at `Pinterest_For_Woocommerce_Ads_Supported_Countries::get_countries`
3. Open the Marketing -> Pinterest page.
4. Call to the `get_countries` should not trigger the API call but the fallback should be used.
5. Connect the plugin
6. After connection the call to the `get_countries` should trigger an API call ( first time )
7. Refresh the page - the next call should use the cached value.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Don't fetch the allowed countries list when not connected.
> Tweak - Increase allowed countries cache lifetime to two days.
