### PR TITLE
Add token exchange update procedure.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -202,6 +202,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			define( 'PINTEREST_FOR_WOOCOMMERCE_API_AUTH_ENDPOINT', 'oauth/callback' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_AUTH', PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_auth_key' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX', 'pfw' );
+			define( 'PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION', PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_pinterest_api_vertsion' );
 		}
 
 
@@ -568,6 +569,18 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			return update_option( $option, $settings );
 		}
 
+		/**
+		 * Set API version used by the plugin.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $version The API version.
+		 *
+		 * @return boolean
+		 */
+		public static function set_api_version( $version ) {
+			return update_option( PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION, $version );
+		}
 
 		/**
 		 * Return APP Data based on its key

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -202,7 +202,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			define( 'PINTEREST_FOR_WOOCOMMERCE_API_AUTH_ENDPOINT', 'oauth/callback' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_AUTH', PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_auth_key' );
 			define( 'PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX', 'pfw' );
-			define( 'PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION', PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_pinterest_api_vertsion' );
+			define( 'PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION', PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_pinterest_api_version' );
 		}
 
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -688,6 +688,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$token['access_token']  = empty( $token['access_token'] ) ? '' : Pinterest\Crypto::encrypt( $token['access_token'] );
 			$token['refresh_token'] = empty( $token['refresh_token'] ) ? '' : Pinterest\Crypto::encrypt( $token['refresh_token'] );
+			$token['scopes']        = empty( $token['scopes'] ) ? '' : $token['scopes'];
 			$token['refresh_date']  = time();
 			return self::save_data( 'token_data', $token );
 		}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"woocommerce/woocommerce-sniffs": "^0.1.0",
 		"wp-coding-standards/wpcs": "^2.3",
 		"phpunit/phpunit": "^7.5",
-		"yoast/phpunit-polyfills": "^1.0",
+		"yoast/phpunit-polyfills": "^1.1.0",
 		"wp-cli/i18n-command": "^2.3"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4fc2c1c588f3e9c77af8f761962a4ea",
+    "content-hash": "0827d35f6cb22ba3c90936a436bdcc01",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -3288,16 +3288,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -3305,13 +3305,12 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -3345,7 +3344,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -3354,11 +3353,12 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=7.3",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -286,7 +286,7 @@ class Base {
 
 		try {
 			if ( $request['auth_header'] ) {
-				$request['headers']['Authorization'] = 'Bearer ' . self::get_token()['access_token'];
+				$request['headers']['Authorization'] = 'Bearer ' . static::get_token()['access_token'];
 			}
 
 			$request_args = array(

--- a/src/API/TokenExchangeV3ToV5.php
+++ b/src/API/TokenExchangeV3ToV5.php
@@ -43,5 +43,25 @@ class TokenExchangeV3ToV5 extends APIV5 {
 		$request_url = 'oauth/commerce_integrations/token/exchange/';
 		return self::make_request( $request_url );
 	}
+	/**
+	 * Update token from V3 to V5.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool $success Whether the token was updated successfully.
+	 */
+	public static function token_update() {
+		$respone = self::exchange_token();
+
+		if ( 'success' != $respone['status'] ) {
+			return false;
+		}
+
+		$token_data = $respone['data'];
+
+		Pinterest_For_Woocommerce()::save_token_data( $token_data );
+
+		return true;
+	}
 
 }

--- a/src/API/TokenExchangeV3ToV5.php
+++ b/src/API/TokenExchangeV3ToV5.php
@@ -64,4 +64,15 @@ class TokenExchangeV3ToV5 extends APIV5 {
 		return true;
 	}
 
+	/**
+	 * Get the V3 token.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string $token The V3 token.
+	 */
+	public static function get_token() {
+		return Pinterest_For_Woocommerce()::get_data( 'token', true );
+	}
+
 }

