### PR TITLE
Add Twenty Twenty-Four compatibility.

### DIFF
--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -25,7 +25,9 @@
 
 // Twenty Twenty-Four compatibility.
 .wp-block-post {
+
 	&.product {
+
 		.pinterest-for-woocommerce-image-wrapper {
 			top: unset;
 			left: unset;

--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -21,3 +21,14 @@
 		}
 	}
 }
+
+
+// Twenty Twenty-Four compatibility.
+.wp-block-post {
+	&.product {
+		.pinterest-for-woocommerce-image-wrapper {
+			top: unset;
+			left: unset;
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #973  .

The absolute positioning of the element does not work with Twenty Twenty-Four because the immediate parent is not a positioned element in this theme.

> The element is positioned relative to its closest positioned ancestor (if any) or to the initial [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block). Its final position is determined by the values of top, right, bottom, and left. 

From https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute

For this reason we need to detect the new parent `.wp-block-post.product` and unset position values. We are sill leaving the `absolute` label to keep the button stacked over the image on hover. 

### Screenshots:

<img width="283" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/3a642aeb-16c4-4972-8b18-7ed951add63b">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Switch to Twenty Twenty-Four
2. Hover over a produc
3. Pin button should be visible an clickable
4. Repeat with Storefront to confirm that there is no regression
