### PR TITLE
Feed Delete Error Admin Notice.

### DIFF
--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -12,9 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
+use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Exception;
 use Throwable;
 
@@ -343,8 +345,23 @@ class Feeds {
 			$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
 			APIV5::delete_feed( $feed_id, $ad_account_id );
 			return true;
-		} catch ( Throwable $th ) {
-			Logger::log( $th->getMessage(), 'error' );
+		} catch ( PinterestApiException $e ) {
+			Logger::log( $e->getMessage(), 'error' );
+			if ( in_array(
+				(int) $e->get_pinterest_code(),
+				[
+					PinterestApiException::MERCHANT_DISAPPROVED,
+					PinterestApiException::MERCHANT_UNDER_REVIEW,
+					PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS
+				]
+			) ) {
+				// Show Admin Notice.
+				try {
+					FeedDeletionFailure::possibly_add_note(  $e->getMessage() );
+				} catch ( NotesUnavailableException $e ) {
+					// Do nothing.
+				}
+			}
 			return false;
 		}
 	}

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -12,9 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Pinterest\API\APIV5;
-use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Exception;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -349,18 +349,14 @@ class Feeds {
 			Logger::log( $e->getMessage(), 'error' );
 			if ( in_array(
 				(int) $e->get_pinterest_code(),
-				[
+				array(
 					PinterestApiException::MERCHANT_DISAPPROVED,
 					PinterestApiException::MERCHANT_UNDER_REVIEW,
-					PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS
-				]
+					PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS,
+				)
 			) ) {
 				// Show Admin Notice.
-				try {
-					FeedDeletionFailure::possibly_add_note(  $e->getMessage() );
-				} catch ( NotesUnavailableException $e ) {
-					// Do nothing.
-				}
+				FeedDeletionFailure::possibly_add_note( $e->getMessage() );
 			}
 			return false;
 		}

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -354,7 +354,7 @@ class Feeds {
 				)
 			) ) {
 				// Show Admin Notice.
-				FeedDeletionFailure::possibly_add_note( $e->getMessage() );
+				FeedDeletionFailure::possibly_add_note( $e->get_pinterest_code() );
 			}
 			return false;
 		}

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -77,7 +77,7 @@ class FeedDeletionFailure {
 	 */
 	public static function possibly_add_note( string $message ) {
 		try {
-			if ( self::note_exists() && !self::has_note_been_actioned() ) {
+			if ( self::note_exists() && ! self::has_note_been_actioned() ) {
 				return;
 			}
 

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -39,7 +39,14 @@ class FeedDeletionFailure {
 	 */
 	public static function get_note( string $message = '' ) {
 		$content_lines = array(
-			__( "The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>{$message}", 'pinterest-for-woocommerce' ),
+			sprintf(
+				// translators: %1$s: Pinterest API message (reason of the failure).
+				__(
+					'The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>%1$s',
+					'pinterest-for-woocommerce'
+				),
+				$message
+			)
 		);
 
 		$additional_data = array(
@@ -62,15 +69,18 @@ class FeedDeletionFailure {
 	 * @param string $message - Pinterest API Exception message.
 	 *
 	 * @return void
-	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function possibly_add_note( string $message ) {
-		if ( self::note_exists() ) {
+		try {
+			if ( self::note_exists() ) {
+				return;
+			}
+
+			$note = self::get_note( $message );
+			$note->save();
+		} catch ( NotesUnavailableException $e ) {
 			return;
 		}
-
-		$note = self::get_note( $message );
-		$note->save();
 	}
 
 	/**

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -58,6 +58,7 @@ class FeedDeletionFailure {
 		$note->set_content( implode( '', $content_lines ) );
 		$note->set_content_data( (object) $additional_data );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+		$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'pinterest-for-woocommerce' );
 		$note->add_action(
@@ -76,7 +77,7 @@ class FeedDeletionFailure {
 	 */
 	public static function possibly_add_note( string $message ) {
 		try {
-			if ( self::note_exists() ) {
+			if ( self::note_exists() && !self::has_note_been_actioned() ) {
 				return;
 			}
 

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -46,7 +46,7 @@ class FeedDeletionFailure {
 					'pinterest-for-woocommerce'
 				),
 				$message
-			)
+			),
 		);
 
 		$additional_data = array(

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WooCommerce Admin: Add First Product.
+ *
+ * Adds a note (type `email`) to bring the client back to the store setup flow.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Add_First_Product.
+ */
+class FeedDeletionFailure {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-feed-deletion-failure';
+
+	/**
+	 * Get the note.
+	 *
+	 * @param string $message - An additional message to show.
+	 *
+	 * @return Note
+	 */
+	public static function get_note( string $message = '' ) {
+		$content_lines = array(
+			__( "The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>{$message}", 'pinterest-for-woocommerce' ),
+		);
+
+		$additional_data = array(
+			'role' => 'administrator',
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest For WooCommerce Feed Deletion Failed.', 'pinterest-for-woocommerce' ) );
+		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content_data( (object) $additional_data );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 *
+	 * @param string $message - Pinterest API Exception message.
+	 *
+	 * @return void
+	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 */
+	public static function possibly_add_note( string $message ) {
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note = self::get_note( $message );
+		$note->save();
+	}
+
+	/**
+	 * Delete the note.
+	 *
+	 * @return void
+	 */
+	public static function delete_note() {
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -114,17 +114,16 @@ class FeedDeletionFailure {
 	 * @param int $code - Pinterest error code.
 	 * @return string - Predefined error message.
 	 */
-	private static function code_to_message( int $code ): string
-	{
-		if ( $code === PinterestApiException::MERCHANT_DISAPPROVED ) {
+	private static function code_to_message( int $code ): string {
+		if ( PinterestApiException::MERCHANT_DISAPPROVED === $code ) {
 			return self::MESSAGE_MERCHANT_DISAPPROVED;
 		}
 
-		if ( $code === PinterestApiException::MERCHANT_UNDER_REVIEW ) {
+		if ( PinterestApiException::MERCHANT_UNDER_REVIEW === $code ) {
 			return self::MESSAGE_MERCHANT_UNDER_REVIEW;
 		}
 
-		if ( $code === PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS ) {
+		if ( PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS === $code ) {
 			return self::MESSAGE_FEED_HAS_PROMOTIONS;
 		}
 

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -57,9 +57,13 @@ class FeedDeletionFailure {
 		$note->set_title( __( 'Pinterest For WooCommerce Feed Deletion Failed.', 'pinterest-for-woocommerce' ) );
 		$note->set_content( implode( '', $content_lines ) );
 		$note->set_content_data( (object) $additional_data );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
 		$note->set_name( self::NOTE_NAME );
-		$note->set_source( 'woocommerce-admin' );
+		$note->set_source( 'pinterest-for-woocommerce' );
+		$note->add_action(
+			'dismiss',
+			__( 'Dismiss', 'pinterest-for-woocommerce' )
+		);
 		return $note;
 	}
 

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -59,22 +59,40 @@ class PinterestApiException extends \Exception {
 	public const OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER = 2318;
 
 	/**
+	 * Merchant has been disapproved.
+	 * Some feeds, when deleting, may fail to delete due to the merchant has been disapproved.
+	 */
+	public const MERCHANT_DISAPPROVED = 2625;
+
+	/**
+	 * Merchant is under review.
+	 * Some feeds, when deleting, may fail to delete due to the merchant is under review.
+	 */
+	public const MERCHANT_UNDER_REVIEW = 2626;
+
+	/**
+	 * Feed has active promotions.
+	 * Some feeds, when deleting, may fail to delete due to active promotions on the feed items.
+	 */
+	public const CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS = 4162;
+
+	/**
 	 * Holds the specific Pinterest error code, which is useful in addition to the response code.
 	 *
 	 * @var int
 	 * @since 1.0.0
 	 */
-	private $pinterest_code = null;
+	private int $pinterest_code = 0;
 
 	/**
 	 * Pinterest_API_Exception constructor.
 	 *
 	 * @param string|array $error The error message or an array containing the error message + additional data.
-	 * @param int          $response_code The response code of the API call.
+	 * @param int          $response_code The HTTP response code of the API call. e.g. 200, 401, 403, 404, etc.
 	 */
 	public function __construct( $error, $response_code ) {
 		$message              = $error['message'] ?? $error;
-		$this->pinterest_code = $error['response_body']['code'] ?? null;
+		$this->pinterest_code = (int) $error['response_body']['code'] ?? 0;
 
 		parent::__construct( $message ?? $error, $response_code );
 	}
@@ -84,7 +102,7 @@ class PinterestApiException extends \Exception {
 	 *
 	 * @return int
 	 */
-	public function get_pinterest_code() {
+	public function get_pinterest_code(): int {
 		return $this->pinterest_code;
 	}
 }

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\Feeds;
+use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
+use Pinterest_For_Woocommerce;
+use WC_Helper_Product;
+
+class FeedsTest extends \WP_UnitTestCase {
+
+	/**
+	 * Tests feed deletion produces an admin notice in case feed deletion has failed.
+	 *
+	 * @return void
+	 */
+	public function test_feed_delete_produces_an_admin_notification() {
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '549765662491' );
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				if ( 'https://api.pinterest.com/v5/catalogs/feeds/1574695656968?ad_account_id=549765662491' === $url ) {
+					$response = array(
+						'headers'  => array(
+							'content-type' => 'application/json',
+						),
+						'body'     => json_encode(
+							array(
+								'code'    => 4162,
+								'message' => 'We can\'t disable a Product Group with active promotions.',
+							)
+						),
+						'response' => array(
+							'code'    => 409,
+							'message' => 'Conflict. Can\'t delete a feed with active promotions.',
+						),
+						'cookies'  => array(),
+						'filename' => '',
+					);
+				}
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = Feeds::delete_feed( '1574695656968' );
+
+		$this->assertFalse( $result );
+		$this->assertTrue( FeedDeletionFailure::note_exists() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #992 .

### Detailed test instructions:

1. Install Pinterest for WooCommerce extension.
2. Connect to Pinterest.
3. Add the code to emulate Pinterest error here

https://github.com/woocommerce/pinterest-for-woocommerce/blob/e5bdf4d9ebbf12413ae17b49b38ca9426ff01bb7/src/Feeds.php#L345-L347

to look like this

```php
$ad_account_id = Pinterest_For_WooCommerce()::get_setting( 'tracking_advertiser' );
throw new PinterestApiException(
	array(
		'message'       => 'Some message related to the exception.',
		'response_body' => array(
			'code' => PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS,
		),
	),
	409
);
APIV5::delete_feed( $feed_id, $ad_account_id );
return true;
```
4. Click Disconnect

<img width="1268" alt="Connection_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_Wildly_Involved_—_WooCommerce" src="https://github.com/user-attachments/assets/70bf7a75-7208-4f76-9528-d1e7dbce8ad6">

5. Observe the notice

<img width="1079" alt="Pinterest_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/user-attachments/assets/e061c880-03de-4524-aab6-f5f2735cfeba">

### Changelog entry

> Add - Adding admin notice in case of feed deletion error.
