### PR TITLE
Replace 2024 coupon code.

### DIFF
--- a/src/AdCreditsCoupons.php
+++ b/src/AdCreditsCoupons.php
@@ -60,7 +60,7 @@ class AdCreditsCoupons {
 	 *
 	 * @var string
 	 */
-	public static $coupon_for_2024 = 'V09PQ09NTUVSQ0VfMTQ2ODQxNF9DUkVESVRfMjAyNA==';
+	public static $coupon_for_2024 = 'V09PQ09NTUVSQ0VfMTQ2ODQxNF9DUkVESVRfMjAyNA';
 
 	/**
 	 * Get a valid coupon for the merchant.

--- a/src/AdCreditsCoupons.php
+++ b/src/AdCreditsCoupons.php
@@ -49,18 +49,11 @@ class AdCreditsCoupons {
 	);
 
 	/**
-	 * 2023 copon code.
-	 *
-	 * @var string
-	 */
-	public static $coupon_for_2023 = 'Q09JTl9DTElFTlRfSURfMTQ2ODQxNF9DUkVESVRT';
-
-	/**
 	 * 2024 copon code.
 	 *
 	 * @var string
 	 */
-	public static $coupon_for_2024 = 'V09PQ09NTUVSQ0VfMTQ2ODQxNF9DUkVESVRfMjAyNA';
+	public static $coupon_for_2024 = '1b2c680bdf2b89eecb3384b10db2ca6a0b3824d82bbe63939b35e5720604cde4';
 
 	/**
 	 * Get a valid coupon for the merchant.
@@ -80,7 +73,7 @@ class AdCreditsCoupons {
 			return false;
 		}
 
-		return ( $current_timestamp >= $switch_timestamp ) ? self::$coupon_for_2024 : self::$coupon_for_2023;
+		return self::$coupon_for_2024;
 	}
 
 	/**

--- a/src/AdCreditsCoupons.php
+++ b/src/AdCreditsCoupons.php
@@ -64,11 +64,7 @@ class AdCreditsCoupons {
 	 * @return string|false Coupon string or false if no coupon was found.
 	 */
 	public static function get_coupon_for_merchant() {
-		$switch_date       = new DateTime( '2023-12-31 23:59:59', new DateTimeZone( 'GMT' ) );
-		$switch_timestamp  = $switch_date->getTimestamp();
-		$current_timestamp = time();
-		$currency          = get_woocommerce_currency();
-
+		$currency = get_woocommerce_currency();
 		if ( ! in_array( $currency, self::$allowed_currencies, true ) ) {
 			return false;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Pinterest API v5 does not support v3 coupon codes. 

Calls to the API with the old coupon codes provide errors in response:

![bug](https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/d82bea59-ede0-408b-8e98-915fb574c11e)

```json
{'offerCodeHash': 'V09PQ09NTUVSQ0VfMTQ2ODQxNF9DUkVESVRfMjAyNA==', 'validateOnly': False}
```

```
WOOCOMMERCE_1468414_CREDIT_2024 in SHA256 is 1b2c680bdf2b89eecb3384b10db2ca6a0b3824d82bbe63939b35e5720604cde4

wrong value passed to the API

Below are all the available hashes

TESTING_WOO_FUTURE_01 6bffa86a3034486985a1408bffb89511297c35a414c11896d073f658f6e1ec28
COIN_CLIENT_ID_1468414_CREDITS 138e9e0ff7e38cf511b880975eb574c09aa9d5e1657590ab0431040da68caa67
WOOCOMMERCE_1468414_CREDIT_2024 1b2c680bdf2b89eecb3384b10db2ca6a0b3824d82bbe63939b35e5720604cde4
```

### Changelog entry

> Fix - Replace the coupon code.
