### PR TITLE
Fix caching.

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -112,10 +112,7 @@ class Base {
 
 			$response = self::handle_request( $request );
 
-			if ( ! empty( $cache_expiry ) ) {
-				$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
-				set_transient( $cache_key, $response, $cache_expiry );
-			}
+			self::maybe_cache_api_response( $endpoint, $method, $payload, $api, $response, $cache_expiry );
 
 			return $response;
 		} catch ( ApiException $e ) {
@@ -194,6 +191,26 @@ class Base {
 	public static function get_cached_response( $endpoint, $method, $payload, $api ) {
 		$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
 		return get_transient( $cache_key );
+	}
+
+	/**
+	 * Caches the API response if cache expiry is set.
+	 * 
+	 * @since x.x.x
+	 * @param string $endpoint     The API endpoint.
+	 * @param string $method       The HTTP method.
+	 * @param array  $payload      The API request payload.
+	 * @param string $api          The API version.
+	 * @param mixed  $response     The API response.
+	 * @param int    $cache_expiry The cache expiry in seconds.
+	 * 
+	 * @return void
+	 */
+	private static function maybe_cache_api_response( $endpoint, $method, $payload, $api, $response, $cache_expiry ) {
+		if ( ! empty( $cache_expiry ) ) {
+			$cache_key = self::get_cache_key( $endpoint, $method, $payload, $api );
+			set_transient( $cache_key, $response, $cache_expiry );
+		}
 	}
 
 	/**

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -90,31 +90,32 @@ class Base {
 			}
 		}
 
+
+		$api         = empty( $api ) ? '' : trailingslashit( $api );
+		$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
+
+		$request = array(
+			'url'     => self::API_DOMAIN . "/{$api}v{$api_version}/{$endpoint}",
+			'method'  => $method,
+			'args'    => $payload,
+			'headers' => array(
+				'Pinterest-Woocommerce-Version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+			),
+		);
+
+		if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
+			// Force json content-type header and json encode payload.
+			$request['headers']['Content-Type'] = 'application/json';
+
+			$request['args'] = wp_json_encode( $payload );
+		}
+
 		try {
-			$api         = empty( $api ) ? '' : trailingslashit( $api );
-			$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
-
-			$request = array(
-				'url'     => self::API_DOMAIN . "/{$api}v{$api_version}/{$endpoint}",
-				'method'  => $method,
-				'args'    => $payload,
-				'headers' => array(
-					'Pinterest-Woocommerce-Version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
-				),
-			);
-
-			if ( 'ads/' === $api && in_array( $method, array( 'POST', 'PATCH' ), true ) ) {
-				// Force json content-type header and json encode payload.
-				$request['headers']['Content-Type'] = 'application/json';
-
-				$request['args'] = wp_json_encode( $payload );
-			}
 
 			$response = self::handle_request( $request );
-
 			self::maybe_cache_api_response( $endpoint, $method, $payload, $api, $response, $cache_expiry );
-
 			return $response;
+			
 		} catch ( ApiException $e ) {
 
 			if ( ! empty( Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' ) ) ) {

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -82,6 +82,9 @@ class Base {
 	 */
 	public static function make_request( $endpoint, $method = 'POST', $payload = array(), $api = '', $cache_expiry = false ) {
 
+		$api         = empty( $api ) ? '' : trailingslashit( $api );
+		$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
+		
 		if ( ! empty( $cache_expiry ) ) {
 			$cache = self::get_cached_response( $endpoint, $method, $payload, $api );
 
@@ -89,10 +92,6 @@ class Base {
 				return $cache;
 			}
 		}
-
-
-		$api         = empty( $api ) ? '' : trailingslashit( $api );
-		$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
 
 		$request = array(
 			'url'     => self::API_DOMAIN . "/{$api}v{$api_version}/{$endpoint}",
@@ -115,7 +114,7 @@ class Base {
 			$response = self::handle_request( $request );
 			self::maybe_cache_api_response( $endpoint, $method, $payload, $api, $response, $cache_expiry );
 			return $response;
-			
+
 		} catch ( ApiException $e ) {
 
 			if ( ! empty( Pinterest_For_WooCommerce()::get_setting( 'enable_debug_logging' ) ) ) {

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -84,7 +84,7 @@ class Base {
 
 		$api         = empty( $api ) ? '' : trailingslashit( $api );
 		$api_version = 'ads/' === $api ? self::API_ADS_VERSION : self::API_VERSION;
-		
+
 		if ( ! empty( $cache_expiry ) ) {
 			$cache = self::get_cached_response( $endpoint, $method, $payload, $api );
 
@@ -195,7 +195,7 @@ class Base {
 
 	/**
 	 * Caches the API response if cache expiry is set.
-	 * 
+	 *
 	 * @since x.x.x
 	 * @param string $endpoint     The API endpoint.
 	 * @param string $method       The HTTP method.
@@ -203,7 +203,7 @@ class Base {
 	 * @param string $api          The API version.
 	 * @param mixed  $response     The API response.
 	 * @param int    $cache_expiry The cache expiry in seconds.
-	 * 
+	 *
 	 * @return void
 	 */
 	private static function maybe_cache_api_response( $endpoint, $method, $payload, $api, $response, $cache_expiry ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #807 .

The main change implemented in this PR is moving the lines that modify the `$api` parameter above the retrieval from the cache line. This fixes the cache issue. Since the `$api` parameter is used to calculate the cache key it is crucial that the cache retrieval and cache storing procedures observe the same value of the `$api` parameter. This was not the case when cache retrieval was done before the line that potentially changes the `$api` parameter.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect the plugin
2. Set a breakpoint at the `make_request` in the `get_list_of_ads_supported_countries`
3. Open Marketing -> Pinterest
4. Step into `make_request` observe cache behaviour
5. Subsequent calls to `make_requst` via ``get_list_of_ads_supported_countries` should properly use cache.

### Additional details:

1. Cache storing code was extracted into a separate method.
2. None critical code lines have been extracted out of `try` o make the `try` more obivious.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Caching of API calls.
