### PR TITLE
Adding heartbeat actions cleanup.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -263,10 +263,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			$this->includes();
 
-			// Start the heartbeat.
-			$this->heartbeat = new Heartbeat( WC()->queue() );
-			$this->heartbeat->init();
-
 			add_action( 'admin_init', array( $this, 'admin_init' ), 0 );
 			add_action( 'rest_api_init', array( $this, 'init_api_endpoints' ) );
 			add_action( 'wp_head', array( $this, 'maybe_inject_verification_code' ) );
@@ -278,6 +274,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			// ActionScheduler is activated on init 1 so lets make sure we are updating after that.
 			add_action( 'init', array( $this, 'maybe_update_plugin' ), 5 );
 			add_action( 'init', array( self::class, 'init_tracking' ) );
+			add_action( 'init', array( Pinterest\Heartbeat::class, 'schedule_events' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\Billing::class, 'schedule_event' ) );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -831,6 +831,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// Cancel scheduled jobs.
 			Pinterest\ProductSync::cancel_jobs();
+			Heartbeat::cancel_jobs();
 		}
 
 		/**

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -138,6 +138,7 @@ register_deactivation_hook(
 	PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE,
 	function () {
 		Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
+		Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
 	}
 );
 
@@ -147,6 +148,7 @@ if ( defined( 'WC_PLUGIN_FILE' ) ) {
 		WC_PLUGIN_FILE,
 		function () {
 			Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
+			Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
 		}
 	);
 }

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -37,6 +37,10 @@ class AdCredits {
 	 * @since 1.2.5
 	 */
 	public static function schedule_event() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
 		add_action( Heartbeat::HOURLY, array( static::class, 'handle_redeem_credit' ), 20 );
 	}
 

--- a/src/Billing.php
+++ b/src/Billing.php
@@ -29,6 +29,10 @@ class Billing {
 	 * @since 1.2.5
 	 */
 	public static function schedule_event() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
 		add_action( Heartbeat::DAILY, array( __CLASS__, 'handle_billing_setup_check' ) );
 	}
 

--- a/src/Heartbeat.php
+++ b/src/Heartbeat.php
@@ -67,4 +67,8 @@ class Heartbeat {
 		}
 	}
 
