### PR TITLE
Fix deprecation notice in PHP 8.2

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -284,7 +284,7 @@ class ProductsXmlFeed {
 
 		$id         = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
 		$taxonomies = array_map(
-			'self::sanitize',
+			[self::class, 'sanitize'],
 			self::get_taxonomies( $id )
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partially fixes #827.

Following deprecation notice is no longer triggered on PHP 8.2 or newer:
```PHP Deprecated:  Use of "self" in callables is deprecated in /…/pinterest-for-woocommerce/src/ProductsXmlFeed.php on line 286```

### Detailed test instructions:

1. Install plugin on PHP 8.2 or newer.
2. Observer no deprecation notice being triggered from `pinterest-for-woocommerce/src/ProductsXmlFeed.php` file.

### Changelog entry

> Fix - Prevent deprecation notice in PHP 8.2.
