### PR TITLE
Add Feed Name exists failure possible reason notice.

### DIFF
--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -15,7 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
+use Automattic\WooCommerce\Pinterest\Notes\FeedNameExistsFailure;
 use Exception;
+use Pinterest_For_Woocommerce;
 use Throwable;
 
 /**
@@ -152,6 +154,10 @@ class Feeds {
 		try {
 			$feed = APIV5::create_feed( $data, $ad_account_id );
 		} catch ( PinterestApiException $e ) {
+			if ( 422 === $e->getCode() ) {
+				FeedNameExistsFailure::possibly_add_note();
+			}
+
 			$delay = Pinterest_For_Woocommerce()::get_data( 'create_feed_delay' ) ?? MINUTE_IN_SECONDS;
 			set_transient( $cache_key, $e->getCode(), $delay );
 			// Double the delay.

--- a/src/Notes/FeedNameExistsFailure.php
+++ b/src/Notes/FeedNameExistsFailure.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WooCommerce Admin: Add First Product.
+ * WooCommerce Admin: Feed with the same name already exists at Pinterest notice.
  *
- * Adds a note (type `email`) to bring the client back to the store setup flow.
+ * Adds a note to inform clients there is a feed from another website already at Pinterest.
  *
  * @package Automattic\WooCommerce\Pinterest\Notes
  */
@@ -17,9 +17,9 @@ use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
- * Add_First_Product.
+ * Feed name already exists at Pinterest admin notice.
  */
-class TokenInvalidFailure {
+class FeedNameExistsFailure {
 	/**
 	 * Note traits.
 	 */
@@ -28,16 +28,18 @@ class TokenInvalidFailure {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'pinterest-for-woocommerce-token-invalid-failure';
+	const NOTE_NAME = 'pinterest-for-woocommerce-feed-name-exists-failure';
 
 	/**
 	 * Get the note.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return Note
 	 */
 	public static function get_note() {
 		$content_lines = array(
-			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
+			__( 'The Pinterest For WooCommerce plugin has detected an issue with your feed.<br/>The feed with the same name already exists at Pinterest.<br/>This can be due to another website already connected to the same Pinterest account.', 'pinterest-for-woocommerce' ),
 		);
 
 		$additional_data = array(
@@ -52,8 +54,8 @@ class TokenInvalidFailure {
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
-			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
-			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
+			'pinterest-for-woocommerce-feed-name-exists-failure-disconnect',
+			__( 'Disconnect Pinterest', 'pinterest-for-woocommerce' ),
 			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true,
@@ -64,6 +66,8 @@ class TokenInvalidFailure {
 
 	/**
 	 * Add the note if it passes predefined conditions.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return void
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #943 .

Adding a notification if feed registration fails due to the feed already exists error.

### Detailed test instructions:

1. Create two similar websites (country,  locale, and currency must match).
2. Install Pinterest for WooCommerce extension on one of the websites.
3. Make sure the website has registered the feed with Pinterest before you continue.
4. Set up the second website similar to the first one.
5. Observe the feed registation procedure failures due to the feed with such a name already exists error.
6. You should also see an admin notice describing the issue with the feed registration.

### Changelog entry

> Tweak - Adding admin notification for a feed registration failure.
