### PR TITLE
Don't sync aems when tracking is not enabled.

### DIFF
--- a/src/PinterestSyncSettings.php
+++ b/src/PinterestSyncSettings.php
@@ -95,6 +95,14 @@ class PinterestSyncSettings {
 	 * @throws Exception PHP Exception.
 	 */
 	private static function automatic_enhanced_match_support() {
+		/*
+		 * Tracking needs to be enabled in order to use automatic enhanced match support.
+		 */
+		$is_tracking_enabled = Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
+		if ( ! $is_tracking_enabled ) {
+			return false;
+		}
+
 		try {
 			$advertiser_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
 			$tag_id        = Pinterest_For_WooCommerce()::get_setting( 'tracking_tag' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1014 .

Do not attempt AEMS setting sync when tracking is not enabled.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect with this PR, opt out from the tracking
2. wp-admin -> Marketing -> Pinterest -> Settings
3. For settings sync:
![image](https://github.com/woocommerce/pinterest-for-woocommerce/assets/17271089/6bff2281-93b0-48ce-9d25-6f33df273392)

4. Go to logs and look for `Tracking advertiser or tag missing` it should not be there 😉 

