### PR TITLE
Removing mandatory condition on tracking.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -1345,7 +1345,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return boolean
 		 */
 		public static function is_setup_complete() {
-			return self::is_business_connected() && self::is_domain_verified() && self::is_tracking_configured();
+			return self::is_business_connected() && self::is_domain_verified();
 		}
 
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -11,9 +11,7 @@ namespace Automattic\WooCommerce\Pinterest;
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-use \Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler as ActionSchedulerProxy;
-use Automattic\WooCommerce\Pinterest\FeedRegistration;
-use Automattic\WooCommerce\Pinterest\API\FeedIssues;
+use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler as ActionSchedulerProxy;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 
 /**
@@ -136,11 +134,9 @@ class ProductSync {
 	 * @return boolean
 	 */
 	public static function is_product_sync_enabled() {
-
 		$domain_verified  = Pinterest_For_Woocommerce()::is_domain_verified();
-		$tracking_enabled = $domain_verified && Pinterest_For_Woocommerce()::is_tracking_configured();
 
-		return (bool) $domain_verified && $tracking_enabled && Pinterest_For_Woocommerce()::get_setting( 'product_sync_enabled' );
+		return (bool) $domain_verified && Pinterest_For_Woocommerce()::get_setting( 'product_sync_enabled' );
 	}
 
 	/**

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -134,7 +134,7 @@ class ProductSync {
 	 * @return boolean
 	 */
 	public static function is_product_sync_enabled() {
-		$domain_verified  = Pinterest_For_Woocommerce()::is_domain_verified();
+		$domain_verified = Pinterest_For_Woocommerce()::is_domain_verified();
 
 		return (bool) $domain_verified && Pinterest_For_Woocommerce()::get_setting( 'product_sync_enabled' );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The New Pinterest Connection Wizard has Tag as an optional step that can be skipped. Compared to the old plugin version (v3 API), where Tag was a mandatory condition to pass the Connection Wizard, the current implementation does not require it to function. However, some application bits check for Tag to be present to sync the catalog and slow landing page. 

Removing Tag presence as a mandatory condition to pass the landing page and enable product sync. 

The symptoms of this are after successfully connecting to Pinterest (with the Tag step skipped), you are faced with a landing page instead of the connection page and the Catalog tab saying, "Product sync is disabled." 

#### Landing Page

<img width="1814" alt="Pinterest_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/ad0c6471-65bb-424b-a650-8d5f1c111ca8">

After the "Get started" button is clicked, you actually see the connected user account information.

<img width="1814" alt="Onboarding_Guide_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/79542cfd-4e73-48cd-8f27-5bbaf775d81a">

#### Product Sync

<img width="1160" alt="Products_Catalog_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/5424c1bc-93c6-4e19-a5e2-5143068e996b">

When the Catalog and the Feed are actually present.

<img width="1814" alt="Pinterest" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/20d21d05-d159-4da3-bfbf-577c7db0e1bb">

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Removing Tag ID mandatory condition.