### PR TITLE
Remove category_name from view_category event.

### DIFF
--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -227,10 +227,7 @@ class Conversions extends Tracker {
 	 */
 	private function get_view_category_data( Category $data ) {
 		return array(
-			'event_id'    => $data->get_event_id(),
-			'custom_data' => array(
-				'category_name' => $data->get_name(),
-			),
+			'event_id' => $data->get_event_id(),
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removing unsupported parameter. That parameter was a copy from TAG where it is supported.

Closes #967  .

### Screenshots:

<img width="877" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/02b8d16b-f92b-4c24-b4a1-788810d6fa8e">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open category page
2. CAPI event should not be logged as error.