+	public static function cancel_jobs() {
+		as_unschedule_all_actions( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		as_unschedule_all_actions( self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+	}
 }

--- a/src/Heartbeat.php
+++ b/src/Heartbeat.php
@@ -8,7 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
-use WC_Queue_Interface;
+use Pinterest_For_Woocommerce;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,35 +29,15 @@ class Heartbeat {
 	const HOURLY = 'pinterest_for_woocommerce_hourly_heartbeat';
 
 	/**
-	 * WooCommerce Queue Interface.
-	 *
-	 * @var WC_Queue_Interface
-	 */
-	protected $queue;
-
-	/**
-	 * Heartbeat constructor.
-	 *
-	 * @since 1.1.0
-	 * @param WC_Queue_Interface $queue WC Action Scheduler proxy.
-	 */
-	public function __construct( WC_Queue_Interface $queue ) {
-		$this->queue = $queue;
-	}
-
-	/**
-	 * Add hooks.
-	 */
-	public function init() {
-		add_action( 'admin_init', array( $this, 'schedule_events' ) );
-	}
-
-	/**
 	 * Schedule heartbeat events.
 	 *
 	 * @since 1.1.0
 	 */
-	public function schedule_events() {
+	public static function schedule_events() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
 		if ( ! as_has_scheduled_action( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
 			as_schedule_recurring_action( time(), DAY_IN_SECONDS, self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		}

--- a/src/Heartbeat.php
+++ b/src/Heartbeat.php
@@ -67,6 +67,13 @@ class Heartbeat {
 		}
 	}
 
+	/**
+	 * Cancels all the scheduled jobs.
+	 *
+	 * @sinxe 1.4.0
+	 *
+	 * @return void
+	 */
 	public static function cancel_jobs() {
 		as_unschedule_all_actions( self::DAILY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		as_unschedule_all_actions( self::HOURLY, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );

--- a/src/RefreshToken.php
+++ b/src/RefreshToken.php
@@ -27,6 +27,10 @@ class RefreshToken {
 	 * @since 1.4.0
 	 */
 	public static function schedule_event() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
 		if ( ! has_action( Heartbeat::DAILY, array( self::class, 'handle_refresh' ) ) ) {
 			add_action( Heartbeat::DAILY, array( self::class, 'handle_refresh' ), 20 );
 		}

--- a/tests/Unit/HeartbeatTest.php
+++ b/tests/Unit/HeartbeatTest.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use Automattic\WooCommerce\Pinterest\Heartbeat;
+use Pinterest_For_Woocommerce;
 
 class HeartbeatTest extends \WP_UnitTestCase {
 
@@ -20,6 +21,9 @@ class HeartbeatTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_cancel_jobs_removes_daily_and_hourly_as_actions() {
+		// Jobs will schedule only if Pinterest is connected (means integration data is set and has the ID).
+		Pinterest_For_Woocommerce::save_data( 'integration_data', array( 'id' => '567891567892' ) );
+
 		$this->heartbeat->schedule_events();
 
 		$this->assertTrue( as_has_scheduled_action( Heartbeat::HOURLY, array(), 'pinterest-for-woocommerce' ) );

--- a/tests/Unit/HeartbeatTest.php
+++ b/tests/Unit/HeartbeatTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\Heartbeat;
+
+class HeartbeatTest extends \WP_UnitTestCase {
+
+	/** @var Heartbeat */
+	private $heartbeat;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->heartbeat = new Heartbeat( WC()->queue() );
+	}
+
+	/**
+	 * Tests feed generator registers the action scheduler failed execution hook.
+	 *
+	 * @return void
+	 */
+	public function test_cancel_jobs_removes_daily_and_hourly_as_actions() {
+		$this->heartbeat->schedule_events();
+
+		$this->assertTrue( as_has_scheduled_action( Heartbeat::HOURLY, array(), 'pinterest-for-woocommerce' ) );
+		$this->assertTrue( as_has_scheduled_action( Heartbeat::DAILY, array(), 'pinterest-for-woocommerce' ) );
+
+		$this->heartbeat->cancel_jobs();
+
+		$this->assertFalse( as_has_scheduled_action( Heartbeat::HOURLY, array(), 'pinterest-for-woocommerce' ) );
+		$this->assertFalse( as_has_scheduled_action( Heartbeat::DAILY, array(), 'pinterest-for-woocommerce' ) );
+	}
+}

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
+use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Automattic\WooCommerce\Pinterest\RefreshToken;
 use Pinterest_For_Woocommerce;
@@ -268,5 +269,13 @@ class PinterestForWoocommerceTest extends WP_UnitTestCase {
 			'partner_metadata'             => 'partner-meta-data',
 		);
 		Pinterest_For_Woocommerce::update_commerce_integration( 'ebi-123456789', $data );
+	}
+
+	public function test_disconnect_removes_as_daily_and_hourly_actions() {
+		$heartbeat = new Heartbeat( WC()->queue() );
+		$heartbeat->schedule_events();
+		Pinterest_For_Woocommerce::disconnect();
+		$this->assertFalse( as_has_scheduled_action( Heartbeat::HOURLY, array(), 'pinterest-for-woocommerce' ) );
+		$this->assertFalse( as_has_scheduled_action( Heartbeat::DAILY, array(), 'pinterest-for-woocommerce' ) );
 	}
 }

--- a/tests/Unit/RefreshTokenTest.php
+++ b/tests/Unit/RefreshTokenTest.php
@@ -22,6 +22,9 @@ class RefreshTokenTest extends \WP_UnitTestCase {
 	}
 
 	public function test_schedule_event_adds_daily_action() {
+		// Jobs will schedule only if Pinterest is connected (means integration data is set and has the ID).
+		Pinterest_For_Woocommerce::save_data( 'integration_data', array( 'id' => '567891567892' ) );
+
 		RefreshToken::schedule_event();
 		$this->assertEquals( 20, has_action( Heartbeat::DAILY, array( RefreshToken::class, 'handle_refresh' ) ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Closes #1008 .

Cancels all the Pinterest for WooCommerce Heartbeat jobs on plugin disconnect, deactivate and WooCommerce deactivate events.

The wrong behavior is that after disconnecting, you still have some Pinterest for WooCommerce actions running, which require Pinterest connection to function. The same is true for deactivating the plugin.

<img width="1263" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-2" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/18274408-5a81-46c7-a950-ce26407070c9">

### Detailed test instructions:

#### Scenario 1. Disconnect plugin.
1. Connect to Pinterest.
2. Go to _WooCommerce_ - _Status_ - _Scheduled Actions_ - _Pending_.
3. Observe four scheduled actions.

<img width="1263" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/1db8e09a-6774-436f-9b38-282fc3fae3b5">

4. Go to Marketing - Pinterest - Connection.
5. Disconnect from Pinterest.
6. Go to _WooCommerce_ - _Status_ - _Scheduled Actions_ - _Pending_.
7. Observe that there are no Pinterest for WooCommerce actions scheduled.

<img width="1263" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-3" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/623a0187-b2aa-4f04-a2e0-654524176a91">

#### Scenario 2. Deactivate plugin.
1. Connect to Pinterest.
2. Go to _WooCommerce_ - _Status_ - _Scheduled Actions_ - _Pending_.
3. Observe four scheduled actions.
4. Go to Plugins.
5. Deactivate the Pinterest for WooCommerce plugin.
6. Go to _WooCommerce_ - _Status_ - _Scheduled Actions_ - _Pending_.
7. Observe that there are no Pinterest for WooCommerce actions scheduled.


### Changelog entry

> Fix - Cancel hourly and daily plugin jobs on disconnect and deactivate.
