### PR TITLE
Website domain into feed name.

### DIFF
--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -99,6 +99,7 @@ class Feeds {
 		$configs       = LocalFeedConfigs::get_instance()->get_configurations();
 		$config        = reset( $configs );
 
+		$name             = (string) parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
 		$default_country  = Pinterest_For_Woocommerce()::get_base_country();
 		$default_currency = get_woocommerce_currency();
 		$default_locale   = LocaleMapper::get_locale_for_api();
@@ -115,7 +116,8 @@ class Feeds {
 			'pinterest_for_woocommerce_unique_feed_name',
 			sprintf(
 				// translators: %1$s is a country ISO 2 code, %2$s is a currency ISO 3 code.
-				esc_html__( 'Created by Pinterest for WooCommerce %1$s|%2$s|%3$s', 'pinterest-for-woocommerce' ),
+				esc_html__( 'Created by Pinterest for WooCommerce at %1$s %2$s|%3$s|%4$s', 'pinterest-for-woocommerce' ),
+				esc_html( $name ),
 				esc_html( $default_country ),
 				esc_html( $default_locale ),
 				esc_html( $default_currency )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #943

Adding website domain into Pinterest feed name to avoid multiple websites trying to create a feed with the same name and receiving errors for the last site to attempt.

### Detailed test instructions:

1. Create two similar websites (country, locale, and currency must match).
2. Install Pinterest for WooCommerce extension on one of the websites.
3. Make sure the website has registered the feed with Pinterest before you continue.
4. Set up the second website similar to the first one.
5. Observe the feed registration procedure finishes successfully.
6. Go to your Pinterest account and observe multiple feeds created sucecssfully.

### Screenshots:

<img width="1728" alt="Pinterest" src="https://github.com/user-attachments/assets/5c80f2a9-9bcd-42b2-b21b-cdc4cb3d4a48">

_I have three websites connected to Pinterest account. One feed since April and two new feeds from Jurrasic Ninja websites created recently._

### Changelog entry

> Tweak - Add the website's domain to the Pinterest feed name.
