### PR TITLE
Fix checkbox control UI issue with WordPress 6.6

### DIFF
--- a/assets/source/setup-guide/app/style.scss
+++ b/assets/source/setup-guide/app/style.scss
@@ -21,6 +21,18 @@ $root: ".woocommerce-setup-guide";
 	}
 }
 
+// This is to fix breaking changes in checkbox control UI in WP 6.6.
+// Code is copied from https://github.com/WordPress/gutenberg/pull/60475.
+:root {
+	--checkbox-input-size: 24px; // Width & height for small viewports.
+
+	@include break-small() {
+		--checkbox-input-size: 20px;
+	}
+
+	--checkbox-input-margin: #{$grid-unit-10};
+}
+
 #{$root} {
 
 	&__body {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://github.com/woocommerce/pinterest-for-woocommerce/issues/1033.

In this PR, we fix the checkbox control UI issue with WordPress 6.6. 

The fix here is done by referring to the cause of issue mentioned in https://github.com/woocommerce/pinterest-for-woocommerce/issues/1033. We specify the `--checkbox-input-size` CSS variable so that the checkbox control has a defined width and height.

### Screenshots:

![Screenshot 2024-07-09 at 12 28 54 AM](https://github.com/woocommerce/pinterest-for-woocommerce/assets/417342/987c8764-6f8a-4b2d-8abe-0ecc452b4caf)

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make sure that you use WordPress 6.6. 
2. Go to the extension settings page: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`
3. The checkbox controls should be displayed nicely as shown in the screenshot above. 
4. Do some exploratory testing to make sure that the CSS changes in this PR does not breaking anything.
5. Downgrade WordPress to older version (e.g. version 6.5). Repeat the above testing to make sure that the CSS changes in this PR works well with older WordPress version.
