### PR TITLE
CAPI calls with Ad Account ID is missing.

### DIFF
--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -266,6 +266,9 @@ class Conversions implements Tracker {
 	 */
 	private function send_request( string $event_name, array $data ) {
 		$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
+		if ( empty( $ad_account_id ) ) {
+			return;
+		}
 
 		/* translators: 1: Conversions API event name, 2: JSON encoded event data. */
 		$messages = sprintf(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #913 .

Pinterest detected some CAPI requests with missing Ad Account ID (which is a required parameter). Not sure what were the circumstances of those calls, but making sure they will never happen is Ad Account ID is missing.

### Changelog entry

> Fix - CAPI calls with empty Ad Account ID.
