### PR TITLE
Fix refresh token response log message.

### DIFF
--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -107,8 +107,15 @@ class RefreshToken {
 		$body = trim( wp_remote_retrieve_body( $response ) );
 		$body = json_decode( $body, true );
 
-		$response['body'] = '**************';
-		self::log( $response );
+		$response['body'] = wp_json_encode(
+			array_merge(
+				$body, array(
+					'access_token' => '***** Sensitive data. *******',
+					'refresh_token' => '******* Sensitive data. *******',
+				)
+			)
+		);
+		self::log( wp_json_encode( $response ) );
 
 		if ( ! is_array( $body ) || ! isset( $body['access_token'], $body['expires_in'] ) ) {
 			return false;

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -109,8 +109,9 @@ class RefreshToken {
 
 		$response['body'] = wp_json_encode(
 			array_merge(
-				$body, array(
-					'access_token' => '***** Sensitive data. *******',
+				$body,
+				array(
+					'access_token'  => '***** Sensitive data. *******',
 					'refresh_token' => '******* Sensitive data. *******',
 				)
 			)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Before the change, the output was just the `Array`. Now, we can see some details, with security measures applied to prevent sensitive data from appearing in logs.

### Changelog entry

> Tweak - Update refresh token request's response message.
