### PR TITLE
Add regenerator-runtime as script dependency (quick fix for WordPress 6.6 breaking change)

### DIFF
--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -276,6 +276,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 					'version'      => PINTEREST_FOR_WOOCOMMERCE_VERSION,
 				);
 
+			// This is a quick fix for a breaking change in WP 6.6.
+			// We may not need this in the future when we update `@wordpress/*` packages to newer versions.
+			$script_info['dependencies'][] = 'regenerator-runtime';
+
 			$script_info['dependencies'][] = 'wc-settings';
 
 			wp_register_script(
@@ -503,7 +507,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 
 			wp_safe_redirect( Pinterest_For_Woocommerce()::get_middleware_url( $context, $args ) );
 			exit;
-
+			
 		}
 
 		/**

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -507,7 +507,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 
 			wp_safe_redirect( Pinterest_For_Woocommerce()::get_middleware_url( $context, $args ) );
 			exit;
-			
+
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/1031. For the cause of issue and related readings on `regenerator-runtime`, see https://github.com/woocommerce/pinterest-for-woocommerce/issues/1031#issuecomment-2210937988.

In this PR, we add `regenerator-runtime` as a script dependency. This is a quick fix for a breaking change in WordPress 6.6.

I believe we may not need this quick fix in the future when we update the `@wordpress/*` packages and rely on Dependency Extraction (without bundling the packages).

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use WordPress 6.6.
2. Install and activate Pinterest extension with this PR.
3. Go to the Pinterest plugin landing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`. You should see the landing page nicely. There should be no console error.
4. Downgrade to WordPress 6.5.
5. Go to the Pinterest plugin landing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Flanding`. You should see the landing page nicely. There should be no console error.

![image](https://github.com/woocommerce/pinterest-for-woocommerce/assets/417342/47ad36ee-b09d-4cff-a19b-e971adecfdf2)
