### PR TITLE
Use options and not transients for feed status manipulation.

### DIFF
--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -130,7 +130,7 @@ class PluginUpdate {
 			),
 			'1.4.0'  => array(
 				'token_update',
-				'feed_status_migration_1_4_0',
+				'feed_status_migration',
 			),
 		);
 	}
@@ -379,7 +379,7 @@ class PluginUpdate {
 	 * @since 1.4.0
 	 * @return void
 	 */
-	private function feed_status_migration_1_4_0(): void {
+	private function feed_status_migration(): void {
 
 		foreach ( ProductFeedStatus::STATE_PROPS as $key => $default_value ) {
 			$name  = ProductFeedStatus::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key;

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -130,6 +130,7 @@ class PluginUpdate {
 			),
 			'1.4.0'  => array(
 				'token_update',
+				'feed_status_migration_1_4_0',
 			),
 		);
 	}
@@ -369,5 +370,23 @@ class PluginUpdate {
 			),
 			PINTEREST_FOR_WOOCOMMERCE_PREFIX
 		);
+	}
+
+	/**
+	 * Feed status migration for 1.4.0.
+	 * Migrate from transients to options.
+	 *
+	 * @since 1.4.0
+	 * @return void
+	 */
+	private function feed_status_migration_1_4_0(): void {
+
+		foreach ( ProductFeedStatus::STATE_PROPS as $key => $default_value ) {
+			$name  = ProductFeedStatus::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key;
+			$value = get_transient( $name );
+			$value = ( false !== $value ) ? $value : $default_value;
+			update_option( $name, $value );
+			delete_transient( $name );
+		}
 	}
 }

--- a/src/ProductFeedStatus.php
+++ b/src/ProductFeedStatus.php
@@ -59,12 +59,10 @@ class ProductFeedStatus {
 		foreach ( self::STATE_PROPS as $key => $default_value ) {
 
 			if ( ! isset( self::$state[ $key ] ) || null === self::$state[ $key ] ) {
-				self::$state[ $key ] = get_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key );
+				self::$state[ $key ] = get_option( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key, $default_value );
 			}
 
-			if ( false === self::$state[ $key ] ) {
-				self::$state[ $key ] = $default_value;
-			} elseif ( null === self::$state[ $key ] ) {
+			if ( null === self::$state[ $key ] ) {
 				self::$state[ $key ] = false;
 			}
 		}
@@ -85,7 +83,7 @@ class ProductFeedStatus {
 
 		foreach ( $state as $key => $value ) {
 			self::$state[ $key ] = $value;
-			set_transient( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key, ( false === $value ? null : $value ) ); // No expiration.
+			update_option( self::PINTEREST_FOR_WOOCOMMERCE_FEEDS_DATA_PREFIX . $key, ( false === $value ? null : $value ) ); // No expiration.
 		}
 
 		if ( ! empty( $state['status'] ) ) {


### PR DESCRIPTION
Use options and not transients for feed status manipulation.

This is done to prevent issues with persisten object cache.

