### PR TITLE
Token invalid reset procedure.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -306,7 +306,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'pinterest_for_woocommerce_token_saved', array( $this, 'post_update_cleanup' ) );
 			add_action( 'pinterest_for_woocommerce_token_saved', array( TokenInvalidFailure::class, 'possibly_delete_note' ) );
 
-			add_action( 'pinterest_for_woocommerce_disconnect', array( Pinterest_For_Woocommerce::class, 'reset_connection' ) );
+			add_action( 'pinterest_for_woocommerce_disconnect', array( self::class, 'reset_connection' ) );
 
 			// Handle the Pinterest verification URL.
 			add_action( 'parse_request', array( $this, 'verification_request' ) );
@@ -822,11 +822,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @since 1.4.0
 		 *
 		 * @return void
-		 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
+		 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException If the notes API is not available.
 		 */
 		public static function reset_connection() {
-			Pinterest_For_Woocommerce::save_data( 'integration_data', array() );
-			Pinterest_For_Woocommerce::disconnect();
+			self::save_data( 'integration_data', array() );
+			self::disconnect();
 
 			TokenInvalidFailure::possibly_add_note();
 		}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -822,7 +822,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		/**
 		 * Resets the connection by clearing the local connection data.
 		 *
-		 * @since 1.4.0
+		 * @since x.x.x
 		 *
 		 * @return void
 		 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException If the notes API is not available.
@@ -837,7 +837,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		/**
 		 * Resets the connection from action scheduler.
 		 *
-		 * @since 1.4.0
+		 * @since x.x.x
 		 *
 		 * @param string    $action_id The ID of the action.
 		 * @param Exception $e         The exception that was thrown.

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -847,7 +847,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @throws Exception                 If the exception is a 401 error.
 		 */
 		public static function action_scheduler_reset_connection( $action_id, $e ) {
-			if ( 401 === $e->getCode() ) {
+			if ( in_array( $e->getCode(), array( 401, 403 ) ) ) {
 				self::reset_connection();
 				throw $e;
 			}

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -839,16 +839,18 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 *
 		 * @since 1.4.0
 		 *
-		 * @param $action_id
-		 * @param $e
-		 * @return mixed
+		 * @param string    $action_id The ID of the action.
+		 * @param Exception $e         The exception that was thrown.
+		 *
+		 * @return void
 		 * @throws NotesUnavailableException If the notes API is not available.
+		 * @throws Exception                 If the exception is a 401 error.
 		 */
 		public static function action_scheduler_reset_connection( $action_id, $e ) {
 			if ( 401 === $e->getCode() ) {
 				self::reset_connection();
+				throw $e;
 			}
-			throw $e;
 		}
 
 		/**

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -819,7 +819,7 @@ class APIV5 extends Base {
 	 * @since 1.4.0
 	 *
 	 * @param string $ad_account_id Ad Account ID.
-	 * @param array $data
+	 * @param array  $data Event data.
 	 * @return array
 	 * @throws PinterestApiException If the request fails with other than 2xx status.
 	 */

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -785,4 +785,49 @@ class APIV5 extends Base {
 			'GET'
 		);
 	}
+
+	/**
+	 * Pull ads supported countries information from the API.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array {
+	 *     Contains the status and token details.
+	 *
+	 *     @type string $status                         The status of the token exchange.
+	 *     @type array  $data {
+	 *         Contains token details.
+	 *
+	 *         @type string $access_token                   The access token for authentication.
+	 *         @type string $refresh_token                  The refresh token for acquiring a new access token.
+	 *         @type string $token_type                     Type of the token, usually "bearer".
+	 *         @type int    $expires_in                     Time in seconds when the access token expires.
+	 *         @type int    $refresh_token_expires_in       Time in seconds when the refresh token expires.
+	 *         @type string $scope                          The scope for which the access token has permission.
+	 *     }
+	 * }
+	 * @throws PinterestApiException If the request fails with other than 2xx status.
+	 */
+	public static function exchange_token() {
+		$request_url = 'oauth/commerce_integrations/token/exchange/';
+		return self::make_request( $request_url );
+	}
+
+	/**
+	 * Sends Conversions API event data to Pinterest.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $ad_account_id Ad Account ID.
+	 * @param array $data
+	 * @return array
+	 * @throws PinterestApiException If the request fails with other than 2xx status.
+	 */
+	public static function send_conversions_api_event( string $ad_account_id, array $data ) {
+		return self::make_request(
+			"ad_accounts/{$ad_account_id}/events",
+			'POST',
+			array( 'data' => array( $data ) )
+		);
+	}
 }

