### PR TITLE
Adding PHP8.3 to GitHub Workflow.

### DIFF
--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [7.4, 8.2]
+        php: [7.4, 8.3]
     name: Code sniff (PHP ${{ matrix.php }}, WP Latest)
     permissions:
       contents: read

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.3]
         wp-version: [latest]
 
     steps:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds PHP8.3 to GitHub Workflows for PHP Code Styling and Unit Tests.

### Changelog entry

> Tweak - PHP8.3 to GitHub PHPCS and Unit Tests workflows.
