### PR TITLE
AJAX Add to Cart for Blocks does not fire Pinterest Tag events.

### DIFF
--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -254,9 +254,15 @@ class Tag extends Tracker {
 		 * If the cart redirect is enabled, force add the event to the deferred events list
 		 * because if redirect is enabled, the cart page will be reloaded and the event will get lost.
 		 */
-		$is_redirect    = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
+		$is_redirect = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
+		/**
+		 * This check is made for Add to Cart when using Blocks. WP does not detect
+		 * the AJAX request in this case, so we must add the event to the deferred
+		 * list.
+		 */
+		$is_ajax = 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' );
 		$is_add_to_cart = Tracking::EVENT_ADD_TO_CART === $event_name;
-		if ( $is_redirect && $is_add_to_cart ) {
+		if ( ( $is_redirect || $is_ajax ) && $is_add_to_cart ) {
 			return static::add_deferred_event( $event_name, $data );
 		}
 

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -255,12 +255,13 @@ class Tag extends Tracker {
 		 * because if redirect is enabled, the cart page will be reloaded and the event will get lost.
 		 */
 		$is_redirect = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
+
 		/*
 		 * This check is made for Add to Cart when using Blocks. WP does not detect
 		 * the AJAX request in this case, so we must add the event to the deferred
 		 * list.
 		 */
-		$is_ajax = 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' );
+		$is_ajax        = 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' );
 		$is_add_to_cart = Tracking::EVENT_ADD_TO_CART === $event_name;
 		if ( ( $is_redirect || $is_ajax ) && $is_add_to_cart ) {
 			return static::add_deferred_event( $event_name, $data );

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -255,7 +255,7 @@ class Tag extends Tracker {
 		 * because if redirect is enabled, the cart page will be reloaded and the event will get lost.
 		 */
 		$is_redirect = 'yes' === get_option( 'woocommerce_cart_redirect_after_add' );
-		/**
+		/*
 		 * This check is made for Add to Cart when using Blocks. WP does not detect
 		 * the AJAX request in this case, so we must add the event to the deferred
 		 * list.


### PR DESCRIPTION
When /shop uses blocks to display products and `Enable AJAX add to cart buttons on archives` is set to `ON` Pinterest Tag events do not render.

<img width="883" alt="WooCommerce_settings_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/000546e9-9b2a-4091-8363-0acf591a9276">

They do try to render, but instead of appearing in the `deferred_events` queue, they fall into the `immediate_events` one. Due to the nature of REST API request Blocks use, we can not identify those as AJAX requests with `wp_doing_ajax()`, which returns `FALSE,` and even if we could, Blocks do not honor cart fragments, so we are unable to use those to fire Pinterest Tag events realtime.

To test the PR:

1. Being at `develop` branch and using Block to render your `/shop` page, with `Enable AJAX add to cart buttons on archives` set to `ON`, click 'Add to Cart' button under any of the products on the page.
2. Watch no 'Add to Cart' Pinterest Tag event is fired.
3. Refresh the page.
4. Check no 'Add to Cart' Pinterest Tag event is fired.
5. Checkout `fix/ajax-add-to-cart-on-blocks` branch.
6. Click 'Add to Cart' button under any of the products on the page.
7. Check no 'Add to Cart' Pinterest Tag event is fired. 
8. Refresh the page.
9. Check 'Add to Cart' Pinterest Tag event is fired.
10. Click `Add to Cart` on multiple products.
11. Refresh the page.
12. Check multiple 'Add to Cart' Pinterest Tag events are fired.