### PR TITLE
Replacing determine_locale with get_locale.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,11 +6,16 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
-		defaultTestSuite="unit"
 >
 	<testsuites>
 		<testsuite name="unit">
-			<directory suffix=".php">./tests/Unit</directory>
+			<directory>./tests/Unit</directory>
+		</testsuite>
+		<testsuite name="integration">
+			<directory>./tests/Integration</directory>
+		</testsuite>
+		<testsuite name="e2e">
+			<directory>./tests/E2e</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -117,7 +117,7 @@ class LocaleMapper {
 	 * @return string
 	 */
 	private static function get_wordpress_locale() {
-		$wordpress_locale = determine_locale();
+		$wordpress_locale = get_locale();
 		return str_replace( '_', '-', $wordpress_locale );
 	}
 }

--- a/tests/E2e/Pinterest401DisconnectE2eTest.php
+++ b/tests/E2e/Pinterest401DisconnectE2eTest.php
@@ -1,10 +1,13 @@
-<?php
+<?php declare( strict_types=1 );
 
-use Automattic\WooCommerce\Pinterest\API\APIV5;
+namespace Automattic\WooCommerce\Pinterest\Tests\E2e;
+
 use Automattic\WooCommerce\Pinterest\Notes\TokenInvalidFailure;
+use Exception;
+use Pinterest_For_Woocommerce;
 
-class Pinterest401DisconnectE2eTest extends WP_UnitTestCase {
-
+class Pinterest401DisconnectE2eTest extends \WP_UnitTestCase
+{
 	protected function setUp(): void {
 		parent::setUp();
 

--- a/tests/E2e/PinterestConnectE2eTest.php
+++ b/tests/E2e/PinterestConnectE2eTest.php
@@ -1,8 +1,17 @@
-<?php
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Tests\E2e;
 
 use Automattic\WooCommerce\Pinterest\Notes\TokenInvalidFailure;
+use Pinterest_For_Woocommerce;
 
-class PinterestConnectE2eTest extends WP_UnitTestCase {
+class PinterestConnectE2eTest extends \WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Pinterest_For_Woocommerce::save_settings( [] );
+	}
 
 	/**
 	 * Tests successful Pinterest auth produces proper settings after all pinterest_for_woocommerce_token_saved hooks are fired.
@@ -80,6 +89,7 @@ class PinterestConnectE2eTest extends WP_UnitTestCase {
 				'erase_plugin_data'                => false,
 				'tracking_advertiser'              => '549765662491',
 				'tracking_tag'                     => '2613286171854',
+				'track_conversions_capi'           => false,
 			),
 			$settings
 		);

--- a/tests/Integration/FeedsTest.php
+++ b/tests/Integration/FeedsTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Integration;
+
+use Automattic\WooCommerce\Pinterest\Feeds;
+use Automattic\WooCommerce\Pinterest\PinterestApiException;
+use Pinterest_For_Woocommerce;
+
+class FeedsTest extends \WP_UnitTestCase {
+
+	/**
+	 * Tests emulates Pinterest create feed endpoint response when a feed with the same name already exists.
+	 *
+	 * @return void
+	 */
+	public function test_feed_registration_handles_422_name_already_exists()
+	{
+		$this->expectException( PinterestApiException::class );
+		$this->expectExceptionCode( 422 );
+		$this->expectExceptionMessage( 'Unprocessable Entity' );
+
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '123' );
+		Pinterest_For_Woocommerce::save_data( 'local_feed_ids', '' );
+
+		$this->create_feed_request_stub();
+
+		Feeds::create_feed();
+	}
+
+	private function create_feed_request_stub()
+	{
+		add_filter(
+			'pre_http_request',
+			function ($response, $parsed_args, $url) {
+				if ('https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=123' === $url) {
+					$response = array(
+						'headers'  => array(
+							'content-type' => 'application/json',
+						),
+						'body'     => json_encode(
+							array(
+								'code'    => 4170,
+								'message' => 'Unprocessable Entity',
+							)
+						),
+						'response' => array(
+							'code'    => 422,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+}

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -22,10 +22,10 @@ class PinterestTestLocaleMapper extends TestCase {
 	/**
 	 * Set up the filter for the locale.
 	 */
-    protected function setUp(): void
-    {
+	protected function setUp(): void
+	{
 		add_filter( 'locale', array( $this, 'locale_filter' ) );
-    }
+	}
 
 	/**
 	 * Remove the filter for the locale.

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -32,7 +32,7 @@ class PinterestTestLocaleMapper extends TestCase {
 	 */
 	protected function tearDown(): void
 	{
-		remove_filter( 'pre_determine_locale', array( $this, 'locale_filter' ) );
+		remove_filter( 'locale', array( $this, 'locale_filter' ) );
 	}
 
 	/**

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -24,7 +24,7 @@ class PinterestTestLocaleMapper extends TestCase {
 	 */
     protected function setUp(): void
     {
-		add_filter( 'pre_determine_locale', array( $this, 'locale_filter' ) );
+		add_filter( 'locale', array( $this, 'locale_filter' ) );
     }
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We need the locale from the website, not from the request. Replacing `determine_locale` with the `get_locale` function call.

### How to test

> You can reproduce the error by:
> 
> 1. Have a connected site with a feed in the site's default language
> 2. Activate the Pinterest logs
> 3. Change the language of your user (or create a new user with a different language than the site default)
> 4. Trigger the run of the scheduled action handle_feed_registration when logged in as that user.
> 5. Check the logs and you will see the creation of the feed with the user's locale
> 
> I checked some of the sites that were experiencing this issue. The site's language was different than the language of the admin user in WordPress.com. (Ex: en_GB on the site and en_US on the user, or en_US on the site and es_ES on the user)

Thanks, @brezocordero ! 

### Changelog entry

> Tweak - replace locale source function.
