### PR TITLE
First implementation.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -907,15 +907,20 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$external_business_id = self::generate_external_business_id();
 			$connection_data      = self::get_data( 'connection_info_data', true );
 
+			$integration_data     = array(
+				'external_business_id'    => $external_business_id,
+				'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
+				'connected_advertiser_id' => $connection_data['advertiser_id'] ?? '',
+			);
+
+			if ( ! empty( $connection_data['tag_id'] ) ) {
+				$integration_data['connected_tag_id'] = $connection_data['tag_id'];
+			}
+
 			$response = Pinterest\API\APIV5::make_request(
 				'integrations/commerce',
 				'POST',
-				array(
-					'external_business_id'    => $external_business_id,
-					'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
-					'connected_advertiser_id' => $connection_data['advertiser_id'] ?? '',
-					'connected_tag_id'        => $connection_data['tag_id'] ?? '',
-				)
+				$integration_data
 			);
 
 			/*

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -113,6 +113,12 @@ class Auth extends VendorAPI {
 		$info_string = base64_decode( $info );
 		$info_data   = (array) json_decode( urldecode( $info_string ) );
 
+		$features    = (array) $info_data['feature_flags'] ?? array();
+
+		$this->apply_oauth_flow_features( $features );
+
+		unset( $info_data['feture_flags'] );
+
 		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
 
 		try {
@@ -125,6 +131,16 @@ class Auth extends VendorAPI {
 
 		wp_safe_redirect( $this->get_redirect_url( $request->get_param( 'view' ) ) );
 		exit;
+	}
+
+	/**
+	 * Applies the features from the OAuth flow to the plugin settings.
+	 *
+	 * @param array $features The features selected by the merchant during the OAuth flow.
+	 */
+	private function apply_oauth_flow_features( $features ) {
+		Pinterest_For_Woocommerce()::save_setting( 'track_conversions', $features['tags'] ?? false );
+		Pinterest_For_Woocommerce()::save_setting( 'product_sync_enabled', $features['catalog'] ?? false );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Use v2 of the Pinterest APIv5 connection popup.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install the plugin.
2. Connect
3. The connection should be working

After this changes the plugin reacts to selections made in the popup. If the merchant does not selects the catalog the sync will be disabled. If the merchant does not select the CAPI/Tag tracking the tracking setting will be disabled and the tag id will not be stored. This scenarios should be tested. 
