### PR TITLE
Fixing Pinterest Save button positioning for Twenty Twenty-Four theme.

### DIFF
--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -28,12 +28,6 @@
 .wc-block-product {
 
 	&.product {
-
 		position: relative;
-
-		.pinterest-for-woocommerce-image-wrapper {
-			top: unset;
-			left: unset;
-		}
 	}
 }

--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -24,9 +24,11 @@
 
 
 // Twenty Twenty-Four compatibility.
-.wp-block-post {
+.wp-block-product {
 
 	&.product {
+
+		position: relative;
 
 		.pinterest-for-woocommerce-image-wrapper {
 			top: unset;

--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -24,7 +24,8 @@
 
 
 // Twenty Twenty-Four compatibility.
-.wp-block-product {
+.wp-block-post,
+.wc-block-product {
 
 	&.product {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1054.

Pinterest Save button has CSS absolute positioning when the product card has no CSS relative position rule on it which makes Pinterest Save button align relatively to the document, instead of a product card element.

### Screenshots:

<img width="1811" alt="Cursor_and_Shop_–_Wildly_Involved" src="https://github.com/user-attachments/assets/ff6c1d2a-8edf-4e39-bbc7-eefdf84e3dd5">

<img width="1530" alt="Music_–_Wildly_Involved" src="https://github.com/user-attachments/assets/7b357beb-f77b-45cf-bd28-8266b731d11c">

### Detailed test instructions:

1. Install Pinterest extension with Twenty Twenty-Four.
2. Navigate to the Shop.
3. Hover any product card.
4. Observe Pinterest Save button is out of bounds.

### Changelog entry

> Fix - Pinterest Save button positioning.
