### PR TITLE
Stop tracking on 404 and views other than page or product.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -81,8 +81,8 @@ class Tracking {
 	 * @return void
 	 */
 	public function handle_page_visit() {
-		if ( ! ( is_page() || is_product() ) ) {
-			// We are not on a page or product page. Don't track the event.
+		if ( is_404() ) {
+			// Do not track 404 pages.
 			return;
 		}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -81,6 +81,11 @@ class Tracking {
 	 * @return void
 	 */
 	public function handle_page_visit() {
+		if ( is_404() ) {
+			// Do not track 404 pages.
+			return;
+		}
+
 		$data = new None( uniqid( 'page' ) );
 		if ( is_product() ) {
 			$product = wc_get_product();

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -81,8 +81,8 @@ class Tracking {
 	 * @return void
 	 */
 	public function handle_page_visit() {
-		if ( is_404() ) {
-			// Do not track 404 pages.
+		if ( ! ( is_page() || is_product() ) ) {
+			// We are not on a page or product page. Don't track the event.
 			return;
 		}
 


### PR DESCRIPTION
Fixes: #945 

Open a 404 page and notice that page_visit should not be recorded.