### PR TITLE
Fixing wrong feed items counter.

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -394,8 +394,8 @@ class FeedGenerator extends AbstractChainedJob {
 					continue;
 				}
 				$this->buffers[ $location ] .= $product_xml;
-				++$processed_products;
 			}
+			++$processed_products;
 		}
 
 		// May throw write to file exception.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moving items counter one level up to prevent from being incremented when looping through the array of feed configurations.

Note: the issue is reproduceable when you have multiple local feed configurations. Also, in some cases, especially with fresh installations, we have a bug in the system when we always have multiple local feed configurations where the first one is `false`, the sign of this is when you have your feed file ending with `...-.csv`, w/o a random suffix. 

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Being at develop branch go to WooCommerce - Status - Scheduled Actions - Pending section.
2. Run `pinterest-for-woocommerce-start-feed-generation` action.

<img width="1528" alt="Cursor_and_WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/d8097cae-9a48-4e7e-abf1-18c9d27d9063">

3. Go to Marketing - Pinterest tab and check counters. You should see items counter to show twice the amount of products added to the feed file when the original file has a proper number of products.

![cursor_and_products_catalog_e280b9_pinterest_e280b9_marketing_e280b9_woocommerce_e280b9_wordpress_pinterest_e28094_woocommerce](https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/7b285db5-4b57-458c-83e1-12d41fd7ebc0)

4. Checkout `fix/wrong-feed-items-counter` branch and repeat all the steps above.
5. This time you should see the correct counter instead.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Wrong feed generation items counter.
