### PR TITLE
Update Woo.com developer blog URLs

### DIFF
--- a/docs/testing-flows.md
+++ b/docs/testing-flows.md
@@ -143,4 +143,4 @@ The Pinterest plugin will add these fields in an attributes tab on the product e
 
 ## Miscellaneous
 
-- Pinterest admin screens are visible and accessible in all supported WooCommerce Admin navigation variations (current WP sidebar and [forthcoming unified nav](https://developer.woocommerce.com/2021/01/15/call-to-action-create-access-for-your-extension-in-the-new-woocommerce-navigation/)).
+- Pinterest admin screens are visible and accessible in all supported WooCommerce Admin navigation variations (current WP sidebar and [forthcoming unified nav](https://developer.woo.com/2021/01/15/call-to-action-create-access-for-your-extension-in-the-new-woocommerce-navigation/)).

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ Bugs should be reported in the [Pinterest for WooCommerce repository](https://gi
 
 Yes you can! Join in on our [GitHub repository](https://github.com/woocommerce/pinterest-for-woocommerce/) :)
 
-Release and roadmap notes available on the [WooCommerce Developers Blog](hhttps://developer.woocommerce.com/)
+Release and roadmap notes available on the [WooCommerce Developers Blog](https://developer.woo.com/)
 
 == Changelog ==
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to https://github.com/woocommerce/pinterest-for-woocommerce/pull/837.

`developer.woocommerce.com` is no moved to `developer.woo.com`, so this was the pending docs/URLs change from that PR.

### Detailed test instructions:
1. No real code changes.
2. Double check all new URLs actually go to a page.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Update Woo.com developer blog URLs.