--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -789,7 +789,7 @@ class APIV5 extends Base {
 	/**
 	 * Pull ads supported countries information from the API.
 	 *
-	 * @since 1.4.0
+	 * @since x.x.x
 	 *
 	 * @return array {
 	 *     Contains the status and token details.
@@ -816,7 +816,7 @@ class APIV5 extends Base {
 	/**
 	 * Sends Conversions API event data to Pinterest.
 	 *
-	 * @since 1.4.0
+	 * @since x.x.x
 	 *
 	 * @param string $ad_account_id Ad Account ID.
 	 * @param array  $data Event data.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -111,7 +111,16 @@ class Base {
 				);
 			}
 
-			if ( 401 === $e->getCode() ) {
+			/**
+			 * Filter to disconnect the merchant from the Pinterest platform on authentication failure.
+			 *
+			 * @since 1.4.0
+			 */
+			$do_disconnect = apply_filters(
+				'pinterest_for_woocommerce_disconnect_on_authentication_failure',
+				'__return_true'
+			);
+			if ( 401 === $e->getCode() && $do_disconnect ) {
 				/**
 				 * Actions to perform disconnecting the merchant from the Pinterest platform.
 				 *

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -12,8 +12,6 @@ namespace Automattic\WooCommerce\Pinterest\API;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Exception;
-use Pinterest_For_Woocommerce;
-use function Automattic\WooCommerce\Pinterest\load_plugins;
 
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -114,7 +114,7 @@ class Base {
 			/**
 			 * Filter to disconnect the merchant from the Pinterest platform on authentication failure.
 			 *
-			 * @since 1.4.0
+			 * @since x.x.x
 			 */
 			$do_disconnect = apply_filters(
 				'pinterest_for_woocommerce_disconnect_on_authentication_failure',

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\Pinterest\API;
 use Automattic\WooCommerce\Pinterest\Logger as Logger;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Exception;
+use Pinterest_For_Woocommerce;
 use function Automattic\WooCommerce\Pinterest\load_plugins;
 
 
@@ -111,6 +112,16 @@ class Base {
 					'error'
 				);
 			}
+
+			if ( 401 === $e->getCode() ) {
+				/**
+				 * Actions to perform disconnecting the merchant from the Pinterest platform.
+				 *
+				 * @since 1.4.0
+				 */
+				do_action( 'pinterest_for_woocommerce_disconnect' );
+			}
+
 			throw $e;
 		}
 	}

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -120,7 +120,7 @@ class Base {
 				'pinterest_for_woocommerce_disconnect_on_authentication_failure',
 				'__return_true'
 			);
