### PR TITLE
Fix tooltip UI issue in Settings page

### DIFF
--- a/assets/source/setup-guide/app/components/SyncSettings/index.js
+++ b/assets/source/setup-guide/app/components/SyncSettings/index.js
@@ -100,8 +100,6 @@ const SyncSettings = () => {
 				'Sync to get latest settings from Pinterest Ads Manager',
 				'pinterest-for-woocommerce'
 			) }
-			showTooltip={ true }
-			tooltipPosition="top center"
 		>
 			{ __( 'Sync', 'pinterest-for-woocommerce' ) }
 		</Button>

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -283,7 +283,7 @@ $root: ".woocommerce-setup-guide";
 						background: unset;
 						padding: 0;
 
-					.components-popover__content {
+						.components-popover__content {
 							background: #000;
 							border-radius: 2px;
 							border-width: 0;
@@ -295,16 +295,16 @@ $root: ".woocommerce-setup-guide";
 							padding: 4px 8px;
 							text-align: center;
 
-						width: 180px;
-						white-space: normal;
-						text-align: left;
+							width: 180px;
+							white-space: normal;
+							text-align: left;
 
-						/*
-						`font-family` is overwritten when using
-						dashicon as the hovering anchor.
-						 */
-						font-family: $default-font;
-					}
+							/*
+							`font-family` is overwritten when using
+							dashicon as the hovering anchor.
+							*/
+							font-family: $default-font;
+						}
 					}
 				}
 

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -279,6 +279,7 @@ $root: ".woocommerce-setup-guide";
 				}
 
 				&__setup-pins {
+
 					.components-tooltip {
 						background: unset;
 						padding: 0;
@@ -293,7 +294,6 @@ $root: ".woocommerce-setup-guide";
 							line-height: 1.4;
 							outline: none;
 							padding: 4px 8px;
-							text-align: center;
 
 							width: 180px;
 							white-space: normal;

--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -279,8 +279,22 @@ $root: ".woocommerce-setup-guide";
 				}
 
 				&__setup-pins {
+					.components-tooltip {
+						background: unset;
+						padding: 0;
 
 					.components-popover__content {
+							background: #000;
+							border-radius: 2px;
+							border-width: 0;
+							box-shadow: none;
+							color: #f0f0f0;
+							font-size: 12px;
+							line-height: 1.4;
+							outline: none;
+							padding: 4px 8px;
+							text-align: center;
+
 						width: 180px;
 						white-space: normal;
 						text-align: left;
@@ -291,7 +305,7 @@ $root: ".woocommerce-setup-guide";
 						 */
 						font-family: $default-font;
 					}
-
+					}
 				}
 
 				&__setup-account {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/985.

In this PR, we fix the tooltip UI issue in Settings page. The code fix is based on tooltip code from WordPress 6.3.

I have also removed the tooltip for the "Sync" button at the top of the page, because I couldn't find an easy fix for it, and the help text does not seem to be really helpful as the "Sync" button is quite self explanatory.

### Screenshots:

<img width="488" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/417342/bd45dfe7-a006-410e-b090-bd17cca22661">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Settings page: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`
2. Hover your mouse cursor over the "Sync" link button at the top of the page. There should be no tooltip help text displayed.
3. Hover your mouse cursor over the "?" tooltip icon.
4. The tooltip help text should be displayed in a popover. The text should be readable.
