### PR TITLE
922 retry oauth

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Pinterest\FeedRegistration;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\Logger;
 use Automattic\WooCommerce\Pinterest\Notes\MarketingNotifications;
+use Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Automattic\WooCommerce\Pinterest\Tracking;
 use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
@@ -299,6 +300,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'create_commerce_integration' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_account_data' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'update_linked_businesses' ) );
+			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'post_update_cleanup' ) );
 
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
@@ -613,6 +615,17 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function set_api_version( $version ) {
 			return update_option( PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION, $version );
+		}
+
+		/**
+		 * Get API version used by the plugin.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return string The API version.
+		 */
+		public static function get_api_version() {
+			return get_option( PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION, '' );
 		}
 
 		/**
@@ -1115,6 +1128,21 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function update_linked_businesses() {
 			self::get_linked_businesses( true );
+		}
+
+		/**
+		 * Cleanup after the token update.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		public static function post_update_cleanup() {
+			// Mark note as actioned so it will be removed from the UI in case it was added.
+			TokenExchangeFailure::possibly_action_note();
+
+			// Update completed successfully.
+			Pinterest_For_Woocommerce()::set_api_version( 'v5' );
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -1138,8 +1138,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return void
 		 */
 		public static function post_update_cleanup() {
-			// Mark note as actioned so it will be removed from the UI in case it was added.
-			TokenExchangeFailure::possibly_action_note();
+			TokenExchangeFailure::delete_failure_note();
 
 			// Update completed successfully.
 			Pinterest_For_Woocommerce()::set_api_version( 'v5' );

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -9,7 +9,6 @@
 namespace Automattic\WooCommerce\Pinterest\API;
 
 use Automattic\WooCommerce\Pinterest\Logger;
-use Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure;
 use Throwable;
 use WP_HTTP_Response;
 use WP_REST_Request;

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -8,7 +8,8 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
-use Automattic\WooCommerce\Pinterest\Logger as Logger;
+use Automattic\WooCommerce\Pinterest\Logger;
+use Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure;
 use Throwable;
 use WP_HTTP_Response;
 use WP_REST_Request;
@@ -128,6 +129,7 @@ class Auth extends VendorAPI {
 			 * @since x.x.x
 			 */
 			do_action( 'pinterest_for_woocommerce_token_saved' );
+			TokenExchangeFailure::possibly_action_note();
 		} catch ( Throwable $th ) {
 			$error = esc_html__( 'There was an error getting the account data. Please try again later.', 'pinterest-for-woocommerce' );
 			$this->log_error_and_redirect( $request, $error );

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -106,14 +106,13 @@ class Auth extends VendorAPI {
 			$this->log_error_and_redirect( $request, $error );
 		}
 
-		$token_string = base64_decode( $token_data );
+		$token_string = base64_decode( $token_data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$token_data   = (array) json_decode( urldecode( $token_string ) );
 
 		Pinterest_For_Woocommerce()::save_token_data( $token_data );
 
-		$info_string = base64_decode( $info );
+		$info_string = base64_decode( $info ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$info_data   = (array) json_decode( urldecode( $info_string ) );
-
 		$features    = (array) $info_data['feature_flags'] ?? array();
 
 		$this->apply_oauth_flow_features( $features );
@@ -129,7 +128,6 @@ class Auth extends VendorAPI {
 			 * @since x.x.x
 			 */
 			do_action( 'pinterest_for_woocommerce_token_saved' );
-			TokenExchangeFailure::possibly_action_note();
 		} catch ( Throwable $th ) {
 			$error = esc_html__( 'There was an error getting the account data. Please try again later.', 'pinterest-for-woocommerce' );
 			$this->log_error_and_redirect( $request, $error );

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\Pinterest\Notes;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
@@ -86,8 +87,9 @@ class TokenExchangeFailure {
 		if ( ! self::note_exists() ) {
 			return;
 		}
-		$note = self::get_note();
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
 		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note->set_is_read( true );
 		$note->save();
 	}
 }

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -77,7 +77,7 @@ class TokenExchangeFailure {
 	}
 
 	/**
-	 * Set note to actioned.
+	 * Delete the note.
 	 *
 	 * @since x.x.x
 	 *

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -83,13 +83,7 @@ class TokenExchangeFailure {
 	 *
 	 * @return void
 	 */
-	public static function possibly_action_note() {
-		if ( ! self::note_exists() ) {
-			return;
-		}
-		$note = Notes::get_note_by_name( self::NOTE_NAME );
-		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
-		$note->set_is_read( true );
-		$note->save();
+	public static function delete_failure_note() {
+		Notes::delete_notes_with_name( self::NOTE_NAME );
 	}
 }

--- a/src/Notes/TokenExchangeFailure.php
+++ b/src/Notes/TokenExchangeFailure.php
@@ -74,4 +74,20 @@ class TokenExchangeFailure {
 		$note->save();
 		return true;
 	}
+
+	/**
+	 * Set note to actioned.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function possibly_action_note() {
+		if ( ! self::note_exists() ) {
+			return;
+		}
+		$note = self::get_note();
+		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note->save();
+	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -314,6 +314,8 @@ class PluginUpdate {
 	 *
 	 * @since 1.4.0
 	 *
+	 * @param $args Parameteres passed via Action Scheduler call.
+	 *
 	 * @return void
 	 */
 	protected function token_update( $args = array( 'retry_count' => 3 ) ): void {
@@ -352,8 +354,7 @@ class PluginUpdate {
 		// Show a warning banner to the merchant informing that they need to reconnect manually.
 		TokenExchangeFailure::possibly_add_note();
 
-		if ( $retry_count = 0 ) {
-
+		if ( 0 == $retry_count ) {
 			// Retry count exceeded. Do not schedule another retry.
 			return;
 		}
@@ -366,6 +367,5 @@ class PluginUpdate {
 			),
 			PINTEREST_FOR_WOOCOMMERCE_PREFIX
 		);
-
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -328,6 +328,11 @@ class PluginUpdate {
 			return;
 		}
 
+		if ( 'v5' === Pinterest_For_Woocommerce()::get_api_version() ) {
+			// Plugin already updated.
+			return;
+		}
+
 		// Set API version to V3. We can use this value to detect failure in the token update procedure.
 		Pinterest_For_Woocommerce()::set_api_version( 'v3' );
 
@@ -337,12 +342,6 @@ class PluginUpdate {
 			$this->update_failure( $retry_count );
 			return;
 		}
-
-		// Mark note as actioned so it will be removed from the UI in case it was added.
-		TokenExchangeFailure::possibly_action_note();
-
-		// Update completed successfully.
-		Pinterest_For_Woocommerce()::set_api_version( 'v5' );
 	}
 
 	/**

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -354,7 +354,7 @@ class PluginUpdate {
 		// Show a warning banner to the merchant informing that they need to reconnect manually.
 		TokenExchangeFailure::possibly_add_note();
 
-		if ( 0 == $retry_count ) {
+		if ( 0 === (int) $retry_count ) {
 			// Retry count exceeded. Do not schedule another retry.
 			return;
 		}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -314,7 +314,7 @@ class PluginUpdate {
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param $args Parameteres passed via Action Scheduler call.
+	 * @param array $args Parameteres passed via Action Scheduler call.
 	 *
 	 * @return void
 	 */

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -314,7 +314,7 @@ class PluginUpdate {
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param array $args Parameteres passed via Action Scheduler call.
+	 * @param int $retry_count Parameteres passed via Action Scheduler call. Number of retries left.
 	 *
 	 * @return void
 	 */
@@ -363,7 +363,7 @@ class PluginUpdate {
 		}
 
 		as_schedule_single_action(
-			time() + MINUTE_IN_SECONDS * 5,
+			time() + MINUTE_IN_SECONDS * 5 * ( 4 - $retry_count ),
 			self::TOKEN_UPDATE_RETRY_HOOK,
 			array(
 				'retry_count' => $retry_count - 1,

--- a/uninstall.php
+++ b/uninstall.php
@@ -34,3 +34,5 @@ if ( function_exists( 'as_unschedule_all_actions' ) ) {
 	as_unschedule_all_actions( 'pinterest-for-woocommerce-feed-generation', array(), 'pinterest-for-woocommerce' );
 	as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
 }
+
+Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure::delete_failure_note();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #922 .

When token procedure fails retry 3 more times in  5, 10 and 15 minutes.

Testing:
- Connect v3 version and authenticate.
- Update with this version but use broken version ( tamper with the oauth url ).
- After the first failure happens an action for retry will be scheduled
- Replace the broken version with the working version and wait until the action gets triggered, or trigger it manually
- Verify that the token exchange worked.