-			if ( 401 === $e->getCode() && $do_disconnect ) {
+			if ( in_array( $e->getCode(), array( 401, 403 ) ) && $do_disconnect ) {
 				/**
 				 * Actions to perform disconnecting the merchant from the Pinterest platform.
 				 *

--- a/src/API/TokenExchangeV3ToV5.php
+++ b/src/API/TokenExchangeV3ToV5.php
@@ -29,31 +29,6 @@ class TokenExchangeV3ToV5 extends APIV5 {
 	const API_DOMAIN = 'https://api.pinterest.com/v3';
 
 	/**
-	 * Pull ads supported countries information from the API.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return array {
-	 *     Contains the status and token details.
-	 *
-	 *     @type string $status                         The status of the token exchange.
-	 *     @type array  $data {
-	 *         Contains token details.
-	 *
-	 *         @type string $access_token                   The access token for authentication.
-	 *         @type string $refresh_token                  The refresh token for acquiring a new access token.
-	 *         @type string $token_type                     Type of the token, usually "bearer".
-	 *         @type int    $expires_in                     Time in seconds when the access token expires.
-	 *         @type int    $refresh_token_expires_in       Time in seconds when the refresh token expires.
-	 *         @type string $scope                          The scope for which the access token has permission.
-	 *     }
-	 * }
-	 */
-	public static function exchange_token() {
-		$request_url = 'oauth/commerce_integrations/token/exchange/';
-		return self::make_request( $request_url );
-	}
-	/**
 	 * Update token from V3 to V5.
 	 *
 	 * @since 1.4.0
@@ -66,7 +41,7 @@ class TokenExchangeV3ToV5 extends APIV5 {
 
 		// Try to exchange the token.
 		try {
-			$response = self::exchange_token();
+			$response = APIV5::exchange_token();
 			if ( 'success' !== $response['status'] ) {
 				throw new Exception(
 					sprintf(

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -79,9 +79,6 @@ class FeedRegistration {
 	 * @throws Exception PHP Exception.
 	 */
 	public function handle_feed_registration(): bool {
-		if ( ! Pinterest_For_Woocommerce::is_business_connected() ) {
-			return true;
-		}
 
 		// Clean merchants error code.
 		$this->clear_merchant_error_code();

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -9,6 +9,7 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Exception;
+use Pinterest_For_Woocommerce;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
@@ -78,6 +79,9 @@ class FeedRegistration {
 	 * @throws Exception PHP Exception.
 	 */
 	public function handle_feed_registration(): bool {
+		if ( ! Pinterest_For_Woocommerce::is_business_connected() ) {
+			return true;
+		}
 
 		// Clean merchants error code.
 		$this->clear_merchant_error_code();
@@ -157,6 +161,8 @@ class FeedRegistration {
 	 * @return void
 	 *
 	 * @since 1.2.13
+	 *
+	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function maybe_delete_stale_feeds_for_merchant( string $feed_id ) {
 		$feeds = Feeds::get_feeds();

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -161,8 +161,6 @@ class FeedRegistration {
 	 * @return void
 	 *
 	 * @since 1.2.13
-	 *
-	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function maybe_delete_stale_feeds_for_merchant( string $feed_id ) {
 		$feeds = Feeds::get_feeds();

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -80,6 +80,7 @@ class FeedRegistration {
 	 * @return bool
 	 *
 	 * @throws Exception PHP Exception.
+	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public function handle_feed_registration(): bool {
 
@@ -98,11 +99,11 @@ class FeedRegistration {
 			}
 			throw new Exception( esc_html__( 'Could not register feed.', 'pinterest-for-woocommerce' ) );
 		} catch ( PinterestApiLocaleException $e ) {
-			Pinterest_For_Woocommerce()::save_data('merchant_locale_not_valid', true);
+			Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', true );
 
 			// translators: %s: Error message.
 			$error_message = "Could not register feed. Error: {$e->getMessage()}";
-			self::log($error_message, 'error');
+			self::log( $error_message, 'error' );
 			return false;
 		} catch ( PinterestApiException $e ) {
 			throw $e;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -240,12 +240,16 @@ class Feeds {
 	 * Get merchant's feeds.
 	 *
 	 * @return array The feed profile objects.
-	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function get_feeds(): array {
-		$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
-		$feeds         = APIV5::get_feeds( $ad_account_id );
-		return $feeds['items'] ?? array();
+		try {
+			$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
+			$feeds         = APIV5::get_feeds( $ad_account_id );
+			return $feeds['items'] ?? array();
+		} catch ( PinterestApiException $e ) {
+			Logger::log( $e->getMessage(), 'error' );
+			return array();
+		}
 	}
 
 	/**
@@ -268,7 +272,6 @@ class Feeds {
 	 * @return string Returns the ID of the feed if properly registered or an empty string otherwise.
 	 *
 	 * @throws PinterestApiLocaleException No valid locale found to check for the registered feed.
-	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function match_local_feed_configuration_to_registered_feeds( array $feeds = array() ): string {
 		$local_country = Pinterest_For_Woocommerce()::get_base_country();

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -92,6 +92,7 @@ class Feeds {
 	 *
 	 * @return string The Feed ID or an empty string if failed.
 	 * @throws Exception PHP Exception if there is an error creating the feed, and we are throttling the requests.
+	 * @throws PinterestApiException Pinterest API Exception if there is an error creating the feed.
 	 */
 	public static function create_feed(): string {
 		$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -150,16 +150,15 @@ class Feeds {
 
 		try {
 			$feed = APIV5::create_feed( $data, $ad_account_id );
-		} catch ( Throwable $th ) {
+		} catch ( PinterestApiException $e ) {
 			$delay = Pinterest_For_Woocommerce()::get_data( 'create_feed_delay' ) ?? MINUTE_IN_SECONDS;
-			set_transient( $cache_key, $th->getCode(), $delay );
+			set_transient( $cache_key, $e->getCode(), $delay );
 			// Double the delay.
 			Pinterest_For_Woocommerce()::save_data(
 				'create_feed_delay',
 				min( $delay * 2, 6 * HOUR_IN_SECONDS )
 			);
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new Exception( $th->getMessage(), $th->getCode() );
+			throw $e;
 		}
 
 		static::invalidate_feeds_cache();

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -240,16 +240,12 @@ class Feeds {
 	 * Get merchant's feeds.
 	 *
 	 * @return array The feed profile objects.
+	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function get_feeds(): array {
-		try {
-			$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
-			$feeds         = APIV5::get_feeds( $ad_account_id );
-			return $feeds['items'] ?? array();
-		} catch ( PinterestApiException $e ) {
-			Logger::log( $e->getMessage(), 'error' );
-			return array();
-		}
+		$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
+		$feeds         = APIV5::get_feeds( $ad_account_id );
+		return $feeds['items'] ?? array();
 	}
 
 	/**
@@ -272,6 +268,7 @@ class Feeds {
 	 * @return string Returns the ID of the feed if properly registered or an empty string otherwise.
 	 *
 	 * @throws PinterestApiLocaleException No valid locale found to check for the registered feed.
+	 * @throws PinterestApiException Pinterest API Exception.
 	 */
 	public static function match_local_feed_configuration_to_registered_feeds( array $feeds = array() ): string {
 		$local_country = Pinterest_For_Woocommerce()::get_base_country();

--- a/src/Notes/TokenInvalidFailure.php
+++ b/src/Notes/TokenInvalidFailure.php
@@ -80,7 +80,6 @@ class TokenInvalidFailure {
 	/**
 	 * Delete the note.
 	 *
-	 * @since 1.4.0
 	 *
 	 * @return void
 	 */

--- a/src/Notes/TokenInvalidFailure.php
+++ b/src/Notes/TokenInvalidFailure.php
@@ -80,7 +80,6 @@ class TokenInvalidFailure {
 	/**
 	 * Delete the note.
 	 *
-	 *
 	 * @return void
 	 */
 	public static function delete_failure_note() {

--- a/src/Notes/TokenInvalidFailure.php
+++ b/src/Notes/TokenInvalidFailure.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WooCommerce Admin: Add First Product.
+ *
+ * Adds a note (type `email`) to bring the client back to the store setup flow.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Add_First_Product.
+ */
+class TokenInvalidFailure {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-token-invalid-failure';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$content_lines = array(
+			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
+		);
+
+		$additional_data = array(
+			'role' => 'administrator',
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
+		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content_data( (object) $additional_data );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
+			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true,
+			'primary'
+		);
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 *
+	 * @return void
+	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 */
+	public static function possibly_add_note() {
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Delete the note.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return void
+	 */
+	public static function delete_failure_note() {
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -303,11 +303,7 @@ class Conversions extends Tracker {
 			return;
 		}
 
-		$response = APIV5::make_request(
-			"ad_accounts/{$ad_account_id}/events",
-			'POST',
-			array( 'data' => array( $data ) )
-		);
+		$response = APIV5::send_conversions_api_event( $ad_account_id, $data );
 
 		// Processing the call results.
 		$is_error = isset( $response['code'] );

--- a/tests/E2e/Pinterest401DisconnectE2eTest.php
+++ b/tests/E2e/Pinterest401DisconnectE2eTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use Automattic\WooCommerce\Pinterest\API\APIV5;
+use Automattic\WooCommerce\Pinterest\Notes\TokenInvalidFailure;
+
+class Pinterest401DisconnectE2eTest extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		remove_all_actions( 'pinterest_for_woocommerce_token_saved' );
+
+		$token_data = array(
+			'access_token' => 'def50200fd71a25bca8b0732a0449818bb58774bc022a75b6a954d233aa8fc06f31fbed01e816cc6d2518a24ecd1018878d1568341b5412a52b33ef4b3627b296d76a6fdd53a9541dfe57bc8a304a837779b78c42b44516c473948941c928d68c9277db225931e3bfd87bfd36212d49018650d167c4fffc1600b27d76bd5debb6733aef64ff4c1de40740f10417f9c98145a12d994bad15b750cf0dbb48ac2ce78e8cec610707e3a087df58c90445ed4fb5acafbb6c60a07f4',
+			'refresh_token' => 'def50200c637373b990d843d5be0b37415610a077359085993d42b7ef032ae368ab2a28e02e90438b5a34fcd92f62d938f65a17de11574743126cddefb30a662440881fe9197911940fddea93b3e0d32e34e4bd348bb74586d4980d304dc6a4b9cc577bc4533f32df239fb91044f4c17dd72842d2900a6aea8518939ddebc4073d11f2c61b92430272451c71a878e70b651dce2214657bd0b333c9517b2694168eb8431fa6c7d82d15720ffea853ea052382cbbcf2f4d2826851dcae7e1c3295433bd9cd586a21a6642ebbb6d5158f8c2a5f8c4f62c8b524ffbb5f13a90df9078feaf1ddda4627b1398eab80a3b57efac3de38cbafd162496f7908dd0cdc48752c4ef26848788fec7e7e48adacadf3144894ea6a1166dacda3649885709aacf049de326bef0f366dd776908b95024a1ef6c0b320ef091a104a127e1b2a5c7600e5b07af918ded1705989431e1ad84fac85c4da4ffc5f29cb3c6753b51eebf3b577bf73422c6d5750fcbb25b83e593c9e5ae03ddbbc5a59214b9e4ec89a93cd7e621a44889dd5e68e03e755b40bb9b1402ad3d327b16ebcc3f92e487929fdb22d9ed5a3a28400f04d17f492592488651c71edb5b93a7c87ee0043ad21a96989dd66cde55dd6ebbd0ba6e23040e809674cdb71bdb68d95183925e2702ab3188815bdddd49a4d76403f3190a8b2011a1e6440e2032589ff6f7d060ec20f6b0c651d77e9c9927cee4a20e4423f3a622b7134fe770f7cd9231569eb252e4f4a252f2e973d5a1e7feb8171fea9d00f62257937885ff193dd28e2fc1b3fbd9da3764a5c06e4ef51654d59fd8e4bb3155d443a4995c83c997c8965587322207957149636b0c1eeccd3d1f5e427ed8896cca3c5',
+			'token_type' => 'bearer',
+			'expires_in' => 2592000,
+			'refresh_token_expires_in' => 31536000,
+			'scope' => 'ads:read ads:write catalogs:read catalogs:write pins:read pins:write user_accounts:read user_accounts:write',
+			'refresh_date' => 1685694065,
+		);
+		Pinterest_For_Woocommerce()::save_token_data( $token_data );
+		$info_data = array(
+			'advertiser_id' => '549765662491',
+			'tag_id' => '2613286171854',
+			'merchant_id' => '1479839719476',
+			'clientHash' => 'MTQ4NjE3MzpkNWJjNTM4ZmVhMTZhYzIwMmZiNDZhMTFjMGNkZGVmNzFhOWU1YWY0',
+		);
+		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
+
+		// API Request filters to stub Pinterest API requests.
+		$this->create_commerce_integration_request_stub();
+		$this->get_account_info_request_stub();
+		$this->get_user_websites_request_stub();
+		$this->get_linked_businesses_request_stub();
+
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'set_default_settings' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'create_commerce_integration' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_account_data' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_linked_businesses' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'post_update_cleanup' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( TokenInvalidFailure::class, 'possibly_delete_note' ) );
+
+		do_action( 'pinterest_for_woocommerce_token_saved' );
+	}
+
+	/**
+	 * Tests .
+	 *
+	 * @return void
+	 */
+	public function test_401_disconnect_resets_integration_data_and_shows_notice() {
+		add_action( 'pinterest_for_woocommerce_disconnect', array( Pinterest_For_Woocommerce::class, 'reset_connection' ) );
+
+		do_action( 'pinterest_for_woocommerce_disconnect' );
+
+		$this->assertEmpty( Pinterest_For_Woocommerce::get_data( 'integration_data' ) );
+		$this->assertTrue( TokenInvalidFailure::note_exists() );
+	}
+
+	private function create_commerce_integration_request_stub() {
+		add_filter(
+			'pre_http_request',
+			function ($response, $parsed_args, $url) {
+				if ('https://api.pinterest.com/v5/integrations/commerce' === $url) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								'id' => '6491114367052267731',
+								'external_business_id' => 'wordpresspinterest-6479a6713160b',
+								'connected_merchant_id' => '1479839719476',
+								'connected_user_id' => '1144266355231574943',
+								'connected_advertiser_id' => '549765662491',
+								'connected_tag_id' => '2613286171854',
+								'connected_lba_id' => '',
+								'partner_access_token_expiry' => 0,
+								'partner_refresh_token_expiry' => 0,
+								'scopes' => '',
+								'created_timestamp' => 1685694065000,
+								'updated_timestamp' => 1685694065000,
+								'additional_id_1' => '',
+								'partner_metadata' => '',
+							)
+						),
+						'response' => array(
+							'code' => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+
+	private function get_account_info_request_stub() {
+		add_filter(
+			'pre_http_request',
+			function ($response, $parsed_args, $url) {
+				if ('https://api.pinterest.com/v5/user_account' === $url) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								'username' => 'dmytromaksiuta1',
+								'profile_image' => 'https://i.pinimg.com/600x600_R/42/f5/36/42f5364f737aff4749a8e9046510828f.jpg',
+								'account_type' => 'BUSINESS',
+							)
+						),
+						'response' => array(
+							'code' => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+
+	private function get_user_websites_request_stub() {
+		add_filter(
+			'pre_http_request',
+			function ($response, $parsed_args, $url) {
+				if ('https://api.pinterest.com/v5/user_account/websites' === $url) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								'items' => array(
+									array(
+										'status' => 'verified',
+										'website' => 'wordpress.dima.works',
+									),
+									array(
+										'status' => 'verified',
+										'website' => 'pinterest.dima.works',
+									)
+								),
+							)
+						),
+						'response' => array(
+							'code' => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+
+	private function get_linked_businesses_request_stub() {
+		add_filter(
+			'pre_http_request',
+			function ($response, $parsed_args, $url) {
+				if ('https://api.pinterest.com/v5/user_account/businesses' === $url) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								array(
+									'username' => 'dmytromaksiuta1',
+									'image_small_url' => 'https://www.example.com/dj23454f53dfk2324.jpg',
+									'image_medium_url' => 'https://www.example.com/dj23454f53dfk2324.jpg',
+									'image_large_url' => 'https://www.example.com/dj23454f53dfk2324.jpg',
+									'image_xlarge_url' => 'https://www.example.com/dj23454f53dfk2324.jpg'
+								),
+							)
+						),
+						'response' => array(
+							'code' => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+}

--- a/tests/E2e/Pinterest401DisconnectE2eTest.php
+++ b/tests/E2e/Pinterest401DisconnectE2eTest.php
@@ -58,6 +58,24 @@ class Pinterest401DisconnectE2eTest extends WP_UnitTestCase {
 		$this->assertTrue( TokenInvalidFailure::note_exists() );
 	}
 
+	/**
+	 * Tests .
+	 *
+	 * @return void
+	 */
+	public function test_401_disconnect_resets_integration_data_and_shows_notice_for_actions_scheduler() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 401 );
+		$this->expectExceptionMessage( 'Authentication failed.' );
+
+		add_action( 'action_scheduler_failed_execution', array( Pinterest_For_Woocommerce::class, 'action_scheduler_reset_connection' ), 10, 2 );
+
+		do_action( 'action_scheduler_failed_execution', '987654', new Exception( 'Authentication failed.', 401 ) );
+
+		$this->assertEmpty( Pinterest_For_Woocommerce::get_data( 'integration_data' ) );
+		$this->assertTrue( TokenInvalidFailure::note_exists() );
+	}
+
 	private function create_commerce_integration_request_stub() {
 		add_filter(
 			'pre_http_request',

--- a/tests/E2e/PinterestConnectE2eTest.php
+++ b/tests/E2e/PinterestConnectE2eTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Pinterest\Notes\TokenInvalidFailure;
+
 class PinterestConnectE2eTest extends WP_UnitTestCase {
 
 	/**
@@ -39,6 +41,7 @@ class PinterestConnectE2eTest extends WP_UnitTestCase {
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_account_data' ) );
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_linked_businesses' ) );
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'post_update_cleanup' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( TokenInvalidFailure::class, 'possibly_delete_note' ) );
 
 		do_action( 'pinterest_for_woocommerce_token_saved' );
 
@@ -80,6 +83,7 @@ class PinterestConnectE2eTest extends WP_UnitTestCase {
 			),
 			$settings
 		);
+		$this->assertFalse( TokenInvalidFailure::note_exists() );
 	}
 
 	private function create_commerce_integration_request_stub() {

--- a/tests/E2e/PinterestConnectE2eTest.php
+++ b/tests/E2e/PinterestConnectE2eTest.php
@@ -38,6 +38,7 @@ class PinterestConnectE2eTest extends WP_UnitTestCase {
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'create_commerce_integration' ) );
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_account_data' ) );
 		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'update_linked_businesses' ) );
+		add_action( 'pinterest_for_woocommerce_token_saved', array( Pinterest_For_Woocommerce::class, 'post_update_cleanup' ) );
 
 		do_action( 'pinterest_for_woocommerce_token_saved' );
 
@@ -56,9 +57,13 @@ class PinterestConnectE2eTest extends WP_UnitTestCase {
 					'coupon_redeem_info'      => array(
 						'redeem_status' => false,
 					),
-					'verified_user_websites' => array(
+					'verified_user_websites'  => array(
 						'wordpress.dima.works',
 						'pinterest.dima.works'
+					),
+					'currency_credit_info'    => array(
+						'spendRequire' => '$15',
+						'creditsGiven' => '$125',
 					),
 				),
 				'track_conversions'                => true,

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -38,6 +38,29 @@ class PinterestForWoocommerceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test of the plugin has disconnect action initialised.
+	 *
+	 * @return void
+	 */
+	public function test_disconnect_events_added_with_plugin() {
+		Pinterest_For_Woocommerce();
+		$this->assertEquals(
+			10,
+			has_action(
+				'pinterest_for_woocommerce_disconnect',
+				[ Pinterest_For_Woocommerce::class, 'reset_connection' ]
+			)
+		);
+		$this->assertEquals(
+			10,
+			has_action(
+				'action_scheduler_failed_execution',
+				[ Pinterest_For_Woocommerce::class, 'action_scheduler_reset_connection' ]
+			)
+		);
+	}
+
+	/**
 	 * Test of the plugin has refresh token action initialised.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #993

Listen to API 401/403 responses, which may happen during user interaction with a plugin or when Pinterest for WooCommerce Action Scheduler tasks run.

In the case of the 401/403 response code, disconnect the user, reset the connection workflow (display landing page), stop feed generation and feed registration Action Scheduled actions, and show a notice about an action required.  

Moving all found occurrences of the `Base::make_request()` direct calls under `APIV5` class.

### Screenshots:

<img width="1031" alt="Pinterest_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/f64e9cb9-3334-4bda-8425-137ad3796d94">

<img width="1546" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/ac176dcc-b4fd-4e60-924d-cbbe8924a65f">

### Detailed test instructions:

#### Action Scheduler 401 test.

1. Connect to Pinterest.
2. Go to https://github.com/woocommerce/pinterest-for-woocommerce/blob/bfe58e500b8738392d1adff4ddcada7bc6030af5/src/API/Base.php#L268
3. Change it (add some characters after `Bearer`, e.g.
```php
            $request['headers']['Authorization'] = 'Bearer ***' . static::get_token()['access_token'];
```
4. Go to _WooCommerce_ - _Status_ - _Pending_ (actions).
5. Force run `pinterest-for-woocommerce-handle-feed-registration` action.
6. Observe a Notice.
7. Check that _Pending_ section does not have `pinterest-for-woocommerce-handle-feed-registration` and `pinterest-for-woocommerce-start-feed-generation` actions scheduled.
8. Go to _Marketing_ - _Pinterest_ and observe the Landing page instead of the Connection page.
9. Observe the Notice above the Landing page.

#### User interaction test.

**NOTE:** _Since the Pinterest for WooCommerce plugin has a React frontend application that calls corresponding REST APIs, the UX may seem a bit odd. 401 errors will occur on REST API calls, and we can not perform proper redirects without modifications to the plugin's communication layer. The page reload is required to observe the 401 handling results. We may adjust the frontend application soon after._

1. Connect to Pinterest.
2. Go to https://github.com/woocommerce/pinterest-for-woocommerce/blob/bfe58e500b8738392d1adff4ddcada7bc6030af5/src/API/Base.php#L268
3. Change it (add some characters after `Bearer`, e.g.
```php
            $request['headers']['Authorization'] = 'Bearer ***' . static::get_token()['access_token'];
```
4. Go to _Marketing_ - _Pinterest_.
5. Refresh the page and see the Landing page with the Notice above it.

**P.S.** _403 error test by changing the scope is impossible since we do not send the scope to Pinterest, which is encoded into the access token. Fake access tokens will always cause 401._ 

### Changelog entry

> Add - 401/403 Pinterest API error handling.
