### PR TITLE
Check feed_location to contain absolute url.

### DIFF
--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -139,9 +139,13 @@ class Merchants {
 		 */
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
+		// Check if the feed location is a full URL or a relative path and build the feed location accordingly.
+		$feed_location = parse_url( $config['feed_url'] );
+		$feed_location = ! empty( $feed_location['host'] ) ? $config['feed_url'] : get_home_url() . $feed_location['path'];
+
 		$args = array(
 			'merchant_domains' => get_home_url(),
-			'feed_location'    => $config['feed_url'],
+			'feed_location'    => $feed_location,
 			'feed_format'      => 'XML',
 			'country'          => Pinterest_For_Woocommerce()::get_base_country() ?? 'US',
 			'locale'           => LocaleMapper::get_locale_for_api(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #838 .

Adding extra check for `feed_location` to be a full URL and not just a relative path.
If `feed_location` does not contain a domain - add current domain to it.

### Detailed test instructions:

There are no test instructions because the issue is not easily reproducible. 
Pinterest reported only some websites have this. 

### Changelog entry

> Tweak - Make sure `feed_location` has a full URL.
