### PR TITLE
Adding Advertiser ID missing exception.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -913,11 +913,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		/**
 		 * Connects WC to Pinterest.
 		 *
+		 * @return array the result of APIV5::create_commerce_integration.
+		 * @throws Exception In case of 404, 409 and 500 errors from Pinterest.*@throws Exception
+		 * @see Pinterest\API\APIV5::create_commerce_integration
 		 * @since 1.4.0
 		 *
-		 * @see Pinterest\API\APIV5::create_commerce_integration
-		 * @return array the result of APIV5::create_commerce_integration.
-		 * @throws PinterestApiException In case of 404, 409 and 500 errors from Pinterest.
 		 */
 		public static function create_commerce_integration(): array {
 			global $wp_version;
@@ -925,7 +925,19 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			$external_business_id = self::generate_external_business_id();
 			$connection_data      = self::get_data( 'connection_info_data', true );
 
-			$integration_data     = array(
+			// It does not make any sense to create integration without Advertiser ID.
+			if ( empty( $connection_data['advertiser_id'] ) ) {
+				throw new Exception(
+					sprintf(
+						esc_html__(
+							'Commerce Integration cannot be created: Advertiser ID is missing.',
+							'pinterest-for-woocommerce'
+						)
+					)
+				);
+			}
+
+			$integration_data = array(
 				'external_business_id'    => $external_business_id,
 				'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
 				'connected_advertiser_id' => $connection_data['advertiser_id'] ?? '',

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -914,10 +914,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * Connects WC to Pinterest.
 		 *
 		 * @return array the result of APIV5::create_commerce_integration.
-		 * @throws Exception In case of 404, 409 and 500 errors from Pinterest.*@throws Exception
+		 * @throws Exception In case of 404, 409 and 500 errors from Pinterest.
 		 * @see Pinterest\API\APIV5::create_commerce_integration
 		 * @since 1.4.0
-		 *
 		 */
 		public static function create_commerce_integration(): array {
 			global $wp_version;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #989 

Commerce Integration without an Advertiser ID does not make sense. However, Pinterest API documentation does not require an Advertiser ID when creating an integration. I am adding an exception if the Advertiser ID is empty.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Adding Advertiser ID exception.
