### PR TITLE
Fix - Undefined array key "path" warning thrown by DomainVerification.php

### DIFF
--- a/src/API/DomainVerification.php
+++ b/src/API/DomainVerification.php
@@ -63,7 +63,7 @@ class DomainVerification extends VendorAPI {
 				$domain_verification_data = APIV5::domain_verification_data();
 				Pinterest_For_Woocommerce()::save_data( 'verification_data', $domain_verification_data );
 				$parsed_website = wp_parse_url( get_home_url() );
-				$result         = APIV5::domain_metatag_verification_request( $parsed_website['host'] . $parsed_website['path'] );
+				$result         = APIV5::domain_metatag_verification_request( $parsed_website['host'] . ( $parsed_website['path'] ?? '' ) );
 				if ( in_array( $result['status'], array( 'success', 'already_verified_by_user' ) ) ) {
 					$account_data['verified_user_websites'][] = $result['website'];
 					$account_data['is_any_website_verified']  = 0 < count( $account_data['verified_user_websites'] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #903.

Closes #1022.

I encountered the following while testing for WC 9.0 compat.
PHP Warning: Undefined array key "path" in /srv/htdocs/wp-content/plugins/pinterest-for-woocommerce/src/API/DomainVerification.php on line 66. This PR fixes this.


### Detailed test instructions:

1. Install on a store with PHP 8.3.
2. Enable WP_DEBUG, WP_DEBUG_LOGGING.
3. Go through smoke testing steps: [Wiki: Smoke Tests ()](https://github.com/woocommerce/pinterest-for-woocommerce/wiki/Smoke-Tests)
4. Check the logs for warnings or notices.
5. (See issues for exact notices that could be present)

### Changelog entry

> Fix - Undefined array key "path" warning thrown by DomainVerification.php
