### PR TITLE
Send notification email when V5 update procedure fails.

### DIFF
--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * WooCommerce Admin: Add First Product.
+ *
+ * Adds a note (type `email`) to bring the client back to the store setup flow.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Internal\Admin\Notes\MerchantEmailNotifications;
+
+/**
+ * Add_First_Product.
+ */
+class TokenExchangeFailure {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-v5-token-exchange-failure-email';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$content_lines = array(
+			'{greetings}<br/><br/>',
+			__( 'We\'re writing to notify you of a critical update to the Pinterest For WooCommerce plugin (version 1.4.0) that has recently been applied to your system. <br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'Pinterest is phasing out its V3 API, which our plugin previously utilized. The updated version 1.4.0 now supports Pinterest\'s new V5 API.<br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'To maintain the functionality of your Pinterest For WooCommerce integration, it is necessary to re-authorize the plugin with your Pinterest account. You can do this by navigating to the plugin settings in your WooCommerce dashboard and clicking on the "Get Started" button.<br/><br/> ', 'pinterest-for-woocommerce' ),
+			__( 'This step is essential to ensure uninterrupted service and access to the latest features offered by the Pinterest integration.<br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'Thank you for your immediate attention to this matter.<br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'Best regards,<br/>', 'pinterest-for-woocommerce' ),
+			__( 'The Pinterest For WooCommerce Team', 'pinterest-for-woocommerce' ),
+		);
+
+		$additional_data = array(
+			'role' => 'administrator',
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
+		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content_data( (object) $additional_data );
+		$note->set_image(
+			Pinterest_For_Woocommerce()->plugin_url() . '/assets/images/pinterest-logo.svg'
+		);
+		$note->set_type( Note::E_WC_ADMIN_NOTE_EMAIL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'pinterest-for-woocommerce-v5-update-failure-go-to-settings', __( 'Go to Pinterest Settings.', 'pinterest-for-woocommerce' ), admin_url( 'admin.php?page=wc-admin&path=/pinterest/landing' ) );
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 *
+	 * @return false|Note False if the note already exists, otherwise the Note object.
+	 */
+	public static function possibly_add_note() {
+		if ( self::note_exists() ) {
+			return false;
+		}
+
+		$note = self::get_note();
+		$note->save();
+		return $note;
+	}
+
+	/**
+	 * Send a note to the merchant tha they need to reconnect manually.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function try_sending_note_to_merchant() {
+
+		// Check if merchant emails are enabled.
+		$merchant_emails_enabled = get_option( 'woocommerce_merchant_email_notifications', 'no' ) === 'yes';
+		if ( ! $merchant_emails_enabled ) {
+			return;
+		}
+
+		// Try to add the note.
+		$note = self::possibly_add_note();
+		if ( ! $note instanceof Note ) {
+			return;
+		}
+
+		// Send the note.
+		MerchantEmailNotifications::send_merchant_notification( $note );
+		$note->set_status( 'sent' );
+		$note->save();
+	}
+}

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
-use Automattic\WooCommerce\Internal\Admin\Notes\MerchantEmailNotifications;
 
 /**
  * Add_First_Product.
@@ -27,7 +26,7 @@ class TokenExchangeFailure {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'pinterest-for-woocommerce-v5-token-exchange-failure-email-t';
+	const NOTE_NAME = 'pinterest-for-woocommerce-v5-token-exchange-failure';
 
 	/**
 	 * Get the note.
@@ -36,15 +35,10 @@ class TokenExchangeFailure {
 	 */
 	public static function get_note() {
 		$content_lines = array(
-			'{greetings}<br/><br/>',
-			__( 'We\'re writing to notify you of a critical update to the Pinterest For WooCommerce plugin (version 1.4.0) that has recently been applied to your system. <br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'There has been a critical update to the Pinterest For WooCommerce plugin (version 1.4.0) that has recently been applied to your system. <br/><br/>', 'pinterest-for-woocommerce' ),
 			__( 'Pinterest is phasing out its V3 API, which our plugin previously utilized. The updated version 1.4.0 now supports Pinterest\'s new V5 API.<br/><br/>', 'pinterest-for-woocommerce' ),
 			__( 'To maintain the functionality of your Pinterest For WooCommerce integration, it is necessary to re-authorize the plugin with your Pinterest account. You can do this by navigating to the plugin settings in your WooCommerce dashboard and clicking on the "Get Started" button.<br/><br/> ', 'pinterest-for-woocommerce' ),
 			__( 'This step is essential to ensure uninterrupted service and access to the latest features offered by the Pinterest integration.<br/><br/>', 'pinterest-for-woocommerce' ),
-			__( 'You’re receiving this email because you signed up for Store Management Insights from your WooCommerce dashboard. <br/><br/>', 'pinterest-for-woocommerce' ),
-			__( 'Thank you for your immediate attention to this matter.<br/><br/>', 'pinterest-for-woocommerce' ),
-			__( 'Best regards,<br/>', 'pinterest-for-woocommerce' ),
-			__( 'The Pinterest For WooCommerce Team', 'pinterest-for-woocommerce' ),
 		);
 
 		$additional_data = array(
@@ -55,13 +49,24 @@ class TokenExchangeFailure {
 		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
 		$note->set_content( implode( '', $content_lines ) );
 		$note->set_content_data( (object) $additional_data );
-		$note->set_image(
-			Pinterest_For_Woocommerce()->plugin_url() . '/assets/images/pinterest-logo.svg'
-		);
-		$note->set_type( Note::E_WC_ADMIN_NOTE_EMAIL );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'pinterest-for-woocommerce-v5-update-failure-go-to-settings', __( 'Go to Pinterest Settings.', 'pinterest-for-woocommerce' ), admin_url( 'admin.php?page=wc-admin&path=/pinterest/landing' ) );
+		$note->add_action(
+			'pinterest-for-woocommerce-v5-update-failure-go-to-settings',
+			__( 'Go to Pinterest Settings', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/landing' ),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true,
+			'primary'
+		);
+		$note->add_action(
+			'pinterest-for-woocommerce-v5-update-failure-dismiss',
+			__( 'Dismiss', 'pinterest-for-woocommerce' ),
+			wc_admin_url(),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false
+		);
 		return $note;
 	}
 
@@ -78,37 +83,5 @@ class TokenExchangeFailure {
 		$note = self::get_note();
 		$note->save();
 		return true;
-	}
-
-	/**
-	 * Send an email (Note) to the merchant tha they need to reconnect manually.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return void
-	 */
-	public static function maybe_send_email_to_merchant() {
-
-		// Check if merchant emails are enabled.
-		$merchant_emails_enabled = get_option( 'woocommerce_merchant_email_notifications', 'no' ) === 'yes';
-		if ( ! $merchant_emails_enabled ) {
-			return;
-		}
-
-		// Try to add the note.
-		$note_added = self::possibly_add_note();
-		if ( ! $note_added ) {
-			return;
-		}
-
-		// Make sure the class exists.
-		if ( ! class_exists( MerchantEmailNotifications::class ) ) {
-			return;
-		}
-
-		$note = self::get_note();
-		MerchantEmailNotifications::send_merchant_notification( $note );
-		$note->set_status( 'sent' );
-		$note->save();
 	}
 }

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -101,6 +101,11 @@ class TokenExchangeFailure {
 			return;
 		}
 
+		// Make sure the class exists.
+		if ( ! class_exists( MerchantEmailNotifications::class ) ) {
+			return;
+		}
+
 		$note = self::get_note();
 		MerchantEmailNotifications::send_merchant_notification( $note );
 		$note->set_status( 'sent' );

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -27,7 +27,7 @@ class TokenExchangeFailure {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'pinterest-for-woocommerce-v5-token-exchange-failure-email';
+	const NOTE_NAME = 'pinterest-for-woocommerce-v5-token-exchange-failure-email-t';
 
 	/**
 	 * Get the note.
@@ -41,6 +41,7 @@ class TokenExchangeFailure {
 			__( 'Pinterest is phasing out its V3 API, which our plugin previously utilized. The updated version 1.4.0 now supports Pinterest\'s new V5 API.<br/><br/>', 'pinterest-for-woocommerce' ),
 			__( 'To maintain the functionality of your Pinterest For WooCommerce integration, it is necessary to re-authorize the plugin with your Pinterest account. You can do this by navigating to the plugin settings in your WooCommerce dashboard and clicking on the "Get Started" button.<br/><br/> ', 'pinterest-for-woocommerce' ),
 			__( 'This step is essential to ensure uninterrupted service and access to the latest features offered by the Pinterest integration.<br/><br/>', 'pinterest-for-woocommerce' ),
+			__( 'You’re receiving this email because you signed up for Store Management Insights from your WooCommerce dashboard. <br/><br/>', 'pinterest-for-woocommerce' ),
 			__( 'Thank you for your immediate attention to this matter.<br/><br/>', 'pinterest-for-woocommerce' ),
 			__( 'Best regards,<br/>', 'pinterest-for-woocommerce' ),
 			__( 'The Pinterest For WooCommerce Team', 'pinterest-for-woocommerce' ),
@@ -76,17 +77,17 @@ class TokenExchangeFailure {
 
 		$note = self::get_note();
 		$note->save();
-		return $note;
+		return true;
 	}
 
 	/**
-	 * Send a note to the merchant tha they need to reconnect manually.
+	 * Send an email (Note) to the merchant tha they need to reconnect manually.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return void
 	 */
-	public static function try_sending_note_to_merchant() {
+	public static function maybe_send_email_to_merchant() {
 
 		// Check if merchant emails are enabled.
 		$merchant_emails_enabled = get_option( 'woocommerce_merchant_email_notifications', 'no' ) === 'yes';
@@ -95,12 +96,12 @@ class TokenExchangeFailure {
 		}
 
 		// Try to add the note.
-		$note = self::possibly_add_note();
-		if ( ! $note instanceof Note ) {
+		$note_added = self::possibly_add_note();
+		if ( ! $note_added ) {
 			return;
 		}
 
-		// Send the note.
+		$note = self::get_note();
 		MerchantEmailNotifications::send_merchant_notification( $note );
 		$note->set_status( 'sent' );
 		$note->save();

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -54,18 +54,11 @@ class TokenExchangeFailure {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'pinterest-for-woocommerce-v5-update-failure-go-to-settings',
-			__( 'Go to Pinterest Settings', 'pinterest-for-woocommerce' ),
-			admin_url( 'admin.php?page=wc-admin&path=/pinterest/landing' ),
+			__( 'Authenticate with Pinterest', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true,
 			'primary'
-		);
-		$note->add_action(
-			'pinterest-for-woocommerce-v5-update-failure-dismiss',
-			__( 'Dismiss', 'pinterest-for-woocommerce' ),
-			wc_admin_url(),
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			false
 		);
 		return $note;
 	}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -321,7 +321,7 @@ class PluginUpdate {
 
 		if ( ! $updated ) {
 			// Update failed. Send an email to the user. Informing that they need to reconnect manually.
-			TokenExchangeFailure::try_sending_note_to_merchant();
+			TokenExchangeFailure::maybe_send_email_to_merchant();
 			return;
 		}
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -320,8 +320,8 @@ class PluginUpdate {
 		$updated = TokenExchangeV3ToV5::token_update();
 
 		if ( ! $updated ) {
-			// Update failed. Send an email to the user. Informing that they need to reconnect manually.
-			TokenExchangeFailure::maybe_send_email_to_merchant();
+			// Show a warning banner to the merchant informing that they need to reconnect manually.
+			TokenExchangeFailure::possibly_add_note();
 			return;
 		}
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Pinterest\API\UserInteraction;
 use Automattic\WooCommerce\Pinterest\API\TokenExchangeV3ToV5;
+use Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure;
 use Exception;
 use Throwable;
 /**
@@ -319,6 +320,8 @@ class PluginUpdate {
 		$updated = TokenExchangeV3ToV5::token_update();
 
 		if ( ! $updated ) {
+			// Update failed. Send an email to the user. Informing that they need to reconnect manually.
+			TokenExchangeFailure::try_sending_note_to_merchant();
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This makes sure that we detect if the token update procedure has failed. And if it happens we send an email to merchant.

Closes #923  .
Closes #924


### Screenshots:

![image](https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/7040bb19-81b0-4aa6-bcc6-d80c413ecc60)


<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Modify the code so the token exchange will fail ( a typo in the url should be OK ).
Make sure that the update version option: 
[PLUGIN_UPDATE_VERSION_OPTION](https://github.com/woocommerce/pinterest-for-woocommerce/blob/8a3d40fbadd8fac3149133909fd954105bdb3f5a/src/PluginUpdate.php#L95)
is set to something pre 1.4.0.
3. Reload the site.
4. The email should be sent.




<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> No changelog necessary.
