### PR TITLE
Adding missing gap between page intro and the banner.

### DIFF
--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -484,7 +484,6 @@ $root: ".woocommerce-setup-guide";
 	}
 
 	&__welcome-section {
-		margin-bottom: 0;
 
 		.components-flex {
 			align-items: flex-end;


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Puts back the margin removed by Pinterest css rules.

Closes #890

### Screenshots:

<img width="1128" alt="Pinterest_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/89631255-1f82-414e-8549-9c6b2b2e05ef">

### Detailed test instructions:

1. Being at the `develop` branch, check the disconnected extension's Home screen.
2. Checkout the `fix/no-margin-above-the-banner` branch and build its sources. `nvm use && nom run build`.
3. Observe that the Home screen has a margin between the banner and the welcome block above it.

### Changelog entry

> Fix - Banner top margin missing.