### PR TITLE
Cache processing_results endpoint response

### DIFF
--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -651,7 +651,7 @@ class APIV5 extends Base {
 			'GET',
 			array(),
 			'',
-			10
+			MINUTE_IN_SECONDS
 		);
 	}
 

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -648,7 +648,10 @@ class APIV5 extends Base {
 	public static function get_feed_processing_results( $feed_id, $ad_account_id ): array {
 		return self::make_request(
 			"catalogs/feeds/{$feed_id}/processing_results?ad_account_id={$ad_account_id}&page_size=1",
-			'GET'
+			'GET',
+			array(),
+			'',
+			10
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Processing results endpoint values are used in various places in the plugin for different purposes. The values returned by the endpoint rarely changes. Therefor adding a short-lived caching should reduce the number of calls in a significant way.

Closes #964 .

1. Use instructions from #964 for verification.


