### PR TITLE
Log CAPI event only once on error.

### DIFF
--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -51,12 +51,20 @@ class Conversions extends Tracker {
 
 		try {
 			$this->send_request( $event_name, $data );
+
+			/* translators: 1: Conversions API event name, 2: JSON encoded event data. */
+			$messages = sprintf(
+				'Sending Pinterest Conversions API event %1$s with a payload: %2$s',
+				$event_name,
+				wp_json_encode( $data )
+			);
+			Logger::log( $messages, 'debug', 'conversions' );
 		} catch ( Throwable $e ) {
 			/* translators: 1: Conversions API event name, 2: JSON encoded event data, 3: Error code, 4: Error message. */
 			$messages = sprintf(
 				'Sending Pinterest Conversions API event %1$s with a payload %2$s has failed with the error %3$d code and %4$s message',
 				$event_name,
-				json_encode( $data ),
+				wp_json_encode( $data ),
 				$e->getCode(),
 				$e->getMessage()
 			);
@@ -296,14 +304,6 @@ class Conversions extends Tracker {
 		if ( empty( $ad_account_id ) ) {
 			return;
 		}
-
-		/* translators: 1: Conversions API event name, 2: JSON encoded event data. */
-		$messages = sprintf(
-			'Sending Pinterest Conversions API event %1$s with a payload: %2$s',
-			$event_name,
-			json_encode( $data )
-		);
-		Logger::log( $messages, 'debug', 'conversions' );
 
 		$response = APIV5::make_request(
 			"ad_accounts/{$ad_account_id}/events",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #965  .

_Replace this with a good description of your changes & reasoning._



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Compare with the following develop commit 0800c80 ( it has an error that shows this issue ) 

1. Open product category
2. Check CAPI events - there should be only one log entry ( error ) related to category view event

For the 0800c80 there should be 2 log entries: one debug and one error


