### PR TITLE
Make sure currency_credit_info is always added to account_data

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -939,7 +939,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 					$data['coupon_redeem_info'] = array( 'redeem_status' => false );
 
 					Pinterest_For_Woocommerce()::save_setting( 'account_data', $data );
-					return $data;
+					return Pinterest_For_Woocommerce()::add_currency_credits_info_to_account_data();
 				}
 
 				self::get_linked_businesses( true );
@@ -1051,13 +1051,14 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 *
 		 * @since 1.3.9
 		 *
-		 * @return void
+		 * @return array The updated account data.
 		 */
 		public static function add_currency_credits_info_to_account_data() {
 			$account_data                         = self::get_setting( 'account_data' );
 			$currency_credit_info                 = AdsCreditCurrency::get_currency_credits();
 			$account_data['currency_credit_info'] = $currency_credit_info;
 			self::save_setting( 'account_data', $account_data );
+			return $account_data;
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/899.

Reported and incorrectly labeled as fixed in https://wordpress.org/support/topic/start-verification-issue/ and https://wordpress.org/support/topic/black-after-claim-your-site/.

As seen in #899, the response to the API call to `/wp-json/pinterest/v1/domain_verification` causes a JS error because the `currency_credits_info` is missing.

That info is added to the existing `account_data` on `init`: https://github.com/woocommerce/pinterest-for-woocommerce/blob/81b703bcf42682bbe07abb5c22b8c144f1434052/class-pinterest-for-woocommerce.php#L287-L288

But during DomainVerification, this data is updated again:
https://github.com/woocommerce/pinterest-for-woocommerce/blob/81b703bcf42682bbe07abb5c22b8c144f1434052/src/API/DomainVerification.php#L82

Which rebuilds the account data WITHOUT the `currency_credits_info`:
https://github.com/woocommerce/pinterest-for-woocommerce/blob/81b703bcf42682bbe07abb5c22b8c144f1434052/class-pinterest-for-woocommerce.php#L912-L942

That breaks the onboarding process. But refreshing runs the init hook again, so the settings are updated and the onboarding can finish.

This PR ensures that, any time the `account_data` is updated **after** the `init` hook has already been executed, the `currency_credits_info` is included. That way the `domain_verification` call returns all the necessary info. (The only other time the `update_account_data` method is used is right after connecting the account, between Steps 1 and 2 of onboarding, so there's no downside to adding the data there).


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through onboarding and ensure that domain verification works correctly.
2. Quick smoke test (update user settings, etc) to make sure everything runs smoothly.
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Blank screen in onboarding after domain verification.
