### PR TITLE
Update docs domain name to Woo.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=412041). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted on [Woo.com](https://woo.com/es-es/feature-requests/pinterest-for-woocommerce/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted on [Woo.com](https://woo.com/es-es/feature-requests/pinterest-for-woocommerce/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted on [Woo.com](https://woo.com/feature-requests/pinterest-for-woocommerce/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A native integration which allows you to market your store on Pinterest, includi
 
 ## Status - _in development_
 
-Pinterest for WooCommerce is under development. To find out more about availability and release, refer to WooCommerce.com.
+Pinterest for WooCommerce is under development. To find out more about availability and release, refer to Woo.com.
 
 ## Support
 
@@ -125,7 +125,7 @@ The tests will execute and you'll be presented with a summary.
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>
 

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -1,6 +1,6 @@
 # Usage Tracking
 
-_Pinterest for WooCommerce_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woocommerce.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
+_Pinterest for WooCommerce_ implements usage tracking, based on the native [WooCommerce Usage Tracking](https://woo.com/usage-tracking/), and is only enabled when WooCommerce Tracking is enabled.
 
 When a store opts in to WooCommerce usage tracking and uses _Pinterest for WooCommerce_, they will also be opted in to the tracking added by _Pinterest for WooCommerce_.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/pinterest-for-woocommerce",
 	"description": "",
-	"homepage": "https://woocommerce.com/",
+	"homepage": "https://woo.com/",
 	"type": "wordpress-plugin",
 	"keywords": [
 		"pinterest",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -5,17 +5,17 @@
  * registers the activation and deactivation functions, and defines a function
  * that starts the plugin.
  *
- * @link              https://woocommerce.com
+ * @link              https://woo.com
  * @since             1.0.0
  * @package           woocommerce/pinterest-for-woocommerce
  *
  * @wordpress-plugin
  * Plugin Name:       Pinterest for WooCommerce
- * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
+ * Plugin URI:        https://woo.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
  * Version:           1.3.12
  * Author:            WooCommerce
- * Author URI:        https://woocommerce.com
+ * Author URI:        https://woo.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       pinterest-for-woocommerce

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Pinterest is a visual discovery engine people use to find inspiration for their 
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 
-Visit the [WooCommerce server requirements documentation](https://docs.woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
+Visit the [WooCommerce server requirements documentation](https://woo.com/document/server-requirements/) for a detailed list of server requirements.
 
 = Automatic installation =
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -181,7 +181,7 @@ class AdCredits {
 	}
 
 	/**
-	 * Check if campaign is enabled in the recommendations API from woocommerce.com.
+	 * Check if campaign is enabled in the recommendations API from woo.com.
 	 *
 	 * @since 1.2.5
 	 *
@@ -190,7 +190,7 @@ class AdCredits {
 	 * @return bool Wether the campaign is active or not.
 	 */
 	private static function get_is_campaign_active_from_recommendations() {
-		$request         = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
+		$request         = wp_remote_get( 'https://woo.com/wp-json/wccom/marketing-tab/1.2/recommendations.json' );
 		$recommendations = array();
 
 		if ( is_wp_error( $request ) ) {

--- a/src/MultichannelMarketing/PinterestChannel.php
+++ b/src/MultichannelMarketing/PinterestChannel.php
@@ -77,7 +77,7 @@ class PinterestChannel implements MarketingChannelInterface {
 	 * @return string
 	 */
 	public function get_icon_url(): string {
-		return 'https://woocommerce.com/wp-content/plugins/wccom-plugins/marketing-tab-rest-api/icons/pinterest.svg';
+		return 'https://woo.com/wp-content/plugins/wccom-plugins/marketing-tab-rest-api/icons/pinterest.svg';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the old WooCommerce.com → the new Woo.com in several places, especially for documentation links (pcShBQ-1cw-p2).

Also updates some text and URLs regarding support requests, and in woo.com API request URLs.

Also changes the `homepage` in `package.json`, shouldn't be an issue should it?

Doesn't change `developer.woocommerce.com` or `connect.woocommerce.com` URLs.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. No real code changes.
2. Double check all new URLs actually go to a page (connect.woocommerce.com and developer.woocommerce.com don't seem to be redirecting, for example, so they weren't changed).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Doc - Use new Woo.com domain.
