### PR TITLE
Adds WooCommerce as a dependency to the plugin header

### DIFF
--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -20,6 +20,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       pinterest-for-woocommerce
  * Domain Path:       /i18n/languages
+ * Requires Plugins:  woocommerce
  *
  * Requires at least: 5.6
  * Tested up to: 6.5

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -89,7 +89,7 @@ if ( is_readable( $autoloader ) ) {
 	 */
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			?>
 			<div class="notice notice-error">
 				<p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1017.

In this PR, we add WooCommerce as a dependency using the `Requires Plugins` header.


### Screenshots:

<!--- Optional --->

#### Screenshot 1

![image](https://github.com/woocommerce/pinterest-for-woocommerce/assets/179533/3c64c9bd-c063-4fa0-94d8-3b81a963ccb8)

#### Screenshot 2

![image](https://github.com/woocommerce/pinterest-for-woocommerce/assets/179533/76fe8a1e-136b-408e-83b1-e59d3d298c90)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate Pinterest for WooCommerce plugin without WooCommerce activated.
2. Verify an error notice is displayed with message: This plugin is active but may not function correctly because required plugins are missing or inactive. (Screenshot 1)
3. Activate WooCommerce. Verify the dependencies are displayed on the plugin screen (Screenshot 2)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Adds WooCommerce as a dependency to the plugin header
