### PR TITLE
Update pinit.js script import to match with Pinterest documentation

### DIFF
--- a/includes/class-pinterest-for-woocommerce-frontend-assets.php
+++ b/includes/class-pinterest-for-woocommerce-frontend-assets.php
@@ -45,9 +45,8 @@ class Pinterest_For_Woocommerce_Frontend_Assets {
 		$assets_path_url = str_replace( array( 'http:', 'https:' ), '', Pinterest_For_Woocommerce()->plugin_url() ) . '/assets/';
 		$ext             = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		wp_enqueue_script( 'pinterest-for-woocommerce-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), PINTEREST_FOR_WOOCOMMERCE_VERSION, true );
+		wp_enqueue_script( 'pinterest-for-woocommerce-pinit', '//assets.pinterest.com/js/pinit.js', array(), PINTEREST_FOR_WOOCOMMERCE_VERSION, true );
 		wp_enqueue_style( 'pinterest-for-woocommerce-pins', $assets_path_url . 'css/frontend/pinterest-for-woocommerce-pins' . $ext . '.css', array(), PINTEREST_FOR_WOOCOMMERCE_VERSION );
-
 	}
 
 
@@ -92,7 +91,7 @@ class Pinterest_For_Woocommerce_Frontend_Assets {
 		);
 
 		if ( in_array( $handle, $defer, true ) ) {
-			return '<script src="' . $src . '" defer="defer"></script>' . "\n"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript --- Not enqueuing here.
+			return '<script type="text/javascript" async defer src="' . $src . '"></script>' . "\n"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript --- Not enqueuing here.
 		}
 
 		return $tag;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/983.

In this PR, we edited the pinit.js script import code so that it matches the code provide in Pinterest documentation: https://developers.pinterest.com/docs/add-ons/save-button/.

There should be no change in functionality. Shoppers should still be able to see the Pinterest Save button in product images, and clicking on the button should open a popup window to save the product image on Pinterest.

The script import code would become like this: 

```html
<script type="text/javascript" async defer src="//assets.pinterest.com/js/pinit.js?ver=1.4.0"></script>
```

The only thing that is different from Pinterest documentation is the `?ver=1.4.0` at the end of the `src` attribute. We are keeping it as a cache busting technique.

Note: this PR is using the `develop` branch as the base branch, with plugin version 1.4.0 which contains the Pinterest v5 API.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the shop page, or a product page. 
2. Go to "view source" for the page.
3. Verify that the pinit.js script is included in the page like this:

```html
<script type="text/javascript" async defer src="//assets.pinterest.com/js/pinit.js?ver=1.4.0"></script>
```

4. Verify that the Pinterest Save button still works the same. Clicking on the button should open a popup window to save the product image on Pinterest.
