### PR TITLE
Add billing status info in the Settings UI

### DIFF
--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Spinner } from '@woocommerce/components';
+import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
+import {
+	Button,
+	CardBody,
+	Flex,
+	FlexItem,
+	FlexBlock,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
+} from '@wordpress/components';
+
+
+/**
+ * Clicking on "Connect" Pinterest account button.
+ *
+ * @event wcadmin_pfw_account_connect_button_click
+ */
+/**
+ * Clicking on "Disconnect" Pinterest account button.
+ *
+ * @event wcadmin_pfw_account_disconnect_button_click
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
+ */
+/**
+ * Opening a modal.
+ *
+ * @event wcadmin_pfw_modal_open
+ * @property {string} name Which modal is it?
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
+ */
+/**
+ * Closing a modal.
+ *
+ * @event wcadmin_pfw_modal_closed
+ * @property {string} name Which modal is it?
+ * @property {string} context `'settings' | 'wizard'` In which context it was used?
+ * @property {string} action
+ * 				`confirm` - When the final "Yes, I'm sure" button is clicked.
+ * 				`dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
+ */
+
+/**
+ * Pinterest account connection component.
+ *
+ * This renders the body of `SetupAccount` card, to connect or disconnect Pinterest account.
+ *
+ * @fires wcadmin_pfw_account_connect_button_click
+ * @fires wcadmin_pfw_account_disconnect_button_click with the given `{ context }`
+ * @fires wcadmin_pfw_modal_open with `{ name: 'account-disconnection', … }`
+ * @fires wcadmin_pfw_modal_closed with `{ name: 'account-disconnection', … }`
+ * @param {Object} props React props.
+ * @param {boolean} props.isConnected
+ * @param {Function} props.setIsConnected
+ * @param {Object} props.accountData
+ * @param {string} props.context Context in which the component is used, to be forwarded to fired Track Events.
+ * @return {JSX.Element} Rendered element.
+ */
+const Billing = ( {
+	accountData,
+} ) => {
+
+	const isBillingSetup = accountData?.is_billing_setup;
+
+	return (
+		<CardBody size="large">
+			<Flex direction="row" className="billing-info">
+				{ isBillingSetup === true ? ( // eslint-disable-line no-nested-ternary --- Code is reasonable readable
+					<>
+						<FlexBlock className="billing-label">
+							<Text variant="body">
+								{ __(
+									'Billing Setup Correctly',
+									'pinterest-for-woocommerce'
+								) }
+							</Text>
+						</FlexBlock>
+
+						<FlexItem>
+							<Button
+								href={
+									wcSettings.pinterest_for_woocommerce
+										.billingSettingsUrl
+								}
+								onClick={ () =>
+									recordEvent(
+										'pfw_go_to_billing_button_click'
+									)
+								}
+							>
+								{ __( 'Go to billing settings', 'pinterest-for-woocommerce' ) }
+							</Button>
+						</FlexItem>
+					</>
+				) : isBillingSetup === false ? (
+					<>
+						<FlexBlock>
+							<Text variant="body">
+								{ __(
+									'No Valid Billing Setup Found',
+									'pinterest-for-woocommerce'
+								) }
+							</Text>
+						</FlexBlock>
+
+						<FlexItem>
+							<Button
+								href={
+									wcSettings.pinterest_for_woocommerce
+										.billingSettingsUrl
+								}
+								onClick={ () =>
+									recordEvent(
+										'pfw_billing_setup_button_click'
+									)
+								}
+							>
+								{ __( 'Setup Billing', 'pinterest-for-woocommerce' ) }
+							</Button>
+						</FlexItem>
+					</>
+				) : (
+					<Spinner className="connection-info__preloader" />
+				) }
+			</Flex>
+		</CardBody>
+	);
+};
+
+export default Billing;

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -58,7 +58,7 @@ const Billing = ( { accountData } ) => {
 
 				<FlexItem>
 					<Button
-						variant="link"
+						isLink
 						href={
 							wcSettings.pinterest_for_woocommerce
 								.billingSettingsUrl

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -33,14 +33,13 @@ import { useSettingsSelect } from '../../helpers/effects';
  */
 
 const Billing = () => {
-
 	const isBillingSetup = useSettingsSelect()?.account_data?.is_billing_setup;
 	const statusLabe = classnames( 'pfw-billing-info', {
 		'pfw-billing-info--status-success': isBillingSetup === true,
 		'pfw-billing-info--status-error': isBillingSetup === false,
 	} );
 
-	const getElement = ( ) => {
+	const getElement = () => {
 		if ( isBillingSetup === undefined ) {
 			return <Spinner className="pfw-billing-info__preloader" />;
 		}
@@ -48,33 +47,33 @@ const Billing = () => {
 		if ( isBillingSetup === true ) {
 			return (
 				<>
-				<FlexBlock className={ statusLabe }>
-					<Text variant="body">
-						{ __(
-							'Billing Setup Correctly',
-							'pinterest-for-woocommerce'
-						) }
-					</Text>
-				</FlexBlock>
+					<FlexBlock className={ statusLabe }>
+						<Text variant="body">
+							{ __(
+								'Billing Setup Correctly',
+								'pinterest-for-woocommerce'
+							) }
+						</Text>
+					</FlexBlock>
 
-				<FlexItem>
-					<Button
-						isLink
-						href={
-							wcSettings.pinterest_for_woocommerce
-								.billingSettingsUrl
-						}
-						onClick={ () =>
-							recordEvent( 'pfw_go_to_billing_button_click' )
-						}
-					>
-						{ __(
-							'Go to billing settings',
-							'pinterest-for-woocommerce'
-						) }
-					</Button>
-				</FlexItem>
-			</>
+					<FlexItem>
+						<Button
+							isLink
+							href={
+								wcSettings.pinterest_for_woocommerce
+									.billingSettingsUrl
+							}
+							onClick={ () =>
+								recordEvent( 'pfw_go_to_billing_button_click' )
+							}
+						>
+							{ __(
+								'Go to billing settings',
+								'pinterest-for-woocommerce'
+							) }
+						</Button>
+					</FlexItem>
+				</>
 			);
 		}
 

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -34,10 +34,6 @@ import { useSettingsSelect } from '../../helpers/effects';
 
 const Billing = () => {
 	const isBillingSetup = useSettingsSelect()?.account_data?.is_billing_setup;
-	const statusLabe = classnames( 'pfw-billing-info', {
-		'pfw-billing-info--status-success': isBillingSetup === true,
-		'pfw-billing-info--status-error': isBillingSetup === false,
-	} );
 
 	const getElement = () => {
 		if ( isBillingSetup === undefined ) {
@@ -47,7 +43,7 @@ const Billing = () => {
 		if ( isBillingSetup === true ) {
 			return (
 				<>
-					<FlexBlock className={ statusLabe }>
+					<FlexBlock className='pfw-billing-info--status-success'>
 						<Text variant="body">
 							{ __(
 								'Billing Setup Correctly',
@@ -79,7 +75,7 @@ const Billing = () => {
 
 		return (
 			<>
-				<FlexBlock className={ statusLabe }>
+				<FlexBlock className='pfw-billing-info--status-error'>
 					<Text variant="body">
 						{ __(
 							'No Valid Billing Setup Found',

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@woocommerce/components';
-import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
@@ -16,64 +14,43 @@ import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 
 /**
- * Clicking on "Connect" Pinterest account button.
+ * Clicking on "Setup Billing" button.
  *
- * @event wcadmin_pfw_account_connect_button_click
- */
-/**
- * Clicking on "Disconnect" Pinterest account button.
- *
- * @event wcadmin_pfw_account_disconnect_button_click
- * @property {string} context `'settings' | 'wizard'` In which context it was used?
- */
-/**
- * Opening a modal.
- *
- * @event wcadmin_pfw_modal_open
- * @property {string} name Which modal is it?
- * @property {string} context `'settings' | 'wizard'` In which context it was used?
- */
-/**
- * Closing a modal.
- *
- * @event wcadmin_pfw_modal_closed
- * @property {string} name Which modal is it?
- * @property {string} context `'settings' | 'wizard'` In which context it was used?
- * @property {string} action
- * 				`confirm` - When the final "Yes, I'm sure" button is clicked.
- * 				`dismiss` -  When the modal is dismissed by clicking on "x", "cancel", overlay, or by pressing a keystroke.
+ * @event wcadmin_pfw_billing_setup_button_click
  */
 
 /**
- * Pinterest account connection component.
+ * Clicking on "Go to billing settings" button.
  *
- * This renders the body of `SetupAccount` card, to connect or disconnect Pinterest account.
- *
- * @fires wcadmin_pfw_account_connect_button_click
- * @fires wcadmin_pfw_account_disconnect_button_click with the given `{ context }`
- * @fires wcadmin_pfw_modal_open with `{ name: 'account-disconnection', … }`
- * @fires wcadmin_pfw_modal_closed with `{ name: 'account-disconnection', … }`
- * @param {Object} props React props.
- * @param {boolean} props.isConnected
- * @param {Function} props.setIsConnected
- * @param {Object} props.accountData
- * @param {string} props.context Context in which the component is used, to be forwarded to fired Track Events.
- * @return {JSX.Element} Rendered element.
+ * @event wcadmin_pfw_go_to_billing_button_click
  */
+
 const Billing = ( {
 	accountData,
 } ) => {
 
 	const isBillingSetup = accountData?.is_billing_setup;
+	const statusLabe = classnames(
+		'pfw-billing-info',
+		{
+			'pfw-billing-info--status-success': isBillingSetup === true,
+			'pfw-billing-info--status-error': isBillingSetup === false,
+		}
+	);
 
 	return (
 		<CardBody size="large">
-			<Flex direction="row" className="billing-info">
-				{ isBillingSetup === true ? ( // eslint-disable-line no-nested-ternary --- Code is reasonable readable
+			<Flex direction="row" className="pfw-billing-info">
+				{ isBillingSetup === true ? (
 					<>
-						<FlexBlock className="billing-label">
+						<FlexBlock className={statusLabe}>
 							<Text variant="body">
 								{ __(
 									'Billing Setup Correctly',
@@ -84,6 +61,7 @@ const Billing = ( {
 
 						<FlexItem>
 							<Button
+								variant='link'
 								href={
 									wcSettings.pinterest_for_woocommerce
 										.billingSettingsUrl
@@ -100,7 +78,7 @@ const Billing = ( {
 					</>
 				) : isBillingSetup === false ? (
 					<>
-						<FlexBlock>
+						<FlexBlock className={statusLabe}>
 							<Text variant="body">
 								{ __(
 									'No Valid Billing Setup Found',
@@ -111,6 +89,7 @@ const Billing = ( {
 
 						<FlexItem>
 							<Button
+								variant='primary'
 								href={
 									wcSettings.pinterest_for_woocommerce
 										.billingSettingsUrl
@@ -126,7 +105,7 @@ const Billing = ( {
 						</FlexItem>
 					</>
 				) : (
-					<Spinner className="connection-info__preloader" />
+					<Spinner className="billing-info__preloader" />
 				) }
 			</Flex>
 		</CardBody>

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -19,7 +19,6 @@ import {
  */
 import './style.scss';
 
-
 /**
  * Clicking on "Setup Billing" button.
  *
@@ -32,81 +31,86 @@ import './style.scss';
  * @event wcadmin_pfw_go_to_billing_button_click
  */
 
-const Billing = ( {
-	accountData,
-} ) => {
-
+const Billing = ( { accountData } ) => {
 	const isBillingSetup = accountData?.is_billing_setup;
-	const statusLabe = classnames(
-		'pfw-billing-info',
-		{
-			'pfw-billing-info--status-success': isBillingSetup === true,
-			'pfw-billing-info--status-error': isBillingSetup === false,
-		}
-	);
+	const statusLabe = classnames( 'pfw-billing-info', {
+		'pfw-billing-info--status-success': isBillingSetup === true,
+		'pfw-billing-info--status-error': isBillingSetup === false,
+	} );
+
+	let element = null;
+
+	if ( isBillingSetup === undefined ) {
+		element = <Spinner className="billing-info__preloader" />;
+	}
+
+	if ( isBillingSetup === true ) {
+		element = (
+			<>
+				<FlexBlock className={ statusLabe }>
+					<Text variant="body">
+						{ __(
+							'Billing Setup Correctly',
+							'pinterest-for-woocommerce'
+						) }
+					</Text>
+				</FlexBlock>
+
+				<FlexItem>
+					<Button
+						variant="link"
+						href={
+							wcSettings.pinterest_for_woocommerce
+								.billingSettingsUrl
+						}
+						onClick={ () =>
+							recordEvent( 'pfw_go_to_billing_button_click' )
+						}
+					>
+						{ __(
+							'Go to billing settings',
+							'pinterest-for-woocommerce'
+						) }
+					</Button>
+				</FlexItem>
+			</>
+		);
+	}
+
+	if ( isBillingSetup === false ) {
+		element = (
+			<>
+				<FlexBlock className={ statusLabe }>
+					<Text variant="body">
+						{ __(
+							'No Valid Billing Setup Found',
+							'pinterest-for-woocommerce'
+						) }
+					</Text>
+				</FlexBlock>
+
+				<FlexItem>
+					<Button
+						variant="primary"
+						href={
+							wcSettings.pinterest_for_woocommerce
+								.billingSettingsUrl
+						}
+						onClick={ () =>
+							recordEvent( 'pfw_billing_setup_button_click' )
+						}
+					>
+						{ __( 'Setup Billing', 'pinterest-for-woocommerce' ) }
+					</Button>
+				</FlexItem>
+			</>
+		);
+	}
 
 	return (
 		<CardBody size="large">
 			<Flex direction="row" className="pfw-billing-info">
-				{ isBillingSetup === true ? (
-					<>
-						<FlexBlock className={statusLabe}>
-							<Text variant="body">
-								{ __(
-									'Billing Setup Correctly',
-									'pinterest-for-woocommerce'
-								) }
-							</Text>
-						</FlexBlock>
-
-						<FlexItem>
-							<Button
-								variant='link'
-								href={
-									wcSettings.pinterest_for_woocommerce
-										.billingSettingsUrl
-								}
-								onClick={ () =>
-									recordEvent(
-										'pfw_go_to_billing_button_click'
-									)
-								}
-							>
-								{ __( 'Go to billing settings', 'pinterest-for-woocommerce' ) }
-							</Button>
-						</FlexItem>
-					</>
-				) : isBillingSetup === false ? (
-					<>
-						<FlexBlock className={statusLabe}>
-							<Text variant="body">
-								{ __(
-									'No Valid Billing Setup Found',
-									'pinterest-for-woocommerce'
-								) }
-							</Text>
-						</FlexBlock>
-
-						<FlexItem>
-							<Button
-								variant='primary'
-								href={
-									wcSettings.pinterest_for_woocommerce
-										.billingSettingsUrl
-								}
-								onClick={ () =>
-									recordEvent(
-										'pfw_billing_setup_button_click'
-									)
-								}
-							>
-								{ __( 'Setup Billing', 'pinterest-for-woocommerce' ) }
-							</Button>
-						</FlexItem>
-					</>
-				) : (
-					<Spinner className="billing-info__preloader" />
-				) }
+				{ element }
 			</Flex>
 		</CardBody>
 	);

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -18,6 +18,7 @@ import {
  * Internal dependencies
  */
 import './style.scss';
+import { useSettingsSelect } from '../helpers/effects';
 
 /**
  * Clicking on "Setup Billing" button.
@@ -31,8 +32,9 @@ import './style.scss';
  * @event wcadmin_pfw_go_to_billing_button_click
  */
 
-const Billing = ( { accountData } ) => {
-	const isBillingSetup = accountData?.is_billing_setup;
+const Billing = () => {
+
+	const isBillingSetup = useSettingsSelect()?.account_data?.is_billing_setup;
 	const statusLabe = classnames( 'pfw-billing-info', {
 		'pfw-billing-info--status-success': isBillingSetup === true,
 		'pfw-billing-info--status-error': isBillingSetup === false,
@@ -41,7 +43,7 @@ const Billing = ( { accountData } ) => {
 	let element = null;
 
 	if ( isBillingSetup === undefined ) {
-		element = <Spinner className="billing-info__preloader" />;
+		element = <Spinner className="pfw-billing-info__preloader" />;
 	}
 
 	if ( isBillingSetup === true ) {

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
@@ -43,7 +42,7 @@ const Billing = () => {
 		if ( isBillingSetup === true ) {
 			return (
 				<>
-					<FlexBlock className='pfw-billing-info--status-success'>
+					<FlexBlock className="pfw-billing-info--status-success">
 						<Text variant="body">
 							{ __(
 								'Billing Setup Correctly',
@@ -75,7 +74,7 @@ const Billing = () => {
 
 		return (
 			<>
-				<FlexBlock className='pfw-billing-info--status-error'>
+				<FlexBlock className="pfw-billing-info--status-error">
 					<Text variant="body">
 						{ __(
 							'No Valid Billing Setup Found',

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -40,15 +40,14 @@ const Billing = () => {
 		'pfw-billing-info--status-error': isBillingSetup === false,
 	} );
 
-	let element = null;
+	getElement = ( ) => {
+		if ( isBillingSetup === undefined ) {
+			return <Spinner className="pfw-billing-info__preloader" />;
+		}
 
-	if ( isBillingSetup === undefined ) {
-		element = <Spinner className="pfw-billing-info__preloader" />;
-	}
-
-	if ( isBillingSetup === true ) {
-		element = (
-			<>
+		if ( isBillingSetup === true ) {
+			return (
+				<>
 				<FlexBlock className={ statusLabe }>
 					<Text variant="body">
 						{ __(
@@ -76,11 +75,10 @@ const Billing = () => {
 					</Button>
 				</FlexItem>
 			</>
-		);
-	}
+			);
+		}
 
-	if ( isBillingSetup === false ) {
-		element = (
+		return (
 			<>
 				<FlexBlock className={ statusLabe }>
 					<Text variant="body">
@@ -107,12 +105,12 @@ const Billing = () => {
 				</FlexItem>
 			</>
 		);
-	}
+	};
 
 	return (
 		<CardBody size="large">
 			<Flex direction="row" className="pfw-billing-info">
-				{ element }
+				{ getElement() }
 			</Flex>
 		</CardBody>
 	);

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -18,7 +18,7 @@ import {
  * Internal dependencies
  */
 import './style.scss';
-import { useSettingsSelect } from '../helpers/effects';
+import { useSettingsSelect } from '../../helpers/effects';
 
 /**
  * Clicking on "Setup Billing" button.
@@ -40,7 +40,7 @@ const Billing = () => {
 		'pfw-billing-info--status-error': isBillingSetup === false,
 	} );
 
-	getElement = ( ) => {
+	const getElement = ( ) => {
 		if ( isBillingSetup === undefined ) {
 			return <Spinner className="pfw-billing-info__preloader" />;
 		}

--- a/assets/source/setup-guide/app/components/Billing/Billing.js
+++ b/assets/source/setup-guide/app/components/Billing/Billing.js
@@ -91,7 +91,7 @@ const Billing = ( { accountData } ) => {
 
 				<FlexItem>
 					<Button
-						variant="primary"
+						isLink
 						href={
 							wcSettings.pinterest_for_woocommerce
 								.billingSettingsUrl

--- a/assets/source/setup-guide/app/components/Billing/style.scss
+++ b/assets/source/setup-guide/app/components/Billing/style.scss
@@ -1,0 +1,14 @@
+@import "~@wordpress/base-styles/_variables";
+
+.pfw-billing-info {
+	display: inline-flex;
+	align-items: center;
+
+	&--status-error {
+		color: $alert-red;
+	}
+
+	&--status-success {
+		color: $alert-green;
+	}
+}

--- a/assets/source/setup-guide/app/components/Billing/style.scss
+++ b/assets/source/setup-guide/app/components/Billing/style.scss
@@ -4,6 +4,10 @@
 	display: inline-flex;
 	align-items: center;
 
+	&__preloader {
+		flex: 1;
+	}
+
 	&--status-error {
 		color: $alert-red;
 	}

--- a/assets/source/setup-guide/app/steps/BillingStatus.js
+++ b/assets/source/setup-guide/app/steps/BillingStatus.js
@@ -3,12 +3,7 @@
  * External dependencies
  */
 
-import {
-	createInterpolateElement,
-} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-import { recordEvent } from '@woocommerce/tracks';
 import { Card } from '@wordpress/components';
 
 /**
@@ -17,69 +12,28 @@ import { Card } from '@wordpress/components';
 import Billing from '../components/Billing/Billing';
 import StepOverview from '../components/StepOverview';
 import { useSettingsSelect } from '../helpers/effects';
-import documentationLinkProps from '../helpers/documentation-link-props';
 
-/**
- * Clicking on "… create a new Pinterest account" button.
- *
- * @event wcadmin_pfw_account_create_button_click
- */
-/**
- * Clicking on "… convert your personal account" button.
- *
- * @event wcadmin_pfw_account_convert_button_click
- */
-
-/**
- * Account setup step component.
- *
- * @fires wcadmin_pfw_account_create_button_click
- * @fires wcadmin_pfw_account_convert_button_click
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: props.view }`
- * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: props.view }`
- * @fires wcadmin_pfw_modal_open with `{ name: 'ads-credits-terms-and-conditions', … }`
- * @fires wcadmin_pfw_modal_closed with `{ name: 'ads-credits-terms-and-conditions'', … }`
- *
- * @param {Object} props React props
- * @param {Function} props.goToNextStep
- * @param {string} props.view
- * @param {boolean} props.isConnected
- * @param {Function} props.setIsConnected
- * @param {boolean} props.isBusinessConnected
- * @return {JSX.Element} Rendered element.
- */
-const BillingStatus = ( {
-	isConnected,
-	setIsConnected,
-} ) => {
+const BillingStatus = () => {
 	const appSettings = useSettingsSelect();
 
 	return (
 		<div className="woocommerce-setup-guide__billing-status">
-
 			<div className="woocommerce-setup-guide__step-columns">
 				<div className="woocommerce-setup-guide__step-column">
 					<StepOverview
-						title={
-							__(
-								'Billing status',
-								'pinterest-for-woocommerce'
-							)
-						}
-						description={
-							__(
-								'A valid billing setup is necessary if you wish to advertise your products on Pinterest. You can set up and manage your billing through your account settings on Pinterest.',
-								'pinterest-for-woocommerce'
-							)
-						}
+						title={ __(
+							'Billing status',
+							'pinterest-for-woocommerce'
+						) }
+						description={ __(
+							'A valid billing setup is necessary if you wish to advertise your products on Pinterest. You can set up and manage your billing through your account settings on Pinterest.',
+							'pinterest-for-woocommerce'
+						) }
 					/>
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>
-						<Billing
-							isConnected={ isConnected }
-							accountData={ appSettings.account_data }
-						/>
+						<Billing accountData={ appSettings.account_data } />
 					</Card>
 				</div>
 			</div>

--- a/assets/source/setup-guide/app/steps/BillingStatus.js
+++ b/assets/source/setup-guide/app/steps/BillingStatus.js
@@ -11,10 +11,8 @@ import { Card } from '@wordpress/components';
  */
 import Billing from '../components/Billing/Billing';
 import StepOverview from '../components/StepOverview';
-import { useSettingsSelect } from '../helpers/effects';
 
 const BillingStatus = () => {
-	const appSettings = useSettingsSelect();
 
 	return (
 		<div className="woocommerce-setup-guide__billing-status">
@@ -33,7 +31,7 @@ const BillingStatus = () => {
 				</div>
 				<div className="woocommerce-setup-guide__step-column">
 					<Card>
-						<Billing accountData={ appSettings.account_data } />
+						<Billing />
 					</Card>
 				</div>
 			</div>

--- a/assets/source/setup-guide/app/steps/BillingStatus.js
+++ b/assets/source/setup-guide/app/steps/BillingStatus.js
@@ -13,7 +13,6 @@ import Billing from '../components/Billing/Billing';
 import StepOverview from '../components/StepOverview';
 
 const BillingStatus = () => {
-
 	return (
 		<div className="woocommerce-setup-guide__billing-status">
 			<div className="woocommerce-setup-guide__step-columns">

--- a/assets/source/setup-guide/app/steps/BillingStatus.js
+++ b/assets/source/setup-guide/app/steps/BillingStatus.js
@@ -1,0 +1,90 @@
+/* eslint-disable @wordpress/no-global-event-listener */
+/**
+ * External dependencies
+ */
+
+import {
+	createInterpolateElement,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { recordEvent } from '@woocommerce/tracks';
+import { Card } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Billing from '../components/Billing/Billing';
+import StepOverview from '../components/StepOverview';
+import { useSettingsSelect } from '../helpers/effects';
+import documentationLinkProps from '../helpers/documentation-link-props';
+
+/**
+ * Clicking on "… create a new Pinterest account" button.
+ *
+ * @event wcadmin_pfw_account_create_button_click
+ */
+/**
+ * Clicking on "… convert your personal account" button.
+ *
+ * @event wcadmin_pfw_account_convert_button_click
+ */
+
+/**
+ * Account setup step component.
+ *
+ * @fires wcadmin_pfw_account_create_button_click
+ * @fires wcadmin_pfw_account_convert_button_click
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'ad-guidelines', context: props.view }`
+ * @fires wcadmin_pfw_documentation_link_click with `{ link_id: 'merchant-guidelines', context: props.view }`
+ * @fires wcadmin_pfw_modal_open with `{ name: 'ads-credits-terms-and-conditions', … }`
+ * @fires wcadmin_pfw_modal_closed with `{ name: 'ads-credits-terms-and-conditions'', … }`
+ *
+ * @param {Object} props React props
+ * @param {Function} props.goToNextStep
+ * @param {string} props.view
+ * @param {boolean} props.isConnected
+ * @param {Function} props.setIsConnected
+ * @param {boolean} props.isBusinessConnected
+ * @return {JSX.Element} Rendered element.
+ */
+const BillingStatus = ( {
+	isConnected,
+	setIsConnected,
+} ) => {
+	const appSettings = useSettingsSelect();
+
+	return (
+		<div className="woocommerce-setup-guide__billing-status">
+
+			<div className="woocommerce-setup-guide__step-columns">
+				<div className="woocommerce-setup-guide__step-column">
+					<StepOverview
+						title={
+							__(
+								'Billing status',
+								'pinterest-for-woocommerce'
+							)
+						}
+						description={
+							__(
+								'A valid billing setup is necessary if you wish to advertise your products on Pinterest. You can set up and manage your billing through your account settings on Pinterest.',
+								'pinterest-for-woocommerce'
+							)
+						}
+					/>
+				</div>
+				<div className="woocommerce-setup-guide__step-column">
+					<Card>
+						<Billing
+							isConnected={ isConnected }
+							accountData={ appSettings.account_data }
+						/>
+					</Card>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default BillingStatus;

--- a/assets/source/setup-guide/app/views/ConnectionApp.js
+++ b/assets/source/setup-guide/app/views/ConnectionApp.js
@@ -60,9 +60,6 @@ const SettingsApp = () => {
 						isBusinessConnected={ isBusinessConnected }
 					/>
 					<BillingStatus
-						setIsConnected={ setIsConnected }
-						isConnected={ isConnected }
-						isBusinessConnected={ isBusinessConnected }
 					/>
 
 					{ isGroup1Visible && (

--- a/assets/source/setup-guide/app/views/ConnectionApp.js
+++ b/assets/source/setup-guide/app/views/ConnectionApp.js
@@ -9,6 +9,7 @@ import { useState, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import SetupAccount from '../steps/SetupAccount';
+import BillingStatus from '../steps/BillingStatus';
 import ClaimWebsite from '../steps/ClaimWebsite';
 import SetupTracking from '../steps/SetupTracking';
 import SaveSettingsButton from '../components/SaveSettingsButton';
@@ -54,6 +55,11 @@ const SettingsApp = () => {
 				<div className="woocommerce-setup-guide__container">
 					<SetupAccount
 						view={ SETTINGS_VIEW }
+						setIsConnected={ setIsConnected }
+						isConnected={ isConnected }
+						isBusinessConnected={ isBusinessConnected }
+					/>
+					<BillingStatus
 						setIsConnected={ setIsConnected }
 						isConnected={ isConnected }
 						isBusinessConnected={ isBusinessConnected }

--- a/assets/source/setup-guide/app/views/ConnectionApp.js
+++ b/assets/source/setup-guide/app/views/ConnectionApp.js
@@ -59,9 +59,7 @@ const SettingsApp = () => {
 						isConnected={ isConnected }
 						isBusinessConnected={ isBusinessConnected }
 					/>
-					<BillingStatus
-					/>
-
+					<BillingStatus />
 					{ isGroup1Visible && (
 						<ClaimWebsite view={ SETTINGS_VIEW } />
 					) }

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -367,6 +367,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				'serviceLoginUrl'          => $this->get_service_login_url(),
 				'createBusinessAccountUrl' => $this->get_create_business_account_url(),
 				'switchBusinessAccountUrl' => $this->get_switch_business_account_url(),
+				'billingSettingsUrl'       => $this->get_advertiser_billing_settings_url(),
 				'homeUrlToVerify'          => get_home_url(),
 				'storeCountry'             => $store_country,
 				'isAdsSupportedCountry'    => Pinterest_For_Woocommerce_Ads_Supported_Countries::is_ads_supported_country(),
@@ -459,6 +460,17 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				),
 				admin_url( 'admin.php' )
 			);
+		}
+
+		/**
+		 * Return the advertiser billing settings URL.
+		 *
+		 * @since x.x.x
+		 * @return string
+		 */
+		private function get_advertiser_billing_settings_url() {
+			$advertiser_id = Pinterest_For_Woocommerce()->get_setting( 'tracking_advertiser' );
+			return "https://ads.pinterest.com/advertiser/{$advertiser_id}/billing";
 		}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This will be useful to merchants but I have quickly developed it to know if the advertiser_id I am using for testing has correct billing setup.


### Screenshots:

Invalid billing status:
<img width="931" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/f6edaa39-560b-4c42-af1d-4d17ec4d8473">

Valid billing status
<img width="931" alt="image" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/4992b703-0671-4ab5-8b50-645ebd7ab624">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to wp-admin -> Marketing -> Pinterest -> Connection
2. Observe billing status with Advertiser that has correct billing and with advertiser that has no billing status set 
3. Make sure that the button takes you to the billing settings.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Billing status UI in Connection tab.
