### PR TITLE
Release 1.3.10 - merge trunk to develop

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.3.10 - 2023-09-12 =
+* Dev - Updates PHPUnit version, unit tests, and matrix in git workflow for PHP8.2 compatibility.
+
 = 1.3.9 - 2023-09-05 =
 * Add - Adds logic to dynamically display spend requirement and credits given based on store currency.
 * Fix -  Uninstall procedure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.3.9
+ * Version:           1.3.10
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.9' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.10' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 6.3
 Requires PHP: 7.3
-Stable tag: 1.3.9
+Stable tag: 1.3.10
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps:
 
 == Changelog ==
 
+= 1.3.10 - 2023-09-12 =
+* Dev - Updates PHPUnit version, unit tests, and matrix in git workflow for PHP8.2 compatibility.
+
 = 1.3.9 - 2023-09-05 =
 * Add - Adds logic to dynamically display spend requirement and credits given based on store currency.
 * Fix -  Uninstall procedure.


### PR DESCRIPTION
We have released https://github.com/woocommerce/pinterest-for-woocommerce/releases/1.3.10, and merged the release branch into the trunk branch in PR https://github.com/woocommerce/pinterest-for-woocommerce/pull/820. 

In this PR, we merge the trunk branch into develop branch.
 