### PR TITLE
Disable a tracker hooks on removal.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -284,7 +284,11 @@ class Tracking {
 		$this->trackers = array_filter(
 			$this->trackers,
 			function ( $item ) use ( $tracker ) {
-				return get_class( $item ) !== $tracker;
+				if ( get_class( $item ) === $tracker ) {
+					$item->disable_hooks();
+					return false;
+				}
+				return true;
 			}
 		);
 	}

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -66,7 +66,9 @@ class Tag extends Tracker {
 	private static $deferred_events = array();
 
 	/**
-	 * Initialises hooks some trackers need to operate.
+	 * Initialises hooks a tracker need to operate.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return void
 	 */
@@ -74,6 +76,19 @@ class Tag extends Tracker {
 		add_action( 'wp_footer', array( $this, 'print_script' ) );
 		add_action( 'wp_footer', array( $this, 'print_noscript' ) );
 		add_action( 'shutdown', array( $this, 'save_deferred_events' ) );
+	}
+
+	/**
+	 * Disables hooks a tracker could set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function disable_hooks() {
+		remove_action( 'wp_footer', array( $this, 'print_script' ) );
+		remove_action( 'wp_footer', array( $this, 'print_noscript' ) );
+		remove_action( 'shutdown', array( $this, 'save_deferred_events' ) );
 	}
 
 	/**

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -30,11 +30,23 @@ abstract class Tracker {
 	);
 
 	/**
-	 * Initialises hooks some trackers need to operate.
+	 * Initialises hooks a tracker need to operate.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return void
 	 */
 	public function init_hooks() {
+	}
+
+	/**
+	 * Disables hooks a tracker could set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function disable_hooks() {
 	}
 
 	/**

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -19,6 +19,17 @@ class TagTest extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'shutdown', array( $tag, 'save_deferred_events' ) ) );
 	}
 
+	public function test_disables_hooks() {
+		$tag = new Tag();
+		$tag->init_hooks();
+
+		$tag->disable_hooks();
+
+		$this->assertFalse( has_action( 'wp_footer', array( $tag, 'print_script' ) ) );
+		$this->assertFalse( has_action( 'wp_footer', array( $tag, 'print_noscript' ) ) );
+		$this->assertFalse( has_action( 'shutdown', array( $tag, 'save_deferred_events' ) ) );
+	}
+
 	public function test_print_script_prints_tag() {
 		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'YU9AOV86F', 'enhanced_match_support' => false ) );
 

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -65,6 +65,9 @@ class TrackingTest extends \WP_UnitTestCase {
 		$tracking->remove_tracker( Tag::class );
 
 		$this->assertEquals( array(), $tracking->get_trackers() );
+		$this->assertFalse( has_action( 'wp_footer', array( $pinterest_tag_tracker, 'print_script' ) ) );
+		$this->assertFalse( has_action( 'wp_footer', array( $pinterest_tag_tracker, 'print_noscript' ) ) );
+		$this->assertFalse( has_action( 'shutdown', array( $pinterest_tag_tracker, 'save_deferred_events' ) ) );
 	}
 
 	public function test_tracking_calls_trackers() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #915 .

The tracking system supports multiple trackers, which may or may not hook into WP/WC actions and filters. Individual trackers can be added/removed from the system. When added, a tracker may set its hooks, but when removed, no hooks get disabled. Adding disable hooks procedure on tracker removal.

### Changelog entry

> Dev - Disable tracker hooks on the tracker removal.
