### PR TITLE
Fixing price value for Pinterest Tag Add to Cart and Checkout events.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -85,7 +85,7 @@ class Tracking {
 				$product->get_name(),
 				wc_get_product_category_list( $product->get_id() ),
 				'brand',
-				$product->get_price(),
+				wc_get_price_to_display( $product ),
 				get_woocommerce_currency(),
 				1
 			);
@@ -134,7 +134,7 @@ class Tracking {
 			$product->get_name(),
 			wc_get_product_category_list( $product->get_id() ),
 			'brand',
-			$product->get_price(),
+			wc_get_price_to_display( $product ),
 			get_woocommerce_currency(),
 			$quantity
 		);
@@ -163,8 +163,7 @@ class Tracking {
 				continue;
 			}
 
-			$product       = $order_item->get_product();
-			$product_price = $product->get_price();
+			$product = $order_item->get_product();
 
 			$items[] = new Product(
 				uniqid( 'product' ),
@@ -172,7 +171,7 @@ class Tracking {
 				$order_item->get_name(),
 				wc_get_product_category_list( $product->get_id() ),
 				'brand',
-				$product_price,
+				wc_get_price_to_display( $product ),
 				get_woocommerce_currency(),
 				$order_item->get_quantity()
 			);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #908 .
Closes #909 .

Replacing product price with the value returned by the function, which may include taxes and is more appropriate in this case.

### Detailed test instructions:

The prerequisites are to have the Pinterest Tag extension installed for your browser so you are able to see events fired at a website. Also, for ease of test product prices must be configured to include taxes.

1. Being at `develop` branch add a product to a Cart and check the event using Pinterest Tag browser extension.
2. Observe price does not match the product price (price displayed excluding taxes, base price).
3. Checkout the Cart.
4. Observe the Checkout event includes product data with the price excluding taxes as well.
5. Checkout `fix/add-to-cart-and-checkout-event-price` branch.
6. Repeat the steps 1-5.
7. Observe Add to Cart and Checkout events are now match the price the product has on the website pages.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Pinterest Tag product price with `wc_get_price_to_display()` function. 
