### PR TITLE
Dynamically generate amount required to spend for credits to be given based on currency

### DIFF
--- a/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, external as externalIcon } from '@wordpress/icons';
 import {
@@ -18,21 +18,13 @@ import { useSettingsSelect } from '../../../setup-guide/app/helpers/effects';
 import { useBillingSetupFlowEntered } from '../../helpers/effects';
 
 const OnboardingModalText = ( { isBillingSetup } ) => {
-	const appSettings = useSettingsSelect();
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-
 	if ( ! isBillingSetup ) {
 		return (
 			<Text variant="body">
 				{ createInterpolateElement(
-					sprintf(
-						// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
-						__(
-							'You are eligible for %1$s of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend %2$s on Pinterest ads.</strong>',
-							'pinterest-for-woocommerce'
-						),
-						currencyCreditInfo.creditsGiven,
-						currencyCreditInfo.spendRequire
+					__(
+						'You are eligible for $125 of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend $15 on Pinterest ads.</strong>',
+						'pinterest-for-woocommerce'
 					),
 					{
 						strong: <strong />,
@@ -44,22 +36,14 @@ const OnboardingModalText = ( { isBillingSetup } ) => {
 
 	return (
 		<Text variant="body">
-			{ sprintf(
-				// translators: %s: Amount of ad credit given with currency.
-				__(
-					'You are eligible for %s of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
-					'pinterest-for-woocommerce'
-				),
-				currencyCreditInfo.creditsGiven
+			{ __(
+				'You are eligible for $125 of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
+				'pinterest-for-woocommerce'
 			) }
 			<strong>
-				{ sprintf(
-					// translators: %s: Amount of money required to spend to claim ad credits with currency.
-					__(
-						'spend %s on Pinterest ads.',
-						'pinterest-for-woocommerce'
-					),
-					currencyCreditInfo.spendRequire
+				{ __(
+					'spend $15 on Pinterest ads.',
+					'pinterest-for-woocommerce'
 				) }
 			</strong>
 		</Text>
@@ -77,7 +61,6 @@ const OnboardingModalText = ( { isBillingSetup } ) => {
 const OnboardingAdsModal = ( { onCloseModal } ) => {
 	const appSettings = useSettingsSelect();
 	const isBillingSetup = appSettings?.account_data?.is_billing_setup;
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
 	const billingSetupFlowEntered = useBillingSetupFlowEntered();
 
 	const onClickBilling = () => {
@@ -100,13 +83,9 @@ const OnboardingAdsModal = ( { onCloseModal } ) => {
 			className="pinterest-for-woocommerce-catalog-sync__onboarding-modal"
 		>
 			<Text variant="title.small">
-				{ sprintf(
-					// translators: %s: Amount of ad credit given with currency.
-					__(
-						'You are one step away from claiming %s of Pinterest ad credits.',
-						'pinterest-for-woocommerce'
-					),
-					currencyCreditInfo.creditsGiven
+				{ __(
+					'You are one step away from claiming $125 of Pinterest ad credits.',
+					'pinterest-for-woocommerce'
 				) }
 			</Text>
 			<Text variant="body">

--- a/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
+++ b/assets/source/catalog-sync/components/OnboardingModals/OnboardingAdsModal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, external as externalIcon } from '@wordpress/icons';
 import {
@@ -18,13 +18,21 @@ import { useSettingsSelect } from '../../../setup-guide/app/helpers/effects';
 import { useBillingSetupFlowEntered } from '../../helpers/effects';
 
 const OnboardingModalText = ( { isBillingSetup } ) => {
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	if ( ! isBillingSetup ) {
 		return (
 			<Text variant="body">
 				{ createInterpolateElement(
-					__(
-						'You are eligible for $125 of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend $15 on Pinterest ads.</strong>',
-						'pinterest-for-woocommerce'
+					sprintf(
+						// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+						__(
+							'You are eligible for %1$s of Pinterest ad credits. To claim the credits, <strong>you would need to add your billing details and spend %2$s on Pinterest ads.</strong>',
+							'pinterest-for-woocommerce'
+						),
+						currencyCreditInfo.creditsGiven,
+						currencyCreditInfo.spendRequire
 					),
 					{
 						strong: <strong />,
@@ -36,14 +44,22 @@ const OnboardingModalText = ( { isBillingSetup } ) => {
 
 	return (
 		<Text variant="body">
-			{ __(
-				'You are eligible for $125 of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
-				'pinterest-for-woocommerce'
+			{ sprintf(
+				// translators: %s: Amount of ad credit given with currency.
+				__(
+					'You are eligible for %s of Pinterest ad credits. To claim the credits, head over to the Pinterest ads manager and ',
+					'pinterest-for-woocommerce'
+				),
+				currencyCreditInfo.creditsGiven
 			) }
 			<strong>
-				{ __(
-					'spend $15 on Pinterest ads.',
-					'pinterest-for-woocommerce'
+				{ sprintf(
+					// translators: %s: Amount of money required to spend to claim ad credits with currency.
+					__(
+						'spend %s on Pinterest ads.',
+						'pinterest-for-woocommerce'
+					),
+					currencyCreditInfo.spendRequire
 				) }
 			</strong>
 		</Text>
@@ -61,6 +77,7 @@ const OnboardingModalText = ( { isBillingSetup } ) => {
 const OnboardingAdsModal = ( { onCloseModal } ) => {
 	const appSettings = useSettingsSelect();
 	const isBillingSetup = appSettings?.account_data?.is_billing_setup;
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
 	const billingSetupFlowEntered = useBillingSetupFlowEntered();
 
 	const onClickBilling = () => {
@@ -83,9 +100,13 @@ const OnboardingAdsModal = ( { onCloseModal } ) => {
 			className="pinterest-for-woocommerce-catalog-sync__onboarding-modal"
 		>
 			<Text variant="title.small">
-				{ __(
-					'You are one step away from claiming $125 of Pinterest ad credits.',
-					'pinterest-for-woocommerce'
+				{ sprintf(
+					// translators: %s: Amount of ad credit given with currency.
+					__(
+						'You are one step away from claiming %s of Pinterest ad credits.',
+						'pinterest-for-woocommerce'
+					),
+					currencyCreditInfo.creditsGiven
 				) }
 			</Text>
 			<Text variant="body">

--- a/assets/source/catalog-sync/sections/AdCreditsNotice.js
+++ b/assets/source/catalog-sync/sections/AdCreditsNotice.js
@@ -81,21 +81,27 @@ const AdCreditsNotice = () => {
 				{ isBillingSetup ? (
 					<Text>
 						{ sprintf(
-							// translators: %1$s: Currency symbol. %2$s: Amount of money required to spend to claim ad credits. %3$s: Amount of ad credits given.
+							// translators: %1$s: Amount of money required to spend to claim ad credits with currency. %2$s: Amount of ad credits given with currency.
 							__(
-								'Spend %1$s%2$s to claim %1$s%3$s in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).', 'pinterest-for-woocommerce'
-								), currencyCreditInfo.currency, currencyCreditInfo.spendRequire, currencyCreditInfo.creditsGiven
-								) }
+								'Spend %1$s to claim %2$s in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).',
+								'pinterest-for-woocommerce'
+							),
+							currencyCreditInfo.spendRequire,
+							currencyCreditInfo.creditsGiven
+						) }
 					</Text>
 				) : (
 					<Text>
 						{ createInterpolateElement(
 							sprintf(
-								// translators: %1: Currency symbol. %2$s: Amount of money required to spend to claim ad credits. %3$s: Amount of ad credits given.
+								// translators: %1$s: Amount of money required to spend to claim ad credits with currency. %2$s: Amount of ad credits given with currency.
 								__(
-									'Spend %1$s%2$s to claim %1$s%3$s in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>', 'pinterest-for-woocommerce'
-									), currencyCreditInfo.currency, currencyCreditInfo.spendRequire, currencyCreditInfo.creditsGiven
-									),
+									'Spend %1$s to claim %2$s in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>',
+									'pinterest-for-woocommerce'
+								),
+								currencyCreditInfo.spendRequire,
+								currencyCreditInfo.creditsGiven
+							),
 							{
 								adsBillingDetails: trackingAdvertiser ? (
 									<ExternalLink

--- a/assets/source/catalog-sync/sections/AdCreditsNotice.js
+++ b/assets/source/catalog-sync/sections/AdCreditsNotice.js
@@ -50,10 +50,6 @@ const AdCreditsNotice = () => {
 	const isBillingSetup = appSettings?.account_data?.is_billing_setup;
 	const trackingAdvertiser = appSettings?.tracking_advertiser;
 	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-	// console.log ( 'test Hello' );
-	// console.log ( appSettings );
-	// console.log(currencyCreditInfo);
-	// console.log(currencyCreditInfo['currency'])
 
 	const closeAdCreditsNotice = () => {
 		setIsNoticeDisplayed( false );
@@ -85,7 +81,7 @@ const AdCreditsNotice = () => {
 				{ isBillingSetup ? (
 					<Text>
 						{ __(
-							`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendReq'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditGiven'] } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
+							`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendRequire'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditsGiven'] } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
 							'pinterest-for-woocommerce'
 						) }
 					</Text>
@@ -93,7 +89,7 @@ const AdCreditsNotice = () => {
 					<Text>
 						{ createInterpolateElement(
 							__(
-								`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendReq'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditGiven'] } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
+								`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendRequire'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditsGiven'] } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
 								'pinterest-for-woocommerce'
 							),
 							{

--- a/assets/source/catalog-sync/sections/AdCreditsNotice.js
+++ b/assets/source/catalog-sync/sections/AdCreditsNotice.js
@@ -81,7 +81,7 @@ const AdCreditsNotice = () => {
 				{ isBillingSetup ? (
 					<Text>
 						{ __(
-							`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendRequire'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditsGiven'] } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
+							`Spend ${ currencyCreditInfo.currency }${ currencyCreditInfo.spendRequire } to claim ${ currencyCreditInfo.currency }${ currencyCreditInfo.creditsGiven } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
 							'pinterest-for-woocommerce'
 						) }
 					</Text>
@@ -89,7 +89,7 @@ const AdCreditsNotice = () => {
 					<Text>
 						{ createInterpolateElement(
 							__(
-								`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendRequire'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditsGiven'] } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
+								`Spend ${ currencyCreditInfo.currency }${ currencyCreditInfo.spendRequire } to claim ${ currencyCreditInfo.currency }${ currencyCreditInfo.creditsGiven } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
 								'pinterest-for-woocommerce'
 							),
 							{

--- a/assets/source/catalog-sync/sections/AdCreditsNotice.js
+++ b/assets/source/catalog-sync/sections/AdCreditsNotice.js
@@ -49,6 +49,11 @@ const AdCreditsNotice = () => {
 	const appSettings = useSettingsSelect();
 	const isBillingSetup = appSettings?.account_data?.is_billing_setup;
 	const trackingAdvertiser = appSettings?.tracking_advertiser;
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+	// console.log ( 'test Hello' );
+	// console.log ( appSettings );
+	// console.log(currencyCreditInfo);
+	// console.log(currencyCreditInfo['currency'])
 
 	const closeAdCreditsNotice = () => {
 		setIsNoticeDisplayed( false );
@@ -80,14 +85,15 @@ const AdCreditsNotice = () => {
 				{ isBillingSetup ? (
 					<Text>
 						{ __(
-							'Spend $15 to claim $125 Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).'
+							`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendReq'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditGiven'] } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
+							'pinterest-for-woocommerce'
 						) }
 					</Text>
 				) : (
 					<Text>
 						{ createInterpolateElement(
 							__(
-								'Spend $15 to get $125 in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>',
+								`Spend ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['spendReq'] } to claim ${ currencyCreditInfo['currency'] }${ currencyCreditInfo['creditGiven'] } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
 								'pinterest-for-woocommerce'
 							),
 							{

--- a/assets/source/catalog-sync/sections/AdCreditsNotice.js
+++ b/assets/source/catalog-sync/sections/AdCreditsNotice.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { recordEvent } from '@woocommerce/tracks';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	createInterpolateElement,
 	useCallback,
@@ -80,18 +80,22 @@ const AdCreditsNotice = () => {
 				/>
 				{ isBillingSetup ? (
 					<Text>
-						{ __(
-							`Spend ${ currencyCreditInfo.currency }${ currencyCreditInfo.spendRequire } to claim ${ currencyCreditInfo.currency }${ currencyCreditInfo.creditsGiven } in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).`,
-							'pinterest-for-woocommerce'
-						) }
+						{ sprintf(
+							// translators: %1$s: Currency symbol. %2$s: Amount of money required to spend to claim ad credits. %3$s: Amount of ad credits given.
+							__(
+								'Spend %1$s%2$s to claim %1$s%3$s in Pinterest ad credits. (Ad credits may take up to 24 hours to be credited to account).', 'pinterest-for-woocommerce'
+								), currencyCreditInfo.currency, currencyCreditInfo.spendRequire, currencyCreditInfo.creditsGiven
+								) }
 					</Text>
 				) : (
 					<Text>
 						{ createInterpolateElement(
-							__(
-								`Spend ${ currencyCreditInfo.currency }${ currencyCreditInfo.spendRequire } to claim ${ currencyCreditInfo.currency }${ currencyCreditInfo.creditsGiven } in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>`,
-								'pinterest-for-woocommerce'
-							),
+							sprintf(
+								// translators: %1: Currency symbol. %2$s: Amount of money required to spend to claim ad credits. %3$s: Amount of ad credits given.
+								__(
+									'Spend %1$s%2$s to claim %1$s%3$s in Pinterest ad credits. To claim the credits, <adsBillingDetails>add your billing details.</adsBillingDetails>', 'pinterest-for-woocommerce'
+									), currencyCreditInfo.currency, currencyCreditInfo.spendRequire, currencyCreditInfo.creditsGiven
+									),
 							{
 								adsBillingDetails: trackingAdvertiser ? (
 									<ExternalLink

--- a/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
+++ b/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Modal,
@@ -11,6 +11,7 @@ import {
 /**
  * Internal dependencies
  */
+import { useSettingsSelect } from '../helpers/effects';
 import documentationLinkProps from '../helpers/documentation-link-props';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
@@ -30,6 +31,9 @@ const advertisingServicesAgreementHref =
  * @return {JSX.Element} Rendered element.
  */
 const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Modal
 			title={
@@ -44,9 +48,14 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 			className="pinterest-for-woocommerce-landing-page__credits-section__tac-modal"
 		>
 			<Text>
-				{ __(
-					'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
-					'pinterest-for-woocommerce'
+			{ sprintf(
+					// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+					__(
+						'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
+						'pinterest-for-woocommerce'
+					),
+					currencyCreditInfo.creditsGiven,
+					currencyCreditInfo.spendRequire
 				) }
 			</Text>
 			<Text>

--- a/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
+++ b/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Modal,
@@ -11,6 +11,7 @@ import {
 /**
  * Internal dependencies
  */
+import { useSettingsSelect } from '../helpers/effects';
 import documentationLinkProps from '../helpers/documentation-link-props';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
@@ -30,6 +31,9 @@ const advertisingServicesAgreementHref =
  * @return {JSX.Element} Rendered element.
  */
 const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Modal
 			title={
@@ -44,9 +48,14 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 			className="pinterest-for-woocommerce-landing-page__credits-section__tac-modal"
 		>
 			<Text>
-				{ __(
-					'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
-					'pinterest-for-woocommerce'
+				{ sprintf(
+					// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+					__(
+						'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
+						'pinterest-for-woocommerce'
+					),
+					currencyCreditInfo.creditsGiven,
+					currencyCreditInfo.spendRequire
 				) }
 			</Text>
 			<Text>

--- a/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
+++ b/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
@@ -48,7 +48,7 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 			className="pinterest-for-woocommerce-landing-page__credits-section__tac-modal"
 		>
 			<Text>
-			{ sprintf(
+				{ sprintf(
 					// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
 					__(
 						'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',

--- a/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
+++ b/assets/source/setup-guide/app/components/TermsAndConditionsModal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Modal,
@@ -11,7 +11,6 @@ import {
 /**
  * Internal dependencies
  */
-import { useSettingsSelect } from '../helpers/effects';
 import documentationLinkProps from '../helpers/documentation-link-props';
 
 const tosHref = 'https://business.pinterest.com/business-terms-of-service/';
@@ -31,9 +30,6 @@ const advertisingServicesAgreementHref =
  * @return {JSX.Element} Rendered element.
  */
 const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
-	const appSettings = useSettingsSelect();
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-
 	return (
 		<Modal
 			title={
@@ -48,14 +44,9 @@ const AdsCreditsTermsAndConditionsModal = ( { onModalClose } ) => {
 			className="pinterest-for-woocommerce-landing-page__credits-section__tac-modal"
 		>
 			<Text>
-				{ sprintf(
-					// translators: %1$s: Amount of ad credit given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
-					__(
-						'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
-						'pinterest-for-woocommerce'
-					),
-					currencyCreditInfo.creditsGiven,
-					currencyCreditInfo.spendRequire
+				{ __(
+					'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Credits may take up to 24 hours to be credited to the user.',
+					'pinterest-for-woocommerce'
 				) }
 			</Text>
 			<Text>

--- a/assets/source/setup-guide/app/steps/components/AdsCreditsPromo.js
+++ b/assets/source/setup-guide/app/steps/components/AdsCreditsPromo.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useState, createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import {
 	CardDivider,
@@ -42,8 +42,6 @@ const AdsCreditsPromo = () => {
 		} );
 	};
 
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-
 	return appSettings?.ads_campaign_is_active ? (
 		<>
 			<CardDivider
@@ -56,14 +54,9 @@ const AdsCreditsPromo = () => {
 				<FlexBlock className="content-block">
 					<Text variant="body">
 						{ createInterpolateElement(
-							sprintf(
-								//  translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
-								__(
-									'As a new Pinterest customer, you can get %1$s in free ad credits when you successfully set up Pinterest for WooCommerce and spend %2$s on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
-									'pinterest-for-woocommerce'
-								),
-								currencyCreditInfo.creditsGiven,
-								currencyCreditInfo.spendRequire
+							__(
+								'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
+								'pinterest-for-woocommerce'
 							),
 							{
 								a: (

--- a/assets/source/setup-guide/app/steps/components/AdsCreditsPromo.js
+++ b/assets/source/setup-guide/app/steps/components/AdsCreditsPromo.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useState, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import {
 	CardDivider,
@@ -42,6 +42,8 @@ const AdsCreditsPromo = () => {
 		} );
 	};
 
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return appSettings?.ads_campaign_is_active ? (
 		<>
 			<CardDivider
@@ -54,9 +56,14 @@ const AdsCreditsPromo = () => {
 				<FlexBlock className="content-block">
 					<Text variant="body">
 						{ createInterpolateElement(
-							__(
-								'As a new Pinterest customer, you can get $125 in free ad credits when you successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
-								'pinterest-for-woocommerce'
+							sprintf(
+								//  translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+								__(
+									'As a new Pinterest customer, you can get %1$s in free ad credits when you successfully set up Pinterest for WooCommerce and spend %2$s on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
+									'pinterest-for-woocommerce'
+								),
+								currencyCreditInfo.creditsGiven,
+								currencyCreditInfo.spendRequire
 							),
 							{
 								a: (

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -176,7 +176,7 @@ const AdsCreditSection = () => {
 				</FlexBlock>
 				<FlexBlock className="content-block">
 					<Text variant="subtitle">
-					{ sprintf(
+						{ sprintf(
 							// translators: %s: Amount of ad credits given with currency.
 							__(
 								'Try Pinterest for WooCommerce and get %s in ad credits!',

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
 import {
 	createInterpolateElement,
@@ -159,6 +159,9 @@ const AdsCreditSection = () => {
 		} );
 	};
 
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__credits-section">
 			<Flex>
@@ -173,16 +176,25 @@ const AdsCreditSection = () => {
 				</FlexBlock>
 				<FlexBlock className="content-block">
 					<Text variant="subtitle">
-						{ __(
-							'Try Pinterest for WooCommerce and get $125 in ad credits!',
-							'pinterest-for-woocommerce'
+					{ sprintf(
+							// translators: %s: Amount of ad credits given with currency.
+							__(
+								'Try Pinterest for WooCommerce and get %s in ad credits!',
+								'pinterest-for-woocommerce'
+							),
+							currencyCreditInfo.creditsGiven
 						) }
 					</Text>
 					<Text variant="body">
 						{ createInterpolateElement(
-							__(
-								'To help you get started with Pinterest Ads, new Pinterest customers can get $125 in ad credits when they have successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
-								'pinterest-for-woocommerce'
+							sprintf(
+								// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+								__(
+									'To help you get started with Pinterest Ads, new Pinterest customers can get %1$s in ad credits when they have successfully set up Pinterest for WooCommerce and spend %2$s on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
+									'pinterest-for-woocommerce'
+								),
+								currencyCreditInfo.creditsGiven,
+								currencyCreditInfo.spendRequire
 							),
 							{
 								a: (

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
 import {
 	createInterpolateElement,
@@ -159,9 +159,6 @@ const AdsCreditSection = () => {
 		} );
 	};
 
-	const appSettings = useSettingsSelect();
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__credits-section">
 			<Flex>
@@ -176,25 +173,16 @@ const AdsCreditSection = () => {
 				</FlexBlock>
 				<FlexBlock className="content-block">
 					<Text variant="subtitle">
-						{ sprintf(
-							// translators: %s: Amount of ad credits given with currency.
-							__(
-								'Try Pinterest for WooCommerce and get %s in ad credits!',
-								'pinterest-for-woocommerce'
-							),
-							currencyCreditInfo.creditsGiven
+						{ __(
+							'Try Pinterest for WooCommerce and get $125 in ad credits!',
+							'pinterest-for-woocommerce'
 						) }
 					</Text>
 					<Text variant="body">
 						{ createInterpolateElement(
-							sprintf(
-								// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
-								__(
-									'To help you get started with Pinterest Ads, new Pinterest customers can get %1$s in ad credits when they have successfully set up Pinterest for WooCommerce and spend %2$s on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
-									'pinterest-for-woocommerce'
-								),
-								currencyCreditInfo.creditsGiven,
-								currencyCreditInfo.spendRequire
+							__(
+								'To help you get started with Pinterest Ads, new Pinterest customers can get $125 in ad credits when they have successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
+								'pinterest-for-woocommerce'
 							),
 							{
 								a: (
@@ -281,9 +269,6 @@ const Feature = ( { title, text, imageUrl } ) => {
 };
 
 const FaqSection = () => {
-	const appSettings = useSettingsSelect();
-	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
-
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__faq-section">
 			<Panel
@@ -316,22 +301,13 @@ const FaqSection = () => {
 				/>
 				<FaqQuestion
 					questionId={ 'can-i-connect-to-multiple-accounts' }
-					question={ sprintf(
-						// translators: %s: Amount of ad credits given with currency.
-						__(
-							'How do I redeem the %s ad credit from Pinterest?',
-							'pinterest-for-woocommerce'
-						),
-						currencyCreditInfo.creditsGiven
+					question={ __(
+						'How do I redeem the $125 ad credit from Pinterest?',
+						'pinterest-for-woocommerce'
 					) }
-					answer={ sprintf(
-						// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
-						__(
-							'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
-							'pinterest-for-woocommerce'
-						),
-						currencyCreditInfo.creditsGiven,
-						currencyCreditInfo.spendRequire
+					answer={ __(
+						'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
+						'pinterest-for-woocommerce'
 					) }
 				/>
 			</Panel>

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -281,6 +281,9 @@ const Feature = ( { title, text, imageUrl } ) => {
 };
 
 const FaqSection = () => {
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__faq-section">
 			<Panel
@@ -311,17 +314,28 @@ const FaqSection = () => {
 						'pinterest-for-woocommerce'
 					) }
 				/>
-				<FaqQuestion
-					questionId={ 'can-i-connect-to-multiple-accounts' }
-					question={ __(
-						'How do I redeem the $125 ad credit from Pinterest?',
-						'pinterest-for-woocommerce'
-					) }
-					answer={ __(
-						'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
-						'pinterest-for-woocommerce'
-					) }
-				/>
+				{ currencyCreditInfo && (
+					<FaqQuestion
+						questionId={ 'how-to-redeem-ad-credits' }
+						question={ sprintf(
+							// translators: %s: Amount of ad credits given with currency.
+							__(
+								'How do I redeem the %s ad credit from Pinterest?',
+								'pinterest-for-woocommerce'
+							),
+							currencyCreditInfo.creditsGiven
+						) }
+						answer={ sprintf(
+							// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+							__(
+								'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
+								'pinterest-for-woocommerce'
+							),
+							currencyCreditInfo.creditsGiven,
+							currencyCreditInfo.spendRequire
+						) }
+					/>
+				) }
 			</Panel>
 		</Card>
 	);

--- a/assets/source/setup-guide/app/views/LandingPageApp.js
+++ b/assets/source/setup-guide/app/views/LandingPageApp.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getNewPath, getHistory } from '@woocommerce/navigation';
 import {
 	createInterpolateElement,
@@ -159,6 +159,9 @@ const AdsCreditSection = () => {
 		} );
 	};
 
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__credits-section">
 			<Flex>
@@ -173,16 +176,25 @@ const AdsCreditSection = () => {
 				</FlexBlock>
 				<FlexBlock className="content-block">
 					<Text variant="subtitle">
-						{ __(
-							'Try Pinterest for WooCommerce and get $125 in ad credits!',
-							'pinterest-for-woocommerce'
+						{ sprintf(
+							// translators: %s: Amount of ad credits given with currency.
+							__(
+								'Try Pinterest for WooCommerce and get %s in ad credits!',
+								'pinterest-for-woocommerce'
+							),
+							currencyCreditInfo.creditsGiven
 						) }
 					</Text>
 					<Text variant="body">
 						{ createInterpolateElement(
-							__(
-								'To help you get started with Pinterest Ads, new Pinterest customers can get $125 in ad credits when they have successfully set up Pinterest for WooCommerce and spend $15 on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
-								'pinterest-for-woocommerce'
+							sprintf(
+								// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+								__(
+									'To help you get started with Pinterest Ads, new Pinterest customers can get %1$s in ad credits when they have successfully set up Pinterest for WooCommerce and spend %2$s on Pinterest Ads. <a>Pinterest Terms and conditions</a> apply.',
+									'pinterest-for-woocommerce'
+								),
+								currencyCreditInfo.creditsGiven,
+								currencyCreditInfo.spendRequire
 							),
 							{
 								a: (
@@ -269,6 +281,9 @@ const Feature = ( { title, text, imageUrl } ) => {
 };
 
 const FaqSection = () => {
+	const appSettings = useSettingsSelect();
+	const currencyCreditInfo = appSettings?.account_data?.currency_credit_info;
+
 	return (
 		<Card className="woocommerce-table pinterest-for-woocommerce-landing-page__faq-section">
 			<Panel
@@ -301,13 +316,22 @@ const FaqSection = () => {
 				/>
 				<FaqQuestion
 					questionId={ 'can-i-connect-to-multiple-accounts' }
-					question={ __(
-						'How do I redeem the $125 ad credit from Pinterest?',
-						'pinterest-for-woocommerce'
+					question={ sprintf(
+						// translators: %s: Amount of ad credits given with currency.
+						__(
+							'How do I redeem the %s ad credit from Pinterest?',
+							'pinterest-for-woocommerce'
+						),
+						currencyCreditInfo.creditsGiven
 					) }
-					answer={ __(
-						'To be eligible and redeem the $125 ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend $15 with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
-						'pinterest-for-woocommerce'
+					answer={ sprintf(
+						// translators: %1$s: Amount of ad credits given with currency. %2$s: Amount of money required to spend to claim ad credits with currency.
+						__(
+							'To be eligible and redeem the %1$s ad credit from Pinterest, you must complete the setup of Pinterest for WooCommerce, set up your billing with Pinterest Ads manager, and spend %2$s with Pinterest ads. Ad credits may vary by country and is subject to availability. Credits may take up to 24 hours to be credited to the user. Each user is only eligible to receive the ad credits once.',
+							'pinterest-for-woocommerce'
+						),
+						currencyCreditInfo.creditsGiven,
+						currencyCreditInfo.spendRequire
 					) }
 				/>
 			</Panel>

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -9,6 +9,7 @@
 use Automattic\WooCommerce\Pinterest as Pinterest;
 use Automattic\WooCommerce\Pinterest\AdCredits;
 use Automattic\WooCommerce\Pinterest\AdCreditsCoupons;
+use Automattic\WooCommerce\Pinterest\AdsCreditCurrency;
 use Automattic\WooCommerce\Pinterest\Billing;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\Notes\MarketingNotifications;
@@ -1017,6 +1018,20 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$account_data['coupon_redeem_info'] = $redeem_information;
 
+			self::save_setting( 'account_data', $account_data );
+		}
+
+		/**
+		 * Add currency_credit_info information to the account data option.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public static function add_currency_credits_info_to_account_data() {
+			$account_data                         = self::get_setting( 'account_data' );
+			$currency_credit_info                 = AdsCreditCurrency::get_currency_credits();
+			$account_data['currency_credit_info'] = $currency_credit_info;
 			self::save_setting( 'account_data', $account_data );
 		}
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -280,6 +280,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Verify that the ads_campaign is active or not.
 			add_action( 'admin_init', array( Pinterest\AdCredits::class, 'check_if_ads_campaign_is_active' ) );
 
+			// Append credits info to account data.
+			add_action( 'init', array( $this, 'add_currency_credits_info_to_account_data' ) );
+
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -45,10 +45,6 @@ class Options extends VendorAPI {
 	public function get_settings() {
 		Pinterest_For_Woocommerce()::maybe_check_billing_setup();
 		Pinterest_For_Woocommerce()::add_currency_credits_info_to_account_data();
-		// $myarray = array(
-		// 	PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
-		// );
-		// error_log(print_r($myarray, true));
 		return array(
 			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
 		);

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -44,7 +44,6 @@ class Options extends VendorAPI {
 	 */
 	public function get_settings() {
 		Pinterest_For_Woocommerce()::maybe_check_billing_setup();
-		Pinterest_For_Woocommerce()::add_currency_credits_info_to_account_data();
 		return array(
 			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
 		);

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -44,6 +44,11 @@ class Options extends VendorAPI {
 	 */
 	public function get_settings() {
 		Pinterest_For_Woocommerce()::maybe_check_billing_setup();
+		Pinterest_For_Woocommerce()::add_currency_credits_info_to_account_data();
+		// $myarray = array(
+		// 	PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
+		// );
+		// error_log(print_r($myarray, true));
 		return array(
 			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => Pinterest_For_Woocommerce()::get_settings( true ),
 		);

--- a/src/AdsCreditCurrency.php
+++ b/src/AdsCreditCurrency.php
@@ -55,8 +55,8 @@ class AdsCreditCurrency {
 		list( $spend_require, $credits_given ) = $credits_array;
 
 		$result = array(
-			'spendRequire' => html_entity_decode( wp_strip_all_tags( wc_price( $spend_require ) ) ),
-			'creditsGiven' => html_entity_decode( wp_strip_all_tags( wc_price( $credits_given ) ) ),
+			'spendRequire' => html_entity_decode( wp_strip_all_tags( wc_price( $spend_require, array( 'decimals' => 0 ) ) ) ),
+			'creditsGiven' => html_entity_decode( wp_strip_all_tags( wc_price( $credits_given, array( 'decimals' => 0 ) ) ) ),
 		);
 
 		return $result;

--- a/src/AdsCreditCurrency.php
+++ b/src/AdsCreditCurrency.php
@@ -51,14 +51,12 @@ class AdsCreditCurrency {
 	public static function get_currency_credits() {
 
 		$currency                              = get_woocommerce_currency();
-		$currency_symbol                       = html_entity_decode( get_woocommerce_currency_symbol() );
 		$credits_array                         = ( ! array_key_exists( $currency, self::$currency_credits_map ) || 'USD' === $currency ) ? self::$currency_credits_map['USD'] : self::$currency_credits_map[ $currency ];
 		list( $spend_require, $credits_given ) = $credits_array;
 
 		$result = array(
-			'spendRequire' => $spend_require,
-			'creditsGiven' => $credits_given,
-			'currency'     => $currency_symbol,
+			'spendRequire' => html_entity_decode( wp_strip_all_tags( wc_price( $spend_require ) ) ),
+			'creditsGiven' => html_entity_decode( wp_strip_all_tags( wc_price( $credits_given ) ) ),
 		);
 
 		return $result;

--- a/src/AdsCreditCurrency.php
+++ b/src/AdsCreditCurrency.php
@@ -56,8 +56,8 @@ class AdsCreditCurrency {
         list( $spend_require, $credits_given ) = $credits_array;
 
         $result = array(
-            'spendReq' => $spend_require,
-            'creditGiven' => $credits_given,
+            'spendRequire' => $spend_require,
+            'creditsGiven' => $credits_given,
             'currency' => $currency_symbol
         );
 

--- a/src/AdsCreditCurrency.php
+++ b/src/AdsCreditCurrency.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Pinterest for WooCommerce Ads Credit Currency
+ *
+ * @package     Pinterest_For_WooCommerce/Classes/
+ * @version     x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class handling ad credits based on currency.
+ */
+class AdsCreditCurrency {
+
+    /**
+     * @var array $currency_credits_map Mapping of currency to spend requirement and credit given.
+     */
+    public static $currency_credits_map = array(
+        "USD" => array(15, 125),
+        "EUR" => array(15, 131),
+        "GBP" => array(13, 117),
+        "BRL" => array(80, 673),
+        "CAD" => array(20, 172),
+        "AUD" => array(23, 195),
+        "MXN" => array(305, 2548),
+        "ARS" => array(2198, 18320),
+        "CHF" => array(14, 124),
+        "CZK" => array(385, 3216),
+        "DKK" => array(116, 970),
+        "HUF" => array(6366, 53050),
+        "JPY" => array(2172, 18102),
+        "NOK" => array(162, 1353),
+        "NZD" => array(26, 222),
+        "PLN" => array(74, 624),
+        "RON" => array(77, 646),
+        "SEK" => array(170, 1424)
+    );
+
+    /**
+     * Get spend requirement and credits based on currency.
+     *
+     * @since x.x.x
+     *
+     * @return array $result Amount to be spent, credits given and currency symbol.
+     */
+    public static function get_currency_credits() {
+
+        $currency = get_woocommerce_currency();
+        $currency_symbol = html_entity_decode( get_woocommerce_currency_symbol() );
+        $credits_array = ( !array_key_exists( $currency, self::$currency_credits_map ) || $currency === 'USD' ) ? self::$currency_credits_map[ 'USD' ] : self::$currency_credits_map[ $currency ];
+        list( $spend_require, $credits_given ) = $credits_array;
+
+        $result = array(
+            'spendReq' => $spend_require,
+            'creditGiven' => $credits_given,
+            'currency' => $currency_symbol
+        );
+
+        return $result;
+    }
+}

--- a/src/AdsCreditCurrency.php
+++ b/src/AdsCreditCurrency.php
@@ -9,7 +9,7 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -17,50 +17,50 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class AdsCreditCurrency {
 
-    /**
-     * @var array $currency_credits_map Mapping of currency to spend requirement and credit given.
-     */
-    public static $currency_credits_map = array(
-        "USD" => array(15, 125),
-        "EUR" => array(15, 131),
-        "GBP" => array(13, 117),
-        "BRL" => array(80, 673),
-        "CAD" => array(20, 172),
-        "AUD" => array(23, 195),
-        "MXN" => array(305, 2548),
-        "ARS" => array(2198, 18320),
-        "CHF" => array(14, 124),
-        "CZK" => array(385, 3216),
-        "DKK" => array(116, 970),
-        "HUF" => array(6366, 53050),
-        "JPY" => array(2172, 18102),
-        "NOK" => array(162, 1353),
-        "NZD" => array(26, 222),
-        "PLN" => array(74, 624),
-        "RON" => array(77, 646),
-        "SEK" => array(170, 1424)
-    );
+	/**
+	 * @var array $currency_credits_map Mapping of currency to spend requirement and credit given.
+	 */
+	public static $currency_credits_map = array(
+		'USD' => array( 15, 125 ),
+		'EUR' => array( 15, 131 ),
+		'GBP' => array( 13, 117 ),
+		'BRL' => array( 80, 673 ),
+		'CAD' => array( 20, 172 ),
+		'AUD' => array( 23, 195 ),
+		'MXN' => array( 305, 2548 ),
+		'ARS' => array( 2198, 18320 ),
+		'CHF' => array( 14, 124 ),
+		'CZK' => array( 385, 3216 ),
+		'DKK' => array( 116, 970 ),
+		'HUF' => array( 6366, 53050 ),
+		'JPY' => array( 2172, 18102 ),
+		'NOK' => array( 162, 1353 ),
+		'NZD' => array( 26, 222 ),
+		'PLN' => array( 74, 624 ),
+		'RON' => array( 77, 646 ),
+		'SEK' => array( 170, 1424 ),
+	);
 
-    /**
-     * Get spend requirement and credits based on currency.
-     *
-     * @since x.x.x
-     *
-     * @return array $result Amount to be spent, credits given and currency symbol.
-     */
-    public static function get_currency_credits() {
+	/**
+	 * Get spend requirement and credits based on currency.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array $result Amount to be spent, credits given and currency symbol.
+	 */
+	public static function get_currency_credits() {
 
-        $currency = get_woocommerce_currency();
-        $currency_symbol = html_entity_decode( get_woocommerce_currency_symbol() );
-        $credits_array = ( !array_key_exists( $currency, self::$currency_credits_map ) || $currency === 'USD' ) ? self::$currency_credits_map[ 'USD' ] : self::$currency_credits_map[ $currency ];
-        list( $spend_require, $credits_given ) = $credits_array;
+		$currency                              = get_woocommerce_currency();
+		$currency_symbol                       = html_entity_decode( get_woocommerce_currency_symbol() );
+		$credits_array                         = ( ! array_key_exists( $currency, self::$currency_credits_map ) || 'USD' === $currency ) ? self::$currency_credits_map['USD'] : self::$currency_credits_map[ $currency ];
+		list( $spend_require, $credits_given ) = $credits_array;
 
-        $result = array(
-            'spendRequire' => $spend_require,
-            'creditsGiven' => $credits_given,
-            'currency' => $currency_symbol
-        );
+		$result = array(
+			'spendRequire' => $spend_require,
+			'creditsGiven' => $credits_given,
+			'currency'     => $currency_symbol,
+		);
 
-        return $result;
-    }
+		return $result;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We display a static message in the ads credits notice (at multiple locations) that states a merchant can get $125 credits on spending $15. We want to dynamically change the credits based on the merchant's store currency and display a custom notice. 

This PR changes the credit values in the Ads credits notice based on store currency. Merchants will see credits in their respective currency if it belongs to EUR, GBP, BRL, CAD, AUD, MXN, ARS, CHF, CZK, DKK, HUF, JPY, NOK, NZD, PLN, RON, or SEK. For all other currencies, including USD, they will see notice in USD credits.

`get_currency_credits()` function returns spend requirement and credits given values based on store currency. `add_currency_credits_info_to_account_data()` function appends the credits info to account data we get from Pinterest. We are able to fetch the values from `account_data` and display them in the notice.

The credits question in FAQ had the same `questionId` as the previous one (multiple accounts question) so this PR changes it to a relevant value `'how-to-redeem-ad-credits'`. 

Partially fixes #801.

### Screenshots:

| Before | After |
|--------|--------|
| <img width="1033" alt="Screenshot 2023-08-18 at 9 00 01 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/21baf646-1809-43c4-a5c7-e8e99f9407ba"> | <img width="1037" alt="Screenshot 2023-08-21 at 9 28 15 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/04af7553-be7e-45fc-bdb3-ce9d04fe4d4b"> |
| <img width="368" alt="AdsCreditsPromo" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/6df30d55-adba-4af5-8755-2fb4c5b72c76"> | <img width="473" alt="Screenshot 2023-08-21 at 9 23 06 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/7606f738-3ae0-4aaa-ae56-444e69ae3c7c"> |
| <img width="492" alt="Screenshot 2023-08-18 at 8 59 08 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/59123813-b2dd-4618-a81f-8f7fdc3f8b8f"> | <img width="511" alt="Screenshot 2023-08-21 at 9 28 08 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/175ee132-bfb2-46a3-aaff-ad2db90c7ff5"> |
| <img width="849" alt="Screenshot 2023-08-21 at 5 04 52 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/add55b78-aa12-4071-b857-5a194668fd7b"> | <img width="840" alt="Screenshot 2023-08-21 at 9 21 39 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/4f5364e8-ce38-4f17-b71c-c0a5619ced09"> |
| <img width="688" alt="Screenshot 2023-08-21 at 5 04 58 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/6d934f73-91e4-4c77-8624-502de1bae125"> | <img width="725" alt="Screenshot 2023-08-21 at 9 22 46 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/37e9f195-423b-4b4c-8dee-6bbe8c165383"> | 
| <img width="1098" alt="Screenshot 2023-08-21 at 5 05 06 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/a927cfc3-b765-4670-8bb7-71e17b5d062d"> | <img width="981" alt="Screenshot 2023-08-21 at 9 23 14 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/c694bccf-4beb-4417-8255-afddcb3f6842"> |
| <img width="833" alt="Screenshot 2023-08-21 at 9 22 19 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/4eaca002-c572-422c-9fde-ef40fbd0e423"> | <img width="825" alt="Screenshot 2023-08-21 at 9 22 38 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/33723519/e55a2e1a-ddb6-4e40-8f41-d5b23ae06cc8"> | 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Clone the repo and checkout this branch 
2. Activate the plugin
3. Set currency to Euros at WooCommerce > Settings > Currency Options > Currency
4. Go to Marketing > Pinterest
5. Verify you see all credits in euros in "Try Pinterest for WooCommerce and get €131 in ad credits!" notice
6. Click on Pinterest Terms and Conditions link under it and verify credits are in euros
7. Scroll down to FAQ section
8. Verify credits are in euros in both question and answer
9. Click on Get Started
10. On the onboarding page, verify the ads credits promo shows credits in euros
11. Click on Pinterest Terms and Conditions link under it and verify credits are in euros
12. Complete the onboarding process and connect your business account
13. Go to Marketing > Pinterest > Catalog
14. Verify credit values are in euros in the onboarding pop up modal
15. Close the modal and verify you see credits in euros on Ads credits notice
16. Repeat steps 4 to 15 with different currencies like USD, GBP, CZK, MXN


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Adds logic to dynamically display spend requirement and credits given based on store currency.
