### PR TITLE
Fix pagination on feed_issues endpoint

### DIFF
--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -8,12 +8,12 @@ import {
 	ExternalLink,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { REPORTS_STORE_NAME } from '../data';
 import SyncIssuesTable from './SyncIssuesTable';
-import { __, sprintf } from '@wordpress/i18n';
 import { useSettingsSelect } from '../../setup-guide/app/helpers/effects';
 
 const SyncIssues = () => {

--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { getHistory, getQuery, onQueryChange } from '@woocommerce/navigation';
@@ -8,7 +9,7 @@ import {
 	ExternalLink,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */

--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -2,16 +2,24 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import {createInterpolateElement, useState} from '@wordpress/element';
 import { getHistory, getQuery, onQueryChange } from '@woocommerce/navigation';
-
+import {
+	ExternalLink,
+	Icon,
+	Notice,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
+} from '@wordpress/components';
 /**
  * Internal dependencies
  */
 import { REPORTS_STORE_NAME } from '../data';
 import SyncIssuesTable from './SyncIssuesTable';
+import {__, sprintf} from "@wordpress/i18n";
+import {useSettingsSelect} from "../../setup-guide/app/helpers/effects";
 
 const SyncIssues = () => {
+	const itemsLimit = 250
 	const [ query, setQuery ] = useState( getQuery() );
 	const feedIssues = useSelect( ( select ) =>
 		select( REPORTS_STORE_NAME ).getFeedIssues( query )
@@ -19,6 +27,11 @@ const SyncIssues = () => {
 	const isRequesting = useSelect( ( select ) =>
 		select( REPORTS_STORE_NAME ).isRequesting()
 	);
+
+	const appSettings = useSettingsSelect();
+	const trackingAdvertiser = appSettings?.tracking_advertiser;
+
+	const total = feedIssues?.total_rows ?? 0
 
 	if ( ! feedIssues?.lines?.length ) {
 		return null;
@@ -37,13 +50,37 @@ const SyncIssues = () => {
 	}
 
 	return (
-		<SyncIssuesTable
-			issues={ feedIssues?.lines }
-			query={ query }
-			totalRows={ feedIssues?.total_rows ?? 0 }
-			isRequesting={ isRequesting }
-			onQueryChange={ onQueryChange }
-		/>
+		<>
+			{
+				itemsLimit === total && (
+					<Text style={{ marginTop: "40px", textAlign: "right" }}>
+						{ createInterpolateElement(
+								sprintf(
+									// translators: %1$s: Amount of money required to spend to claim ad credits with currency. %2$s: Amount of ad credits given with currency.
+									__(
+										'Only the first %1$s Errors and Warnings are displayed below. To see more, please, visit <feedDiagnostics>Pinterest Feed Diagnostics</feedDiagnostics> page.',
+										'pinterest-for-woocommerce'
+									),
+									total
+								),
+								{
+									feedDiagnostics: <ExternalLink
+										href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${trackingAdvertiser}` }
+									/>
+								}
+							)
+						}
+					</Text>
+				)
+			}
+			<SyncIssuesTable
+				issues={feedIssues?.lines}
+				query={query}
+				totalRows={total}
+				isRequesting={isRequesting}
+				onQueryChange={onQueryChange}
+			/>
+		</>
 	);
 };
 

--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -13,11 +13,11 @@ import {
  */
 import { REPORTS_STORE_NAME } from '../data';
 import SyncIssuesTable from './SyncIssuesTable';
-import {__, sprintf} from "@wordpress/i18n";
-import {useSettingsSelect} from "../../setup-guide/app/helpers/effects";
+import { __, sprintf } from '@wordpress/i18n';
+import { useSettingsSelect } from '../../setup-guide/app/helpers/effects';
 
 const SyncIssues = () => {
-	const itemsLimit = 250
+	const itemsLimit = 250;
 	const [ query, setQuery ] = useState( getQuery() );
 	const feedIssues = useSelect( ( select ) =>
 		select( REPORTS_STORE_NAME ).getFeedIssues( query )
@@ -29,11 +29,11 @@ const SyncIssues = () => {
 	const appSettings = useSettingsSelect();
 	const trackingAdvertiser = appSettings?.tracking_advertiser;
 
-	const total = feedIssues?.total_rows ?? 0
+	const total = feedIssues?.total_rows ?? 0;
 
 	const messageStyles = {
 		marginTop: '40px',
-		textAlign: 'right'
+		textAlign: 'right',
 	};
 
 	if ( ! feedIssues?.lines?.length ) {
@@ -70,13 +70,11 @@ const SyncIssues = () => {
 								<ExternalLink
 									href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${ trackingAdvertiser }` }
 								/>
-							)
+							),
 						}
-						)
-					}
+					) }
 				</Text>
-				)
-			}
+			) }
 			<SyncIssuesTable
 				issues={ feedIssues?.lines }
 				query={ query }

--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -32,9 +32,9 @@ const SyncIssues = () => {
 	const total = feedIssues?.total_rows ?? 0
 
 	const messageStyles = {
-		marginTop: "40px",
-		textAlign: "right"
-	}
+		marginTop: '40px',
+		textAlign: 'right'
+	};
 
 	if ( ! feedIssues?.lines?.length ) {
 		return null;
@@ -54,28 +54,27 @@ const SyncIssues = () => {
 
 	return (
 		<>
-			{
-				itemsLimit === total && (
-					<Text style={ messageStyles }>
-						{ createInterpolateElement(
-								sprintf(
-									// translators: %1$s: Total number of issues in the table.
-									__(
-										'Only the first %1$s Errors and Warnings are displayed below. To see more, please, visit <feedDiagnostics>Pinterest Feed Diagnostics</feedDiagnostics> page.',
-										'pinterest-for-woocommerce'
-									),
-									total
-								),
-								{
-									feedDiagnostics: (
-										<ExternalLink
-											href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${trackingAdvertiser}` }
-										/>
-									)
-								}
+			{ itemsLimit === total && (
+				<Text style={ messageStyles }>
+					{ createInterpolateElement(
+						sprintf(
+							// translators: %1$s: Total number of issues in the table.
+							__(
+								'Only the first %1$s Errors and Warnings are displayed below. To see more, please, visit <feedDiagnostics>Pinterest Feed Diagnostics</feedDiagnostics> page.',
+								'pinterest-for-woocommerce'
+							),
+							total
+						),
+						{
+							feedDiagnostics: (
+								<ExternalLink
+									href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${ trackingAdvertiser }` }
+								/>
 							)
 						}
-					</Text>
+						)
+					}
+				</Text>
 				)
 			}
 			<SyncIssuesTable

--- a/assets/source/catalog-sync/sections/SyncIssues.js
+++ b/assets/source/catalog-sync/sections/SyncIssues.js
@@ -2,12 +2,10 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {createInterpolateElement, useState} from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 import { getHistory, getQuery, onQueryChange } from '@woocommerce/navigation';
 import {
 	ExternalLink,
-	Icon,
-	Notice,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis --- _experimentalText unlikely to change/disappear and also used by WC Core
 } from '@wordpress/components';
 /**
@@ -33,6 +31,11 @@ const SyncIssues = () => {
 
 	const total = feedIssues?.total_rows ?? 0
 
+	const messageStyles = {
+		marginTop: "40px",
+		textAlign: "right"
+	}
+
 	if ( ! feedIssues?.lines?.length ) {
 		return null;
 	}
@@ -53,10 +56,10 @@ const SyncIssues = () => {
 		<>
 			{
 				itemsLimit === total && (
-					<Text style={{ marginTop: "40px", textAlign: "right" }}>
+					<Text style={ messageStyles }>
 						{ createInterpolateElement(
 								sprintf(
-									// translators: %1$s: Amount of money required to spend to claim ad credits with currency. %2$s: Amount of ad credits given with currency.
+									// translators: %1$s: Total number of issues in the table.
 									__(
 										'Only the first %1$s Errors and Warnings are displayed below. To see more, please, visit <feedDiagnostics>Pinterest Feed Diagnostics</feedDiagnostics> page.',
 										'pinterest-for-woocommerce'
@@ -64,9 +67,11 @@ const SyncIssues = () => {
 									total
 								),
 								{
-									feedDiagnostics: <ExternalLink
-										href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${trackingAdvertiser}` }
-									/>
+									feedDiagnostics: (
+										<ExternalLink
+											href={ `https://pinterest.com/business/catalogs/diagnosticsv2/?advertiserId=${trackingAdvertiser}` }
+										/>
+									)
 								}
 							)
 						}
@@ -74,11 +79,11 @@ const SyncIssues = () => {
 				)
 			}
 			<SyncIssuesTable
-				issues={feedIssues?.lines}
-				query={query}
-				totalRows={total}
-				isRequesting={isRequesting}
-				onQueryChange={onQueryChange}
+				issues={ feedIssues?.lines }
+				query={ query }
+				totalRows={ total }
+				isRequesting={ isRequesting }
+				onQueryChange={ onQueryChange }
 			/>
 		</>
 	);

--- a/tests/Unit/Api/FeedIssuesTest.php
+++ b/tests/Unit/Api/FeedIssuesTest.php
@@ -1,0 +1,197 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit\Api;
+
+use Pinterest_For_Woocommerce;
+use WC_Helper_Product;
+use WP_REST_Request;
+use WP_Test_REST_TestCase;
+
+class FeedIssuesTest extends WP_Test_REST_TestCase {
+
+	/**
+	 * Tests if the feed issues route is registered.
+	 *
+	 * @return void
+	 */
+	public function test_feed_issues_route_registered() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/pinterest/v1/feed_issues', $routes );
+	}
+
+	/**
+	 * Tests if the feed issues endpoint rejects access.
+	 *
+	 * @return void
+	 */
+	public function test_feed_issues_endpoint_rejects_access() {
+		// 1. No authentication.
+		$request  = new WP_REST_Request( 'GET', '/pinterest/v1/feed_issues' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+
+		// 2. No authorisation.
+		$user = $this->factory->user->create( array( 'role' => 'guest' ) );
+		wp_set_current_user( $user );
+
+		$request  = new WP_REST_Request( 'GET', '/pinterest/v1/feed_issues' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Tests if the feed issues endpoint returns feed issues.
+	 *
+	 * @return void
+	 */
+	public function test_feed_issues_endpoint_returns_feed_issues() {
+		$user              = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user );
+		$product1          = WC_Helper_Product::create_simple_product();
+		$product2          = WC_Helper_Product::create_simple_product();
+		$mock_account_data = array (
+			'verified_user_websites'  => array ( 'mysite.test' ),
+			'is_any_website_verified' => true,
+		);
+		$mock_feed_id      = uniqid();
+
+		Pinterest_For_WooCommerce::save_setting( 'tracking_advertiser', 'ai-123456789' );
+		Pinterest_For_WooCommerce::save_setting( 'account_data', $mock_account_data );
+		Pinterest_For_Woocommerce::save_setting( 'product_sync_enabled', true );
+		Pinterest_For_Woocommerce::save_data( 'feed_registered', $mock_feed_id  );
+
+		add_filter(
+			'home_url',
+			function () {
+				return 'https://mysite.test/';
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( $mock_feed_id, $product1, $product2 ) {
+				if ( str_contains( $url, "catalogs/feeds/{$mock_feed_id}/processing_results" ) ) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								'items' => array(
+									array(
+										'id' => '1234567890123456789',
+									)
+								),
+							)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+				if ( str_contains( $url, "catalogs/processing_results/1234567890123456789/item_issues" ) ){
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array(
+								'items' => array (
+									0 =>
+										array (
+											'warnings' =>
+												array (
+													'OPTIONAL_CONDITION_MISSING' =>
+														array (
+															'attribute_name' => 'CONDITION',
+															'provided_value' => '',
+														),
+													'OPTIONAL_PRODUCT_CATEGORY_MISSING' =>
+														array (
+															'attribute_name' => 'GOOGLE_PRODUCT_CATEGORY',
+															'provided_value' => '',
+														),
+												),
+											'item_number' => 0,
+											'item_id' => $product1->get_id(),
+											'errors' =>
+												array (
+													'IMAGE_LINK_MISSING' =>
+														array (
+															'attribute_name' => 'IMAGE_LINK',
+															'provided_value' => '',
+														),
+												),
+										),
+									1 =>
+										array (
+											'warnings' =>
+												array (
+													'OPTIONAL_CONDITION_MISSING' =>
+														array (
+															'attribute_name' => 'CONDITION',
+															'provided_value' => '',
+														),
+													'OPTIONAL_PRODUCT_CATEGORY_MISSING' =>
+														array (
+															'attribute_name' => 'GOOGLE_PRODUCT_CATEGORY',
+															'provided_value' => '',
+														),
+												),
+											'item_number' => 1,
+											'item_id' => $product2->get_id(),
+											'errors' =>
+												array (
+													'IMAGE_LINK_MISSING' =>
+														array (
+															'attribute_name' => 'IMAGE_LINK',
+															'provided_value' => '',
+														),
+												),
+										)
+								)
+								)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies' => array(),
+						'filename' => '',
+					);
+				}
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/pinterest/v1/feed_issues' );
+		$request->set_query_params( array(
+			'paged' => 1,
+			'per_page' => 4
+		) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertEquals( $response_data['total_rows'], 6 );
+		$this->assertCount( 4, $response_data['lines'] );
+
+		$request  = new WP_REST_Request( 'GET', '/pinterest/v1/feed_issues' );
+		$request->set_query_params( array(
+			'paged' => 2,
+			'per_page' => 4
+		) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertEquals( $response_data['total_rows'], 6 );
+		$this->assertCount( 2, $response_data['lines'] );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #936 

Fix the pagination on the Feed Issues table by slicing the results based on `per_page` and `paged` parameters.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Requires a site connected to Pinterest and a synched catalog with issues. 
2. Go to wp-admin/Marketing/Pinterest
3. If your catalog has more than 25 issues, check the pagination works
4. If your catalog has less than 25 issues, add the parameters to the query and check the number of issues displayed is correct. (Ex: on a catalog with 18 issues `page=wc-admin&path=%2Fpinterest%2Fcatalog&paged=2&per_page=10` should display 8 issues)

<img width="1306" alt="Screenshot 2024-06-21 at 7 17 16 PM" src="https://github.com/woocommerce/pinterest-for-woocommerce/assets/8002881/5c9f00fe-085a-47f7-8e4e-d9e7ed8765cf">


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Pagination on Feed Issues table.
