### PR TITLE
Release/1.3.19 - `trunk` into `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.3.19 - 2024-01-09 =
+* Tweak - Changed minimum WC version to 6.3.
+* Tweak - WC 8.5 compatibility.
+
 = 1.3.18 - 2023-12-27 =
 * Fix - Pinterest duplicated notices.
 * Fix - Product Editor transient notice shift.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -25,7 +25,7 @@
  * Tested up to: 6.4
  * Requires PHP: 7.4
  *
- * WC requires at least: 5.3
+ * WC requires at least: 6.3
  * WC tested up to: 8.3
  */
 

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woo.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.3.18
+ * Version:           1.3.19
  * Author:            WooCommerce
  * Author URI:        https://woo.com
  * License:           GPL-2.0+
@@ -26,7 +26,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 8.3
+ * WC tested up to: 8.5
  */
 
 /**
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.18' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.19' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.3.19 - 2024-01-09 =
+* Tweak - Changed minimum WC version to 6.3.
+* Tweak - WC 8.5 compatibility.
+
 = 1.3.18 - 2023-12-27 =
 * Fix - Pinterest duplicated notices.
 * Fix - Product Editor transient notice shift.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 6.4
 Requires PHP: 7.3
-Stable tag: 1.3.18
+Stable tag: 1.3.19
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR merges the changes from [release v1.3.19](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.3.19) back into `develop`.