### PR TITLE
Release/1.3.21 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.3.21 - 2024-02-14 =
+* Tweak - WC 8.6 compatibility.
+
 = 1.3.20 - 2024-01-12 =
 * Fix - Use proper redeem code format.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4181,9 +4181,9 @@
       }
     },
     "@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
       "dev": true
     },
     "@types/markdown-it": {
@@ -4206,9 +4206,9 @@
       }
     },
     "@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -30581,7 +30581,7 @@
     },
     "woocommerce-grow-jsdoc": {
       "version": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?9eb10353728dc915bf5f7bdd4b8e218c625355a9",
-      "integrity": "sha512-+JolGUAS7n3eKygg5lFOiQgBH7V23fbsuV7H3ECLFORjAqOGR2bHyc54sSgYeUgEWgNchnmdex3Zu65nS6SA2Q==",
+      "integrity": "sha512-ksRpzDDkKtk43cUqTRw04829SoKWpnGtSLqQMkgpKc9+XqLsmo9zvz0izGDHeSxqkzg8Ze1PBQul14vegt25Bg==",
       "dev": true,
       "requires": {
         "jsdoc": "^3.6.10",
@@ -30611,9 +30611,9 @@
           "dev": true
         },
         "jsdoc": {
-          "version": "3.6.10",
-          "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-          "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+          "version": "3.6.11",
+          "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+          "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
           "dev": true,
           "requires": {
             "@babel/parser": "^7.9.4",
@@ -30622,7 +30622,7 @@
             "catharsis": "^0.9.0",
             "escape-string-regexp": "^2.0.0",
             "js2xmlparser": "^4.0.2",
-            "klaw": "^4.0.1",
+            "klaw": "^3.0.0",
             "markdown-it": "^12.3.2",
             "markdown-it-anchor": "^8.4.1",
             "marked": "^4.0.10",
@@ -30634,10 +30634,13 @@
           }
         },
         "klaw": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-          "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
-          "dev": true
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+          "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
+          }
         },
         "linkify-it": {
           "version": "3.0.3",
@@ -30662,15 +30665,15 @@
           }
         },
         "markdown-it-anchor": {
-          "version": "8.6.4",
-          "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-          "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
+          "version": "8.6.7",
+          "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+          "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
           "dev": true
         },
         "marked": {
-          "version": "4.0.16",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
-          "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+          "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
           "dev": true
         },
         "mkdirp": {
@@ -30680,9 +30683,9 @@
           "dev": true
         },
         "underscore": {
-          "version": "1.13.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-          "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
+          "version": "1.13.6",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woo.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.3.20
+ * Version:           1.3.21
  * Author:            WooCommerce
  * Author URI:        https://woo.com
  * License:           GPL-2.0+
@@ -26,7 +26,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 8.5
+ * WC tested up to: 8.6
  */
 
 /**
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.20' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.3.21' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, pinterest, advertise
 Requires at least: 5.6
 Tested up to: 6.4
 Requires PHP: 7.3
-Stable tag: 1.3.20
+Stable tag: 1.3.21
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.3.21 - 2024-02-14 =
+* Tweak - WC 8.6 compatibility.
+
 = 1.3.20 - 2024-01-12 =
 * Fix - Use proper redeem code format.
 


### PR DESCRIPTION
This PR merges the changes from [release v1.3.21](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.3.21) back into `develop`.