### PR TITLE
Delete Pinterest API version during uninstall procedure.

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -28,6 +28,7 @@ if ( $plugin_settings['erase_plugin_data'] ) {
 	delete_option( 'pinterest_for_woocommerce_marketing_notifications_init_timestamp' );
 	delete_option( 'pinterest_for_woocommerce_account_connection_timestamp' );
 	delete_option( PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION );
+	delete_option( 'pinterest-for-woocommerce-update-version' );
 }
 
 if ( function_exists( 'as_unschedule_all_actions' ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,7 @@ if ( $plugin_settings['erase_plugin_data'] ) {
 	delete_option( 'pinterest_for_woocommerce_data' );
 	delete_option( 'pinterest_for_woocommerce_marketing_notifications_init_timestamp' );
 	delete_option( 'pinterest_for_woocommerce_account_connection_timestamp' );
+	delete_option( PINTEREST_FOR_WOOCOMMERCE_PINTEREST_API_VERSION );
 }
 
 if ( function_exists( 'as_unschedule_all_actions' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As requested here 

Closes #931  .

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install the plugin
2. Connect to Pinterest
3. Uninstall/delete the plugin
4. Verify that the `pinterest_for_woocommerce_pinterest_api_version` option is not in the DB.


