### PR TITLE
Remove CAPI tracker by Pinterest request.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -335,11 +335,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				return false;
 			}
 
-			$tag_tracker         = new Tag();
-			$user                = new User( WC_Geolocation::get_ip_address(), wc_get_user_agent() );
-			$conversions_tracker = new Conversions( $user );
+			$tag_tracker = new Tag();
 
-			return new Tracking( array( $tag_tracker, $conversions_tracker ) );
+			return new Tracking( array( $tag_tracker ) );
 		}
 
 		/**

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -328,18 +328,15 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			 *
 			 * @param bool $disable_tracking Whether to disable tracking.
 			 */
-			$is_tracking_disabled = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
-			$is_not_a_site        = wp_doing_cron() || is_admin();
-			if ( $is_tracking_disabled || $is_not_a_site ) {
+			$is_tracking_disabled             = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
+			$is_tracking_conversions_disabled = ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
+			$is_not_a_site                    = wp_doing_cron() || is_admin();
+
+			if ( $is_tracking_disabled || $is_tracking_conversions_disabled || $is_not_a_site ) {
 				return false;
 			}
 
-			$is_tracking_conversions_enabled      = Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
 			$is_tracking_conversions_capi_enabled = Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
-
-			if ( ! $is_tracking_conversions_enabled ) {
-				return false;
-			}
 
 			$tracking = new Tracking( array( new Tag() ) );
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -125,6 +125,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		protected static $default_settings = array(
 			'track_conversions'                => true,
+			'track_conversions_capi'           => false,
 			'enhanced_match_support'           => true,
 			'automatic_enhanced_match_support' => true,
 			'save_to_pinterest'                => true,
@@ -327,17 +328,28 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			 *
 			 * @param bool $disable_tracking Whether to disable tracking.
 			 */
-			$is_tracking_disabled             = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
-			$is_tracking_conversions_disabled = ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
-			$is_not_a_site                    = wp_doing_cron() || is_admin();
-
-			if ( $is_tracking_disabled || $is_tracking_conversions_disabled || $is_not_a_site ) {
+			$is_tracking_disabled = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
+			$is_not_a_site        = wp_doing_cron() || is_admin();
+			if ( $is_tracking_disabled || $is_not_a_site ) {
 				return false;
 			}
 
-			$tag_tracker = new Tag();
+			$is_tracking_conversions_enabled      = Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
+			$is_tracking_conversions_capi_enabled = Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
 
-			return new Tracking( array( $tag_tracker ) );
+			if ( ! $is_tracking_conversions_enabled ) {
+				return false;
+			}
+
+			$tracking = new Tracking( array( new Tag() ) );
+
+			if ( $is_tracking_conversions_capi_enabled ) {
+				$user                = new User( WC_Geolocation::get_ip_address(), wc_get_user_agent() );
+				$conversions_tracker = new Conversions( $user );
+				$tracking->add_tracker( $conversions_tracker );
+			}
+
+			return $tracking;
 		}
 
 		/**

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -139,10 +139,17 @@ class Auth extends VendorAPI {
 	/**
 	 * Applies the features from the OAuth flow to the plugin settings.
 	 *
-	 * @param array $features The features selected by the merchant during the OAuth flow.
+	 * @param array $features {
+	 *      The features selected by the merchant during the OAuth flow.
+	 *
+	 *      @type bool $tags    Whether Pinterest Tag was enabled.
+	 *      @type bool $CAPI    Whether Conversions API was enabled.
+	 *      @type bool $catalog Whether Catalog synchronisation was enabled.
+	 * }
 	 */
-	private function apply_oauth_flow_features( $features ) {
+	private function apply_oauth_flow_features( array $features ): void {
 		Pinterest_For_Woocommerce()::save_setting( 'track_conversions', $features['tags'] ?? false );
+		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
 		Pinterest_For_Woocommerce()::save_setting( 'product_sync_enabled', $features['catalog'] ?? false );
 	}
 

--- a/src/TrackerSnapshot.php
+++ b/src/TrackerSnapshot.php
@@ -79,11 +79,11 @@ class TrackerSnapshot {
 	 * @return array
 	 */
 	protected static function parse_settings(): array {
-
-		$settings = (array) Pinterest_For_Woocommerce()::get_settings( true );
+		$settings = Pinterest_For_Woocommerce()::get_settings( true );
 
 		$tracked_settings = array(
 			'track_conversions',
+			'track_conversions_capi',
 			'enhanced_match_support',
 			'automatic_enhanced_match_support',
 			'save_to_pinterest',

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Automattic\WooCommerce\Pinterest\RefreshToken;
+use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
+use Automattic\WooCommerce\Pinterest\Tracking\Tag;
 use Pinterest_For_Woocommerce;
 use WP_UnitTestCase;
 
@@ -25,6 +27,7 @@ class PinterestForWoocommerceTest extends WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'track_conversions'                => true,
+				'track_conversions_capi'           => false,
 				'enhanced_match_support'           => true,
 				'automatic_enhanced_match_support' => true,
 				'save_to_pinterest'                => true,
@@ -277,5 +280,69 @@ class PinterestForWoocommerceTest extends WP_UnitTestCase {
 		Pinterest_For_Woocommerce::disconnect();
 		$this->assertFalse( as_has_scheduled_action( Heartbeat::HOURLY, array(), 'pinterest-for-woocommerce' ) );
 		$this->assertFalse( as_has_scheduled_action( Heartbeat::DAILY, array(), 'pinterest-for-woocommerce' ) );
+	}
+
+	public function test_init_tracking_inits_if_at_least_one_tracker() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
+		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+	}
+
+	public function test_init_tracking_does_not_init_if_no_trackers() {
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+
+		$this->assertFalse( has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
+		$this->assertFalse( has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
+		$this->assertFalse( has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
+		$this->assertFalse( has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
+		$this->assertFalse( has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
+	}
+
+	public function test_init_tracking_inits_tag_tracker() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions_capi', false );
+
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+
+		$trackers = $tracking->get_trackers();
+
+		$this->assertCount( 1, $trackers );
+		$this->assertInstanceOf( Tag::class, current( $trackers ) );
+	}
+
+	public function test_init_tracking_does_not_init_capi_tracker_if_tag_tracker_disabled() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', false );
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions_capi', true );
+
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+		$this->assertFalse( $tracking );
+	}
+
+	public function test_init_tracking_inits_no_trackers() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', false );
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions_capi', false );
+
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+
+		$this->assertFalse( $tracking );
+	}
+
+	public function test_init_tracking_inits_both_trackers() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions_capi', true );
+
+		$tracking = Pinterest_For_Woocommerce::init_tracking();
+
+		$trackers = $tracking->get_trackers();
+
+		$this->assertCount( 2, $trackers );
+		$this->assertInstanceOf( Tag::class, array_shift( $trackers ) );
+		$this->assertInstanceOf( Conversions::class, array_shift( $trackers ) );
 	}
 }

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -13,19 +13,6 @@ class TrackingTest extends \WP_UnitTestCase {
 		parent::setUp();
 	}
 
-	public function test_init_tracking_inits() {
-		Pinterest_For_Woocommerce::save_settings( array( 'track_conversions' => true ) );
-		add_filter( 'wp_doing_cron', '__return_false' );
-
-		$tracking = Pinterest_For_Woocommerce::init_tracking();
-
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_page_visit' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_view_category' ) ) );
-		$this->assertEquals( 10, has_action( 'woocommerce_add_to_cart', array( $tracking, 'handle_add_to_cart' ) ) );
-		$this->assertEquals( 10, has_action( 'woocommerce_before_thankyou', array( $tracking, 'handle_checkout' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_footer', array( $tracking, 'handle_search' ) ) );
-	}
-
 	function test_tracking_adds_actions_monitoring() {
 		$tracking = new Tracking();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Disabling Conversion API tracker according to some temporary legal aspects from Pinterest.

### How to test.

1. Install Pinterest extension.
2. Following the Connect Wizard, set up conversion tracking.

<img width="577" alt="Pinterest" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/9010963/b2f1e5f9-91a7-4e7a-a5ac-0f2c1325975d">

3. Setting up conversion tracking will send the extension corresponding boolean flags to indicate Pinterest Tag tracking and Conversions API tracking must be enabled.
4. Check `pinterest_for_woocommerce` option inside `wp_options` database table.
5. The option must include `s:22:"track_conversions_capi";b:0;` serialized data.
6. The above will indicate the despite Pinterest is sending us Conversions API is `ON`, we force it `OFF` into options.
e.g. `s:17:"track_conversions";b:1;s:22:"track_conversions_capi";b:0;`: Pinterest Tag on `ON`, but Conversions API is `OFF`.

### Changelog entry

> Update - Disabling CAPI tracker.
