### PR TITLE
Add url parameter to token refresh call.

### DIFF
--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -69,6 +69,7 @@ class RefreshToken {
 					),
 					'body'    => array(
 						'refresh_token' => Crypto::decrypt( $token_data['refresh_token'] ),
+						'url'           => get_site_url(),
 					),
 					'sslverify' => false,
 				);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: #856

This PR adds the `url` parameter to the `renew` call.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

No testing instructions.