--- a/src/API/TokenExchangeV3ToV5.php
+++ b/src/API/TokenExchangeV3ToV5.php
@@ -9,6 +9,9 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
+use Automattic\WooCommerce\Pinterest\Crypto;
+use Automattic\WooCommerce\Pinterest\Logger;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -72,7 +75,16 @@ class TokenExchangeV3ToV5 extends APIV5 {
 	 * @return string $token The V3 token.
 	 */
 	public static function get_token() {
-		return Pinterest_For_Woocommerce()::get_data( 'token', true );
+		$token = Pinterest_For_Woocommerce()::get_data( 'token', true );
+
+		try {
+			$token['access_token'] = empty( $token['access_token'] ) ? '' : Crypto::decrypt( $token['access_token'] );
+		} catch ( \Exception $th ) {
+			/* Translators: The error description */
+			Logger::log( sprintf( esc_html__( 'Could not decrypt the Pinterest API access token. Try reconnecting to Pinterest. [%s]', 'pinterest-for-woocommerce' ), $th->getMessage() ), 'error' );
+		}
+
+		return $token;
 	}
 
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -303,7 +303,7 @@ class PluginUpdate {
 	 */
 	protected function token_update(): void {
 		// Update should only happen if the plugin is connected using the V3 token.
-		if ( Pinterest_For_Woocommerce()::is_connected() ) {
+		if ( ! Pinterest_For_Woocommerce()::is_connected() ) {
 			return;
 		}
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Pinterest\API\UserInteraction;
+use Automattic\WooCommerce\Pinterest\API\TokenExchangeV3ToV5;
 use Exception;
 use Throwable;
 /**
@@ -100,6 +101,7 @@ class PluginUpdate {
 	 *
 	 * @since 1.0.10
 	 * @since 1.2.7 Updates procedures organized in an array by plugin version.
+	 * @since 1.4.0 Added token_update procedure.
 	 * @return array List of update procedures names.
 	 */
 	private function update_procedures() {
@@ -112,6 +114,9 @@ class PluginUpdate {
 			),
 			'1.2.5'  => array(
 				'ads_credits_integration',
+			),
+			'1.4.0' => array(
+				'token_update',
 			),
 		);
 	}
@@ -287,5 +292,31 @@ class PluginUpdate {
 	protected function ads_credits_integration(): void {
 		// Set modals as dismissed and notice as not dismissed.
 		update_option( PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME . '_' . UserInteraction::ADS_MODAL_DISMISSED, true, false );
+	}
+
+	/**
+	 * Token update procedure. V3 to V5.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	protected function token_update(): void {
+		// Update should only happen if the plugin is connected using the V3 token.
+		if ( Pinterest_For_Woocommerce()::is_connected() ) {
+			return;
+		}
+
+		// Set API version to V3. We can use this value to detect failure in the token update procedure.
+		Pinterest_For_Woocommerce()::set_api_version( 'v3' );
+
+		$updated = TokenExchangeV3ToV5::token_update();
+
+		if ( ! $updated ) {
+			return;
+		}
+
+		// Update completed successfully.
+		Pinterest_For_Woocommerce()::set_api_version( 'v5' );
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -303,7 +303,11 @@ class PluginUpdate {
 	 */
 	protected function token_update(): void {
 		// Update should only happen if the plugin is connected using the V3 token.
-		if ( ! Pinterest_For_Woocommerce()::is_connected() ) {
+		$token_data   = Pinterest_For_Woocommerce()::get_data( 'token', true );
+		$has_v3_token = $token_data && ! empty( $token_data['access_token'] );
+
+		if ( ! $has_v3_token ) {
+			// Plugin not connected. Regular, manual connection flow will be used.
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the plugin gets updated the token exchange procedure should be triggered.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #844 .

Relies on #840.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install the current production version and connect.
2. Complete the setup and connection.
3. Switch to this branch. Update manually `PINTEREST_FOR_WOOCOMMERCE_VERSION` to `1.4.0`
4. Add a breakpoint at the update method. Reload the plugin.
5. Observer the flow.

