### PR TITLE
Integrating v5 billing endpoints.

### DIFF
--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -543,4 +543,33 @@ class APIV5 extends Base {
 			'GET'
 		);
 	}
+
+	/**
+	 * Attempts to redeem the offer code for the given advertiser.
+	 *
+	 * @link https://developers.pinterest.com/docs/api/v5/#operation/ads_credit/redeem
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $advertiser_id Advertiser ID.
+	 * @param string $offer_code    Offer code (hash).
+	 *
+	 * @return array {
+	 *     Credits redeem status.
+	 *
+	 *     @type bool    $success       Whether the offer code was successfully redeemed or not.
+	 *     @type ?int    $errorCode     Error code type if error occurs.
+	 *     @type ?string $errorMessage  Reason for failure.
+	 * }
+	 * @throws PinterestApiException When unable to redeem the offer code or any unexpected error occur.
+	 */
+	public static function redeem_ads_offer_code( $advertiser_id, $offer_code ) {
+		return self::make_request(
+			"ad_accounts/{$advertiser_id}/ads_credit/redeem",
+			'POST',
+			array(
+				'offerCodeHash' => $offer_code
+			)
+		);
+	}
 }

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -572,4 +572,38 @@ class APIV5 extends Base {
 			)
 		);
 	}
+
+	/**
+	 * Get active billing profiles in the advertiser account.
+	 *
+	 * @link https://developers.pinterest.com/docs/api/v5/#operation/billing_profiles/get
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $ad_account_id Pinterest Ad Account ID.
+	 *
+	 * @return array {
+	 *     Billing profiles in the advertiser account.
+	 *
+	 *     @type array[] $items {
+	 *         @type string $id                     Billing ID.
+	 *         @type string $card_type              Type of the card ("UNKNOWN" "VISA" "MASTERCARD" "AMERICAN_EXPRESS"
+	 *                                              "DISCOVER" "ELO").
+	 *         @type string $status                 Status of the billing. ("UNSPECIFIED" "VALID" "INVALID" "PENDING"
+	 *                                              "DELETED" "SECONDARY" "PENDING_SECONDARY").
+	 *         @type string $advertiser_id          Advertiser ID of the billing.
+	 *         @type string $payment_method_brand   Brand of the payment method. ("UNKNOWN" "VISA" "MASTERCARD"
+	 *                                              "AMERICAN_EXPRESS" "DISCOVER" "SOFORT" "DINERS_CLUB" "ELO"
+	 *                                              "CARTE_BANCAIRE").
+	 *     }
+	 *     @type string $bookmark Cursor used to fetch the next page of items.
+	 * }
+	 * @throws PinterestApiException If the request fails with other than 2xx status.
+	 */
+	public static function get_active_billing_profiles( string $ad_account_id ): array {
+		return self::make_request(
+			"ad_accounts/{$ad_account_id}/billing_profiles?is_active=true",
+			'GET'
+		);
+	}
 }

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -551,7 +551,7 @@ class APIV5 extends Base {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param string $advertiser_id Advertiser ID.
+	 * @param string $ad_account_id Pinterest Ad Account ID.
 	 * @param string $offer_code    Offer code (hash).
 	 *
 	 * @return array {
@@ -563,9 +563,9 @@ class APIV5 extends Base {
 	 * }
 	 * @throws PinterestApiException When unable to redeem the offer code or any unexpected error occur.
 	 */
-	public static function redeem_ads_offer_code( $advertiser_id, $offer_code ) {
+	public static function redeem_ads_offer_code( string $ad_account_id, string $offer_code ): array {
 		return self::make_request(
-			"ad_accounts/{$advertiser_id}/ads_credit/redeem",
+			"ad_accounts/{$ad_account_id}/ads_credit/redeem",
 			'POST',
 			array(
 				'offerCodeHash' => $offer_code

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -568,7 +568,7 @@ class APIV5 extends Base {
 			"ad_accounts/{$ad_account_id}/ads_credit/redeem",
 			'POST',
 			array(
-				'offerCodeHash' => $offer_code
+				'offerCodeHash' => $offer_code,
 			)
 		);
 	}

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -792,32 +792,6 @@ class Base {
 	}
 
 	/**
-	 * Redeem advertisement offer code ( ads credit ).
-	 *
-	 * @param string $advertiser_id The advertiser id for which we redeem the offer code.
-	 * @param string $offer_code Promotional ads credit offer code.
-	 *
-	 * @return mixed
-	 */
-	public static function redeem_ads_offer_code( $advertiser_id, $offer_code ) {
-		$request_url = "advertisers/{$advertiser_id}/marketing_offer/{$offer_code}/redeem?is_encoded=true";
-		return self::make_request( $request_url, 'POST', array(), 'ads' );
-	}
-
-	/**
-	 * Validate advertisement offer code ( ads credit ).
-	 *
-	 * @param string $advertiser_id The advertiser id for which we validate the offer code.
-	 * @param string $offer_code Promotional ads credit offer code.
-	 *
-	 * @return mixed
-	 */
-	public static function validate_ads_offer_code( $advertiser_id, $offer_code ) {
-		$url = "advertisers/{$advertiser_id}/marketing_offer/{$offer_code}/redeem?validate_only=true";
-		return self::make_request( $url, 'POST', array(), 'ads' );
-	}
-
-	/**
 	 * Pull information about available ads credits for advertiser.
 	 *
 	 * @param string $advertiser_id The advertiser id for which we check the available ads credits.

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Pinterest;
 use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\API\Base;
 use Exception;
+use Pinterest_For_Woocommerce;
 use Pinterest_For_Woocommerce_Ads_Supported_Countries;
 use Throwable;
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\API\Base;
 use Exception;
 use Pinterest_For_Woocommerce_Ads_Supported_Countries;
@@ -85,49 +86,24 @@ class AdCredits {
 	 * @return bool Weather the coupon was successfully redeemed or not.
 	 */
 	public static function redeem_credits( $offer_code, &$error_code = null, &$error_message = null ) {
-
 		if ( ! Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' ) ) {
 			// Advertiser not connected, we can't check if credits were redeemed.
 			return false;
 		}
 
-		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
-
-		if ( false === $advertiser_id ) {
-			// No advertiser id stored. But we are connected. This is an abnormal state that should not happen.
-			Logger::log( __( 'Advertiser connected but the connection id is missing.', 'pinterest-for-woocommerce' ) );
-			return false;
-		}
-
+		$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
 		try {
-			$result = Base::redeem_ads_offer_code( $advertiser_id, $offer_code );
-			if ( 'success' !== $result['status'] ) {
+			$offer_code_credits_data = APIV5::redeem_ads_offer_code( $ad_account_id, $offer_code );
+			if ( ! $offer_code_credits_data['success'] ) {
+				$error_code    = $offer_code_credits_data['errorCode'];
+				$error_message = $offer_code_credits_data['errorMessage'];
+				Logger::log( "{$error_code}: {$error_message}", 'error' );
 				return false;
 			}
-
-			$redeem_credits_data     = (array) $result['data'];
-			$offer_code_credits_data = reset( $redeem_credits_data );
-			if ( false === $offer_code_credits_data ) {
-				// No data for the requested offer code.
-				Logger::log( __( 'There is no available data for the requested offer code.', 'pinterest-for-woocommerce' ) );
-				return false;
-			}
-
-			if ( ! $offer_code_credits_data->success ) {
-				Logger::log( $offer_code_credits_data->failure_reason, 'error' );
-				$error_code    = $offer_code_credits_data->error_code;
-				$error_message = $offer_code_credits_data->failure_reason;
-
-				return false;
-			}
-
 			return true;
-
 		} catch ( Throwable $th ) {
-
 			Logger::log( $th->getMessage(), 'error' );
 			return false;
-
 		}
 	}
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -46,8 +46,7 @@ class AdCredits {
 	 * @return mixed
 	 */
 	public static function handle_redeem_credit() {
-
-		if ( ! Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' ) ) {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
 			// Advertiser not connected redeem operation makes no sense.
 			return true;
 		}
@@ -86,7 +85,7 @@ class AdCredits {
 	 * @return bool Weather the coupon was successfully redeemed or not.
 	 */
 	public static function redeem_credits( $offer_code, &$error_code = null, &$error_message = null ) {
-		if ( ! Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' ) ) {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
 			// Advertiser not connected, we can't check if credits were redeemed.
 			return false;
 		}
@@ -201,7 +200,7 @@ class AdCredits {
 	 * @return mixed False when no info is available, discounts object when discounts are available.
 	 */
 	public static function process_available_discounts() {
-		if ( ! Pinterest_For_Woocommerce()::get_data( 'is_advertiser_connected' ) ) {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
 			// Advertiser not connected, we can't check if credits were redeemed.
 			return false;
 		}

--- a/src/Billing.php
+++ b/src/Billing.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\API\Base;
+use Pinterest_For_Woocommerce;
 use Throwable;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -133,11 +134,11 @@ class Billing {
 
 			return array_reduce(
 				$active_profiles['items'] ?? array(),
-				function( $carry, $item ) {
+				function ( $carry, $item ) {
 					if ( $carry ) {
 						return $carry;
 					}
-					return $item['status'] === 'VALID';
+					return 'VALID' === $item['status'];
 				},
 				false
 			);


### PR DESCRIPTION
### Pinterest Billing API

The task is to research the possibility to integrate newly suggested Billing APIs into the extension. The main question is can we easily replace all the places where we have calls to the old API with the new ones considering that we have four old API endpoints and Pinterest suggests only three new.

### The research.

`POST /ads/v4/advertisers/<advertiser-id>/marketing_offer/<offer-code>/redeem`
Used in two places: to validate if the code is valid (when called with parameter ‘validate only’) and to actually redeem the code.

Studying the codebase I did not manage to find a single place where validation is happening which makes me think of a validate_ads_offer_code function being redundant and not used anymore.

However, it is still used for redeeming a code and what we need from it is a status field to check if the action was successful and if not – error details from the response, which are going to be present if the request did not succeed.

According to the Pinterest new endpoint description both scenarios are supported by the new endpoint so the endpoint can be easily replaced.

The new endpoint’s response is missing success property which the old endpoint provides, instead an HTTP status code is used and is 200 if the action was successful or 4xx with the details on the error otherwise.

`GET /ads/v4/advertisers/<advertiser-id>/discounts`
Current endpoint is not described under either v3 or v4 endpoint documentations ( [https://developers.pinterest.com/docs/api/v3/](https://href.li/?https://developers.pinterest.com/docs/api/v3/), [https://developers.pinterest.com/docs/api/v4/](https://href.li/?https://developers.pinterest.com/docs/api/v4/) ).

From the code I can only guess why we search for specific response elements under indexes of 5 and 16 to work with. The new endpoint returns an array of items and from the document I can tell that each item returned has the properties we need to integrate the call into the extensions’s codebase.

`GET /ads/v4/advertisers/<advertiser-id>/partners/billing_profiles`
We use the endpoint to detect if billing was setup. We do not. use any other information returned by the endpoint and the new endpoint suggested by Pinterest has the data we need to determine the same (new API has a flag to include only active profiles and depending on the number of returned billing profile we know what we need).

`GET /ads/v4/advertisers/<advertiser-id>/billing_data`
Billing data endpoint is an analog of billing profiles endpoint and according to my research is not used by the extension. get_advertiser_billing_data can be removed from the codebase.