### PR TITLE
Defer events affected by WC settings only.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -53,13 +53,13 @@ class Tracking {
 		$this->trackers = $trackers;
 
 		// Tracks page visit events.
-		add_action( 'wp_footer', array( $this, 'handle_page_visit' ) );
+		add_action( 'wp_footer', array( $this, 'handle_page_visit' ), 0 );
 
 		// Tracks category visit events.
-		add_action( 'wp_footer', array( $this, 'handle_view_category' ) );
+		add_action( 'wp_footer', array( $this, 'handle_view_category' ), 0 );
 
 		// Tracks search events.
-		add_action( 'wp_footer', array( $this, 'handle_search' ) );
+		add_action( 'wp_footer', array( $this, 'handle_search' ), 0 );
 
 		// Tracks add to cart events.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'handle_add_to_cart' ), 10, 6 );

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -38,7 +38,7 @@ class Tracking {
 	const EVENT_VIEW_CATEGORY = 'ViewCategory';
 
 	/**
-	 * @var array $trackers A list of available trackers.
+	 * @var Tracker[] $trackers A list of available trackers.
 	 */
 	private $trackers = array();
 
@@ -53,19 +53,24 @@ class Tracking {
 		$this->trackers = $trackers;
 
 		// Tracks page visit events.
-		add_action( 'wp_footer', array( $this, 'handle_page_visit' ), 0 );
+		add_action( 'wp_footer', array( $this, 'handle_page_visit' ) );
 
 		// Tracks category visit events.
-		add_action( 'wp_footer', array( $this, 'handle_view_category' ), 0 );
+		add_action( 'wp_footer', array( $this, 'handle_view_category' ) );
 
 		// Tracks search events.
-		add_action( 'wp_footer', array( $this, 'handle_search' ), 0 );
+		add_action( 'wp_footer', array( $this, 'handle_search' ) );
 
 		// Tracks add to cart events.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'handle_add_to_cart' ), 10, 6 );
 
 		// Tracks checkout events.
 		add_action( 'woocommerce_before_thankyou', array( $this, 'handle_checkout' ), 10, 2 );
+
+		array_walk(
+			$this->trackers,
+			fn ( $tracker ) => call_user_func( array( $tracker, 'init_hooks' ) )
+		);
 	}
 
 	/**

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -268,6 +268,7 @@ class Tracking {
 	 * @return void
 	 */
 	public function add_tracker( Tracker $tracker ) {
+		$tracker->init_hooks();
 		$this->trackers[ get_class( $tracker ) ] = $tracker;
 	}
 

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -22,7 +22,7 @@ use Throwable;
 /**
  * Pinterest Conversions API support.
  */
-class Conversions implements Tracker {
+class Conversions extends Tracker {
 
 	/** @var User $user User data object. Data for Conversions API. */
 	private $user;

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class adds PinterestTag tracker support.
  */
-class Tag implements Tracker {
+class Tag extends Tracker {
 
 	private const TAG_ID_SLUG       = '%%TAG_ID%%';
 	private const HASHED_EMAIL_SLUG = '%%HASHED_EMAIL%%';
@@ -66,11 +66,11 @@ class Tag implements Tracker {
 	private static $deferred_events = array();
 
 	/**
-	 * Initialises Tag tracker and adds hooks trackers needs to operate.
+	 * Initialises hooks some trackers need to operate.
 	 *
 	 * @return void
 	 */
-	public function __construct() {
+	public function init_hooks() {
 		add_action( 'wp_footer', array( $this, 'print_script' ) );
 		add_action( 'wp_footer', array( $this, 'print_noscript' ) );
 		add_action( 'shutdown', array( $this, 'save_deferred_events' ) );

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -71,8 +71,8 @@ class Tag implements Tracker {
 	 * @return void
 	 */
 	public function __construct() {
-		add_action( 'wp_head', array( $this, 'print_script' ) );
-		add_action( 'wp_body_open', array( $this, 'print_noscript' ), 0 );
+		add_action( 'wp_footer', array( $this, 'print_script' ) );
+		add_action( 'wp_footer', array( $this, 'print_noscript' ) );
 		add_action( 'shutdown', array( $this, 'save_deferred_events' ) );
 	}
 

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -14,7 +14,7 @@ use Throwable;
 /**
  * Interface for Pinterest tracker implementations.
  */
-interface Tracker {
+abstract class Tracker {
 
 	/**
 	 * Maps tracking events to corresponding tracker methods and conversions API events names.
@@ -30,6 +30,14 @@ interface Tracker {
 	);
 
 	/**
+	 * Initialises hooks some trackers need to operate.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+	}
+
+	/**
 	 * Tracks the event.
 	 *
 	 * @since x.x.x
@@ -41,5 +49,5 @@ interface Tracker {
 	 *
 	 * @return true
 	 */
-	public function track_event( string $event_name, Data $data );
+	abstract public function track_event( string $event_name, Data $data );
 }

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -12,6 +12,7 @@ class TagTest extends \WP_UnitTestCase {
 
 	public function test_adds_hooks() {
 		$tag = new Tag();
+		$tag->init_hooks();
 
 		$this->assertEquals( 10, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
 		$this->assertEquals( 10, has_action( 'wp_body_open', array( $tag, 'print_noscript' ) ) );

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -13,8 +13,8 @@ class TagTest extends \WP_UnitTestCase {
 	public function test_adds_hooks() {
 		$tag = new Tag();
 
-		$this->assertEquals( 0, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
-		$this->assertEquals( 0, has_action( 'wp_body_open', array( $tag, 'print_noscript' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_body_open', array( $tag, 'print_noscript' ) ) );
 		$this->assertEquals( 10, has_action( 'shutdown', array( $tag, 'save_deferred_events' ) ) );
 	}
 

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -14,8 +14,8 @@ class TagTest extends \WP_UnitTestCase {
 		$tag = new Tag();
 		$tag->init_hooks();
 
-		$this->assertEquals( 10, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_body_open', array( $tag, 'print_noscript' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tag, 'print_script' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tag, 'print_noscript' ) ) );
 		$this->assertEquals( 10, has_action( 'shutdown', array( $tag, 'save_deferred_events' ) ) );
 	}
 

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -13,7 +13,7 @@ class TagTest extends \WP_UnitTestCase {
 	public function test_adds_hooks() {
 		$tag = new Tag();
 
-		$this->assertEquals( 10, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_head', array( $tag, 'print_script' ) ) );
 		$this->assertEquals( 0, has_action( 'wp_body_open', array( $tag, 'print_noscript' ) ) );
 		$this->assertEquals( 10, has_action( 'shutdown', array( $tag, 'save_deferred_events' ) ) );
 	}

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -18,21 +18,21 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = Pinterest_For_Woocommerce::init_tracking();
 
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
 	}
 
 	function test_tracking_adds_actions_monitoring() {
 		$tracking = new Tracking();
 
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
 	}
 
 	public function test_trackers_are_empty_on_init() {

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -49,8 +49,8 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$this->assertEquals( array( Tag::class => $pinterest_tag_tracker ), $tracking->get_trackers() );
 
-		$this->assertEquals( 10, has_action( 'wp_head', array( $pinterest_tag_tracker, 'print_script' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_body_open', array( $pinterest_tag_tracker, 'print_noscript' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $pinterest_tag_tracker, 'print_script' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $pinterest_tag_tracker, 'print_noscript' ) ) );
 		$this->assertEquals( 10, has_action( 'shutdown', array( $pinterest_tag_tracker, 'save_deferred_events' ) ) );
 	}
 

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -18,21 +18,21 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = Pinterest_For_Woocommerce::init_tracking();
 
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
 	}
 
 	function test_tracking_adds_actions_monitoring() {
 		$tracking = new Tracking();
 
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
 		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
-		$this->assertEquals( 0, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
 	}
 
 	public function test_trackers_are_empty_on_init() {

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -48,6 +48,10 @@ class TrackingTest extends \WP_UnitTestCase {
 		$tracking->add_tracker( $pinterest_tag_tracker );
 
 		$this->assertEquals( array( Tag::class => $pinterest_tag_tracker ), $tracking->get_trackers() );
+
+		$this->assertEquals( 10, has_action( 'wp_head', array( $pinterest_tag_tracker, 'print_script' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_body_open', array( $pinterest_tag_tracker, 'print_noscript' ) ) );
+		$this->assertEquals( 10, has_action( 'shutdown', array( $pinterest_tag_tracker, 'save_deferred_events' ) ) );
 	}
 
 	public function test_tracker_is_removed() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #910 .

Not all Pinterest Tag events have to be deferred. Since the only event affected by WC settings is the 'Add to Cart' event - defer it and fire the others asap.

### Detailed test instructions:

Whether these are old shortcodes used for the Cart and the Checkout page or the new Block ones, both scenarios should work the same. As a prerequisite, Pinterest Tag Chrome extension to track events must be installed and used.

#### Tests with 'Redirect to the cart page after successful addition' is ON:

1. Shop page.

	- Click 'Add to Cart' next othe any product on the page.
	- Observe browser navigates to the cart page. The Add to Cart event is fired.
	- Click 'Procceed to Checkout' button.
	- At checkout page fill in all the required fields and press 'Place Order'.
	- Observe browser navigates to 'Thank You' page and 'Checkout' event is fired.

2. Product page.

	- Click 'Add to Cart' next to the product.
	- Observe 'Add to Cart' event is fired.
	- Navigate to the Cart page.
	- Click 'Procceed to Checkout' button.
	- At checkout page fill in all the required fields and press 'Place Order'.
	- Observe browser navigates to 'Thank You' page and 'Checkout' event is fired.

#### Tests with 'Redirect to the cart page after successful addition' is OFF:

1. Shop page.

	- Click 'Add to Cart' next othe any product on the page.
	- Observe the Shop page reloaded and 'Add to Cart' event fired.
	- Navigate to the Cart page.
	- Click 'Procceed to Checkout' button.
	- At checkout page fill in all the required fields and press 'Place Order'.
	- Observe browser navigates to 'Thank You' page and 'Checkout' event is fired.


2. Product page.

	- Click 'Add to Cart' next to the product.
	- Observe 'Add to Cart' event is fired.
	- Navigate to the Cart page.
	- Click 'Procceed to Checkout' button.
	- At checkout page fill in all the required fields and press 'Place Order'.
	- Observe browser navigates to 'Thank You' page and 'Checkout' event is fired.

Both cases should also work for the Product Archive page.

### Changelog entry

> Update - Defer only the 'Add to Cart' event when redirect to cart is on.
