### PR TITLE
Adding missing Order ID into `custom_data` array for Checkout CAPI event.

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -156,7 +156,7 @@ class Tracking {
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param string $order_id - WooCommerce order id.
+	 * @param string $order_id WooCommerce order id.
 	 *
 	 * @return void
 	 */
@@ -191,7 +191,7 @@ class Tracking {
 
 		$data = new Checkout(
 			uniqid( 'checkout' ),
-			$order_id,
+			(string) $order->get_id(),
 			$order->get_total(),
 			$total_quantity,
 			$order->get_currency(),

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -50,8 +50,6 @@ class Conversions extends Tracker {
 		$data = $this->prepare_request_data( $event_name, $data );
 
 		try {
-			$this->send_request( $event_name, $data );
-
 			/* translators: 1: Conversions API event name, 2: JSON encoded event data. */
 			$messages = sprintf(
 				'Sending Pinterest Conversions API event %1$s with a payload: %2$s',
@@ -59,6 +57,8 @@ class Conversions extends Tracker {
 				wp_json_encode( $data )
 			);
 			Logger::log( $messages, 'debug', 'conversions' );
+
+			$this->send_request( $event_name, $data );
 		} catch ( Throwable $e ) {
 			/* translators: 1: Conversions API event name, 2: JSON encoded event data, 3: Error code, 4: Error message. */
 			$messages = sprintf(
@@ -145,6 +145,7 @@ class Conversions extends Tracker {
 		return array(
 			'event_id'    => $data->get_event_id(),
 			'custom_data' => array(
+				'order_id'    => (string) $data->get_order_id(),
 				'currency'    => $data->get_currency(),
 				'value'       => (string) $data->get_price(),
 				'content_ids' => array_map(

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -50,6 +50,8 @@ class Conversions extends Tracker {
 		$data = $this->prepare_request_data( $event_name, $data );
 
 		try {
+			$this->send_request( $event_name, $data );
+
 			/* translators: 1: Conversions API event name, 2: JSON encoded event data. */
 			$messages = sprintf(
 				'Sending Pinterest Conversions API event %1$s with a payload: %2$s',
@@ -57,8 +59,6 @@ class Conversions extends Tracker {
 				wp_json_encode( $data )
 			);
 			Logger::log( $messages, 'debug', 'conversions' );
-
-			$this->send_request( $event_name, $data );
 		} catch ( Throwable $e ) {
 			/* translators: 1: Conversions API event name, 2: JSON encoded event data, 3: Error code, 4: Error message. */
 			$messages = sprintf(

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -116,6 +116,7 @@ class ConversionsTest extends WP_UnitTestCase {
 					'client_user_agent' => 'Some user agent string.',
 				),
 				'custom_data'      => array(
+					'order_id'    => '1234567890',
 					'currency'    => 'USD',
 					'value'       => '29.97',
 					'content_ids' => array( 1, 2, 3 ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Pinterest reported Order ID is missing from Checkout CAPI events.
Adding Order ID into the `custom_data` event data array.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add Order ID into Checkout CAPI event.
