### PR TITLE
Adding currency credit info to account data.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -284,6 +284,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Verify that the ads_campaign is active or not.
 			add_action( 'admin_init', array( Pinterest\AdCredits::class, 'check_if_ads_campaign_is_active' ) );
 
+			// Append credits info to account data.
+			add_action( 'init', array( $this, 'add_currency_credits_info_to_account_data' ) );
+
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 
@@ -1041,6 +1044,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$account_data['coupon_redeem_info'] = $redeem_information;
 
 			self::save_setting( 'account_data', $account_data );
+		}
+
+		/**
+		 * Add currency_credit_info information to the account data option.
+		 *
+		 * @since 1.3.9
+		 *
+		 * @return void
+		 */
+		public static function add_currency_credits_info_to_account_data() {
+			$account_data = self::get_setting( 'account_data' );
+			if ( ! isset( $account_data['currency_credit_info'] ) ) {
+				$account_data['currency_credit_info'] = AdsCreditCurrency::get_currency_credits();
+				self::save_setting( 'account_data', $account_data );
+			}
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -284,9 +284,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// Verify that the ads_campaign is active or not.
 			add_action( 'admin_init', array( Pinterest\AdCredits::class, 'check_if_ads_campaign_is_active' ) );
 
-			// Append credits info to account data.
-			add_action( 'init', array( $this, 'add_currency_credits_info_to_account_data' ) );
-
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'set_default_settings' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 
@@ -304,7 +301,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Hook the setup task. The hook admin_init is not triggered when the WC fetches the tasks using the endpoint: wp-json/wc-admin/onboarding/tasks and hence hooking into init.
 			add_action( 'init', array( $this, 'add_onboarding_task' ), 20 );
-
 		}
 
 
@@ -935,8 +931,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					 * We will be able to check that only when the advertiser will be connected.
 					 * The billing is tied to advertiser.
 					 */
-					$data['is_billing_setup']   = false;
-					$data['coupon_redeem_info'] = array( 'redeem_status' => false );
+					$data['is_billing_setup']     = false;
+					$data['coupon_redeem_info']   = array( 'redeem_status' => false );
+					$data['currency_credit_info'] = AdsCreditCurrency::get_currency_credits();
 
 					Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
 					return $data;
@@ -1043,20 +1040,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$account_data['coupon_redeem_info'] = $redeem_information;
 
-			self::save_setting( 'account_data', $account_data );
-		}
-
-		/**
-		 * Add currency_credit_info information to the account data option.
-		 *
-		 * @since 1.3.9
-		 *
-		 * @return void
-		 */
-		public static function add_currency_credits_info_to_account_data() {
-			$account_data                         = self::get_setting( 'account_data' );
-			$currency_credit_info                 = AdsCreditCurrency::get_currency_credits();
-			$account_data['currency_credit_info'] = $currency_credit_info;
 			self::save_setting( 'account_data', $account_data );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currency credit information data is required for the UI to display promo using proper currencies and amounts per locale. For domain verification step the information was missing causing page to go blank once verification finishes. That was all due to domain verification step was also fetching account data from Pinterest and updated it into options database table vanishing previously set currency credit information. 

Further research showed that there is a function used as a callback to init action to fetch currency information and save into account data. Debugging the function calls showed it was called up to 10 times per page load, updated it to alter account data only if the key is missing from the data set.

The solution is to initialise currency credit information setup to token save and domain verification steps, the same place other account data keys are initialised and assigned.

### Detailed test instructions:

1. Being at `develop` branch.
2. Get to `wp_options` database table and search for `pinterest_for_woocommerce` option name
3. Update the option value `verified_user_websites` subset by removing tested website domain from the list.
4. Refresh the page to see `Start verification` button.

<img width="1057" alt="Onboarding_Guide_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/0ee40008-9627-43b0-887d-b342ef65fccb">

5. Press the button and see blank page display.

<img width="1057" alt="Onboarding_Guide_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/5a739c80-4c6b-43e7-b943-51d234d17bdc">

Note: There is a console error _Cannot read properties of undefined (reading 'creditsGiven')_

<img width="1201" alt="DevTools_-_pinterest_dima_works_wp-admin_admin_php_page_wc-admin_path__2Fpinterest_2Fonboarding_step_claim-website_view_wizard" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/636a1331-6216-45de-9f82-c3cf7b33119c">

Note: payload does not contain `currency_credit_info`

<img width="1201" alt="DevTools_-_pinterest_dima_works_wp-admin_admin_php_page_wc-admin_path__2Fpinterest_2Fonboarding_step_claim-website_view_wizard" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/6fb6e0e2-3e09-4f5f-824f-5e6ee337ca36">

6. Checkout `fix/currency-credit-info-missing` branch.
7. Get to `wp_options` database table and search for `pinterest_for_woocommerce` option name
8. Update the option value `verified_user_websites` subset by removing tested website domain from the list.
9. Refresh the page to see `Start verification` button.
10. This time you should see verification process successfully finish, no console error and the response payload to have proper data subset under `account_data` key.

<img width="1057" alt="Onboarding_Guide_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/a9686943-8fdd-4258-b8ce-48ed9a73b7dc">

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Currency and credit information missing at domain verification step.
