### PR TITLE
Fix add to cart event is not fired with add to cart Ajax button.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -100,7 +100,7 @@ class Tracking {
 			}
 
 			// AddToCart - ajax.
-			if ( 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' ) && 'yes' !== get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			if ( 'yes' !== get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				add_action( 'wp_enqueue_scripts', array( __CLASS__, 'ajax_tracking_snippet' ), 20 );
 				add_filter(
 					'woocommerce_loop_add_to_cart_args',

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Pinterest_For_Woocommerce;
+
 class TrackingTest extends \WP_UnitTestCase {
 
 	function setUp() {
@@ -10,10 +12,12 @@ class TrackingTest extends \WP_UnitTestCase {
 	}
 
 	function test_ajax_tracking_snippet_action_added() {
-		add_option( 'woocommerce_enable_ajax_add_to_cart', 'yes' );
-		add_option( 'woocommerce_cart_redirect_after_add', 'no' );
-		\Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
-		\Pinterest_For_Woocommerce::save_setting( 'tracking_tag', 'some-tag-id' );
+		// Deleting the option to make sure it does not affect tracking.
+		delete_option( 'woocommerce_enable_ajax_add_to_cart' );
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+		Pinterest_For_Woocommerce::save_setting( 'tracking_tag', 'some-tag-id' );
 
 		Tracking::maybe_init();
 
@@ -25,5 +29,19 @@ class TrackingTest extends \WP_UnitTestCase {
 			10,
 			has_filter( 'woocommerce_loop_add_to_cart_args', array( Tracking::class, 'filter_add_to_cart_attributes' ) )
 		);
+	}
+
+	function test_ajax_tracking_snippet_action_is_not_added() {
+		// Deleting the option to make sure it does not affect tracking.
+		delete_option( 'woocommerce_enable_ajax_add_to_cart' );
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+		Pinterest_For_Woocommerce::save_setting( 'tracking_tag', 'some-tag-id' );
+
+		Tracking::maybe_init();
+
+		$this->assertFalse( has_action( 'wp_enqueue_scripts', array( Tracking::class, 'ajax_tracking_snippet' ) ) );
+		$this->assertFalse( has_filter( 'woocommerce_loop_add_to_cart_args', array( Tracking::class, 'filter_add_to_cart_attributes' ) ) );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #789 .
Closes #793 .

Add to cart events aren't being tracked on themes or plugins using AJAX on the single product page when Enable AJAX add to cart buttons on archives isn't enabled in WooCommerce Add to cart behaviour in WooCommerce > Settings > Products.

Removing _Enable AJAX add to cart buttons on archives_ value check not to affect add to cart events.

### Detailed test instructions:

1. Checkout `fix/add-to-cart-event-with-ajax` branch.
2. Install Chrome Pinterest Tag Helper extension.
3. Make sure WooCommerce settings for `Redirect to the cart page after successful addition` and `Enable AJAX add to cart buttons on archives` are both set to `OFF`.

<img width="978" alt="255561257-89ad0e91-46bb-4724-b4d0-3c9db844180c" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/45801cf5-d283-4530-8b3b-09a545e2ac17">

4. Install [Ajax add to cart for WooCommerce](https://wordpress.org/plugins/woo-ajax-add-to-cart/) and Activate the plugin.
5. Open any product page and hit Add to cart button.
6. Check the request was made with AJAX.
7. Check Pinterest Tag Helper and search for Add to Cart event tracked.

<img width="1191" alt="Cursor_and_Beanie_–_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/2d6846a6-d84d-4e6b-b87b-285afb07eacb">

8. Deactivate _**Ajax add to cart for WooCommerce**_
9. Open any product page and hit Add to cart button.
10. Check the request was not AJAX and the page was reloaded.
11. Check Pinterest Tag Helper and search for Add to Cart event tracked.

<img width="1190" alt="Cursor_and_Beanie_–_WordPress-2" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/d644e0ef-716e-48ec-b2b2-073eb28cece3">

### Changelog entry

> Fix - Make add to cart events independent from WooCommerce archive page settings.
