### PR TITLE
Release/1.3.17 - `trunk` into `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.3.17 - 2023-12-19 =
+* Dev - Update Woo.com developer blog URLs.
+* Update - promo code for 2024.
+
 = 1.3.16 - 2023-12-13 =
 * Tweak - Make sure `feed_location` has a full URL.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woo.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.3.16
+ * Version:           1.3.17
  * Author:            WooCommerce
  * Author URI:        https://woo.com
  * License:           GPL-2.0+
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.16' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.17' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 6.4
 Requires PHP: 7.3
-Stable tag: 1.3.16
+Stable tag: 1.3.17
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.3.17 - 2023-12-19 =
+* Dev - Update Woo.com developer blog URLs.
+* Update - promo code for 2024.
+
 = 1.3.16 - 2023-12-13 =
 * Tweak - Make sure `feed_location` has a full URL.
 

--- a/src/AdCreditsCoupons.php
+++ b/src/AdCreditsCoupons.php
@@ -23,7 +23,7 @@ class AdCreditsCoupons {
 	/**
 	 * List of Ads Credits allowed currencies.
 	 *
-	 * @since x.x.x
+	 * @since 1.3.17
 	 *
 	 * @var array
 	 */
@@ -66,7 +66,7 @@ class AdCreditsCoupons {
 	 * Get a valid coupon for the merchant.
 	 *
 	 * @since 1.2.5
-	 * @since x.x.x update logic for new data format.
+	 * @since 1.3.17 update logic for new data format.
 	 *
 	 * @return string|false Coupon string or false if no coupon was found.
 	 */


### PR DESCRIPTION
This PR merges the changes from release [1.3.17](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.3.17) from `trunk` back into `develop`