### PR TITLE
PHP 8.3 compatibilty

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -540,7 +540,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_setting( $key, $data ) {
 
-			$settings = self::get_settings( true );
+			$settings = self::get_settings( true ) ?: array();
 
 			$settings[ $key ] = $data;
 
@@ -594,7 +594,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_data( $key, $data ) {
 
-			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME ) ?: array();
 
 			$settings[ $key ] = $data;
 
@@ -978,7 +978,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function maybe_check_billing_setup() {
-			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
+			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' ) ?: array();
 			$has_billing_setup_old = is_array( $account_data ) && $account_data['is_billing_setup'] ?? false;
 			if ( Billing::should_check_billing_setup_often() ) {
 				$has_billing_setup_new = self::add_billing_setup_info_to_account_data();
@@ -1054,7 +1054,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function add_currency_credits_info_to_account_data() {
-			$account_data = self::get_setting( 'account_data' );
+			$account_data = self::get_setting( 'account_data' ) ?: array();
 			if ( ! isset( $account_data['currency_credit_info'] ) ) {
 				$account_data['currency_credit_info'] = AdsCreditCurrency::get_currency_credits();
 				self::save_setting( 'account_data', $account_data );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -540,8 +540,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_setting( $key, $data ) {
 
-			$settings = self::get_settings( true ) ?: array();
-
+			$settings = self::get_settings( true );
+			// Handle possible false value.
+			if ( ! is_array( $settings ) ) {
+				$settings = array();
+			}
 			$settings[ $key ] = $data;
 
 			return self::save_settings( $settings );
@@ -594,8 +597,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function save_data( $key, $data ) {
 
-			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME ) ?: array();
-
+			$settings = self::get_settings( true, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+			// Handle possible false value.
+			if ( ! is_array( $settings ) ) {
+				$settings = array();
+			}
 			$settings[ $key ] = $data;
 
 			return self::save_settings( $settings, PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
@@ -1054,8 +1060,12 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function add_currency_credits_info_to_account_data() {
-			$account_data = self::get_setting( 'account_data' ) ?: array();
+			$account_data = self::get_setting( 'account_data' );
 			if ( ! isset( $account_data['currency_credit_info'] ) ) {
+				// Handle possible false value.
+				if ( ! is_array( $account_data ) ) {
+					$account_data = array();
+				}
 				$account_data['currency_credit_info'] = AdsCreditCurrency::get_currency_credits();
 				self::save_setting( 'account_data', $account_data );
 			}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -979,7 +979,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function maybe_check_billing_setup() {
 			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' ) ?: array();
-			$has_billing_setup_old = is_array( $account_data ) && $account_data['is_billing_setup'] ?? false;
+			$has_billing_setup_old = is_array( $account_data ) && ( $account_data['is_billing_setup'] ?? false );
 			if ( Billing::should_check_billing_setup_often() ) {
 				$has_billing_setup_new = self::add_billing_setup_info_to_account_data();
 				// Detect change in billing setup to true and try to redeem.

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -984,7 +984,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function maybe_check_billing_setup() {
-			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' ) ?: array();
+			$account_data          = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
 			$has_billing_setup_old = is_array( $account_data ) && ( $account_data['is_billing_setup'] ?? false );
 			if ( Billing::should_check_billing_setup_often() ) {
 				$has_billing_setup_new = self::add_billing_setup_info_to_account_data();

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -394,7 +394,7 @@ class Base {
 		$request_url = 'websites/verification/metatag/realtime/';
 
 		$parsed_website = wp_parse_url( get_home_url() );
-		$request_url    = add_query_arg( 'website', $parsed_website['host'] . $parsed_website['path'], $request_url );
+		$request_url    = add_query_arg( 'website', $parsed_website['host'] . ( $parsed_website['path'] ?? '' ), $request_url );
 
 		return self::make_request( $request_url, 'POST' );
 	}

--- a/src/Admin/Tasks/Onboarding.php
+++ b/src/Admin/Tasks/Onboarding.php
@@ -83,7 +83,7 @@ class Onboarding extends Task {
 	 * @return string
 	 */
 	public function get_parent_id() {
-		if ( is_callable( 'parent::get_parent_id' ) ) {
+		if ( is_callable( parent::class . 'get_parent_id' ) ) {
 			return parent::get_parent_id();
 		}
 

--- a/src/Admin/Tasks/Onboarding.php
+++ b/src/Admin/Tasks/Onboarding.php
@@ -83,7 +83,7 @@ class Onboarding extends Task {
 	 * @return string
 	 */
 	public function get_parent_id() {
-		if ( is_callable( parent::class . 'get_parent_id' ) ) {
+		if ( is_callable( parent::class . '::get_parent_id' ) ) {
 			return parent::get_parent_id();
 		}
 

--- a/src/Billing.php
+++ b/src/Billing.php
@@ -57,7 +57,8 @@ class Billing {
 		 * Check if we have verified a correct billing setup.
 		 */
 		$account_data       = Pinterest_For_Woocommerce()::get_setting( 'account_data' );
-		$has_billing_setup  = is_array( $account_data ) && $account_data['is_billing_setup'] ?? false;
+
+		$has_billing_setup  = is_array( $account_data ) && ( $account_data['is_billing_setup'] ?? false );
 		$should_check_often = false !== get_transient( self::CHECK_BILLING_SETUP_OFTEN );
 		if ( $has_billing_setup && $should_check_often ) {
 			/*

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -284,7 +284,7 @@ class ProductsXmlFeed {
 
 		$id         = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
 		$taxonomies = array_map(
-			self::class . 'sanitize',
+			self::class . '::sanitize',
 			self::get_taxonomies( $id )
 		);
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -284,7 +284,7 @@ class ProductsXmlFeed {
 
 		$id         = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
 		$taxonomies = array_map(
-			'self::sanitize',
+			self::class . 'sanitize',
 			self::get_taxonomies( $id )
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #898 and #827. Incorporates change proposed in in #895.

Makes an set of changes to address PHP notifications and warnings raised in PHP 8.2 and PHP 8.3.

### Detailed test instructions:
1. Install on a store with PHP 8.3.
2. Enable WP_DEBUG, WP_DEBUG_LOGGING.
3. Go through smoke testing steps: https://github.com/woocommerce/pinterest-for-woocommerce/wiki/Smoke-Tests
4. Check the logs for warnings or notices.
(See issues for exact notices that could be present)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - PHP notices and warnings in PHP 8.2 and PHP 8.3.
