### PR TITLE
Removing unused `feature_flags` key from connection info data.

### DIFF
--- a/src/API/TokenExchangeV3ToV5.php
+++ b/src/API/TokenExchangeV3ToV5.php
@@ -102,11 +102,6 @@ class TokenExchangeV3ToV5 extends APIV5 {
 			'advertiser_id' => Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' ),
 			'tag_id'        => Pinterest_For_WooCommerce()::get_setting( 'tracking_tag' ),
 			'merchant_id'   => Pinterest_For_Woocommerce()::get_data( 'merchant_id' ),
-			'feature_flags' => array(
-				'tags'    => true,
-				'CAPI'    => true,
-				'catalog' => true,
-			),
 		);
 		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removing unused connection info data `feature_flags` key. 
Does not affect anything since tracking switch is stored at another options key, and CAPI feature flag is not used anywhere.

### Changelog entry

> Tweak - Remove `feature_flag` connection info data key.
