### PR TITLE
Fix translators strings for Error message.

### DIFF
--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -105,8 +105,8 @@ class AdvertiserConnect extends VendorAPI {
 		} catch ( Throwable $th ) {
 			throw new Exception(
 				sprintf(
-					/* translators: 1. Error message. */
-					esc_html__( 'Error: $1%s', 'pinterest-for-woocommerce' ),
+					/* translators: 1. the error message as returned by the Pinterest API */
+					esc_html__( 'Commerce integration update error: $1%s', 'pinterest-for-woocommerce' ),
 					esc_html( $th->getMessage() )
 				),
 				400

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -273,7 +273,7 @@ class Base {
 			throw new PinterestApiException(
 				sprintf(
 					/* translators: Empty error body exception. */
-					esc_html__( 'Error: $1%s', 'pinterest-for-woocommerce' ),
+					esc_html__( 'Response body processing error: $1%s', 'pinterest-for-woocommerce' ),
 					esc_html( $e->getMessage() )
 				),
 				(int) $e->getCode()


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix translator messages and make the error log message more concrete.

Closes #974 .


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. run `npm run build`
2. observer command output. 
3. create pot message should indicate that there are no translators errors:

<img width="361" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/8061fed1-869b-4752-9dbb-22e6e5f7e32f">

