### PR TITLE
Changing External Business ID format.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -1027,22 +1027,24 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return string
 		 */
 		public static function generate_external_business_id(): string {
+			$name = (string) parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
+			if ( empty( $name ) ) {
+				$name = sanitize_title( get_bloginfo( 'name' ) );
+			}
+			$id = uniqid( sprintf( 'woo-%s-', $name ), false );
+
 			/**
 			 * Filters the shop's external business id.
 			 *
 			 * This is passed to Pinterest when connecting.
 			 * Should be non-empty and without special characters,
-			 * otherwise the ID will be obtained from the site URL as fallback.
+			 * otherwise the ID will be obtained from the site's name as fallback.
 			 *
 			 * @since x.x.x
 			 *
 			 * @param string $id the shop's external business id.
 			 */
-			$id = sanitize_key( (string) apply_filters( 'wc_pinterest_external_business_id', get_bloginfo( 'name' ) ) );
-			if ( empty( $id ) ) {
-				$id = sanitize_key( str_replace( array( 'http', 'https', 'www' ), '', get_bloginfo( 'url' ) ) );
-			}
-			return uniqid( sprintf( '%s-', $id ), false );
+			return (string) apply_filters( 'wc_pinterest_external_business_id', $id );
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #906

Besides changing the External Business ID format, the bug with the `wc_pinterest_external_business_id` filter initial value is fixed.

Before `<normalized website title>-<random hash>`
After `woo-<site domain>-<random hash>`

### Detailed test instructions:

1. Connect to Pinterest and observe `wp_options` table for a key named `pinterest_for_woocommerce_data`;
2. Check the key value to contain something as `"external_business_id";s:38:"<site title>-65d60c3f19523"`;
3. Disconnect from Pinterest.
3. Check out the PR `fix/external-business-id` branch.
4. Connect to Pinterest and observe `wp_options` table for a key named `pinterest_for_woocommerce_data`;
5. Check the key value to contain something as `"external_business_id";s:38:"woo-<site domain>-65d60c3f19523"`;

### Changelog entry

> Fix - External Business ID format and filter initial value.
