### PR TITLE
Update/error cases handling for discounts

### DIFF
--- a/src/API/AdvertiserConnect.php
+++ b/src/API/AdvertiserConnect.php
@@ -114,7 +114,7 @@ class AdvertiserConnect extends VendorAPI {
 		}
 
 		// At this stage we can check if the connected advertiser has billing setup.
-		$has_billing = Pinterest_For_Woocommerce::add_billing_setup_info_to_account_data();
+		$has_billing = Pinterest_For_Woocommerce::update_billing_information();
 
 		/*
 		 * If the advertiser does not have a correct billing lets check for the setup frequently for the next hour.

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -246,14 +246,13 @@ class AdCredits {
 			return false;
 		}
 
-		$advertiser_id = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
+		$advertiser_id      = Pinterest_For_Woocommerce()::get_setting( 'tracking_advertiser' );
+		$discounts          = APIV5::get_ads_credit_discounts( $advertiser_id )['items'] ?? array();
+		$coupon             = AdCreditsCoupons::get_coupon_for_merchant();
+		$remaining_discount = 0;
+		$found_discounts    = array();
 
-		$result = APIV5::get_ads_credit_discounts( $advertiser_id );
-
-		$coupon                   = AdCreditsCoupons::get_coupon_for_merchant();
-		$remaining_discount_value = 0;
-		$found_discounts          = array();
-		foreach ( $result as $discount ) {
+		foreach ( $discounts as $discount ) {
 			if ( ! $discount['active'] ) {
 				continue;
 			}
@@ -263,12 +262,12 @@ class AdCredits {
 					$found_discounts['future_discount'] = true;
 				}
 			} elseif ( static::MARKETING_OFFER_CREDIT === $discount['discount_type'] ) {
-				$remaining_discount_value += (float) $discount['remaining_discount_in_micro_currency'] / 1000000;
+				$remaining_discount += (float) $discount['remaining_discount_in_micro_currency'] / 1000000;
 			}
 		}
 
 		$found_discounts['marketing_offer'] = array(
-			'remaining_discount' => wc_price( $remaining_discount_value ),
+			'remaining_discount' => wc_price( $remaining_discount ),
 		);
 
 		return $found_discounts;

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -9,7 +9,7 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\API\APIV5;
-use Automattic\WooCommerce\Pinterest\API\Base;
+use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Exception;
 use Pinterest_For_Woocommerce;
 use Pinterest_For_Woocommerce_Ads_Supported_Countries;
@@ -237,7 +237,9 @@ class AdCredits {
 	 * Fetch data from the discount endpoint and get the necessary fields.
 	 *
 	 * @since 1.2.5
+	 * @since x.x.x
 	 *
+	 * @throws PinterestApiException Originating from get_coupon_for_merchant.
 	 * @return mixed False when no info is available, discounts object when discounts are available.
 	 */
 	public static function process_available_discounts() {

--- a/src/Billing.php
+++ b/src/Billing.php
@@ -41,7 +41,7 @@ class Billing {
 	 */
 	public static function handle_billing_setup_check() {
 
-		Pinterest_For_Woocommerce()::add_billing_setup_info_to_account_data();
+		Pinterest_For_Woocommerce()::update_billing_information();
 
 		return true;
 	}

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -20,12 +20,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PinterestApiException extends \Exception {
 
 	/**
-	 * Merchant not found during the API call. API response message:
+	 * Merchant not found during the API call.
+	 *
+	 * API response message:
 	 * "Sorry! We couldn't find that merchant. Please ensure you have access and a valid merchant id."
 	 *
 	 * @var int MERCHANT_NOT_FOUND Error code for merchant not found API error.
 	 */
 	public const MERCHANT_NOT_FOUND = 650;
+
+
+	/**
+	 * The Ads Credit offer was already redeemed.
+	 *
+	 * API response message:
+	 * "The offer has already been redeemed by this advertiser"
+	 *
+	 * @var int OFFER_ALREADY_REDEEMED Error code for offer already redeemed API error.
+	 */
+	public const OFFER_ALREADY_REDEEMED = 2324;
+
+
+	/**
+	 * No valid billing setup.
+	 *
+	 * API response message:
+	 * "Billing setup is required for getting offer codes for an Advertiser"
+	 */
+	public const NO_VALID_BILLING_SETUP = 4374;
+
+
+	/**
+	 * Offer already redeemed by another advertiser.
+	 *
+	 * API response message:
+	 * "User has this offer on another advertiser"
+	 */
+	public const OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER = 2318;
 
 	/**
 	 * Holds the specific Pinterest error code, which is useful in addition to the response code.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #991
Closes #990

1. A small refactor was performed. `check_if_coupon_was_redeemed` was moved to `AdCredits` where it should be.
2. API error codes have beed added as constants to the error class.
3. add_billing_setup_info_to_account_data has been split into two separate methods that allows setting the billing status separately from fetching it from API.
4. `redeem_credits` method now correctly catches error codes.
5. If `redeem_credits` encounters billing setup error it invalidates the billing setup information which will block coupon redemption attempts until the daily action detects that the billing setup was fixed.
6. Detection of already redeemed coupon by another advertiser has been added.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

On a setup with no valid billing setup, and no previously redeemed credit:
1. Mock the billing setup stored value to true. One can trigger manually `Pinterest_For_Woocommerce()::add_billing_setup_status_to_account_data( true )` this will make the plugin believe that the billing setup is OK.
2. Trigger hourly action to start the coupon redeme process. redeeme attempt should be visible in logs and it should fail.
3. Check options for billing status - it should be switched to false.
4. Trigger hourly action again - this time redeem attempt should not happen.
