### PR TITLE
Fix no product in page visit tracking

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -77,6 +77,7 @@ class Tracking {
 	 * Used as a callback for the wp_footer hook.
 	 *
 	 * @since 1.4.0
+	 * @since x.x.x Added checkf for product page.
 	 *
 	 * @return void
 	 */
@@ -86,20 +87,31 @@ class Tracking {
 			return;
 		}
 
+		// Dumy data for when we can't get product data.
 		$data = new None( uniqid( 'page' ) );
-		if ( is_product() ) {
-			$product = wc_get_product();
-			$data    = new Product(
-				uniqid( 'page' ),
-				$product->get_id(),
-				$product->get_name(),
-				wc_get_product_category_list( $product->get_id() ),
-				'brand',
-				wc_get_price_to_display( $product ),
-				get_woocommerce_currency(),
-				1
-			);
+
+		// Not a product page.
+		if ( ! is_product() ) {
+			$this->track_event( static::EVENT_PAGE_VISIT, $data );
+			return;
 		}
+
+		$product = wc_get_product();
+		if ( ! $product instanceof \WC_Product ) {
+			$this->track_event( static::EVENT_PAGE_VISIT, $data );
+			return;
+		}
+
+		$data = new Product(
+			uniqid( 'page' ),
+			$product->get_id(),
+			$product->get_name(),
+			wc_get_product_category_list( $product->get_id() ),
+			'brand',
+			wc_get_price_to_display( $product ),
+			get_woocommerce_currency(),
+			1
+		);
 		$this->track_event( static::EVENT_PAGE_VISIT, $data );
 	}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -77,7 +77,7 @@ class Tracking {
 	 * Used as a callback for the wp_footer hook.
 	 *
 	 * @since 1.4.0
-	 * @since x.x.x Added checkf for product page.
+	 * @since x.x.x Added check for product page.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1059 .

There is no good reason behind this PR except that I am adding a defensive code to check if the product has been fetched.

In theory `is_product()` and `wc_get_product()` should return consistent results. Since we are observing the issue it means that they are not. Without access to the merchant site and proper debugging I don't see a way to getting to the root cause of this issue.

### Screenshots:
No screenshots.
<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Tracking should still work, especially for page_visit

I don't know how to reproduce this issue so we can only check if there is no regression and hope that the defensive code will fix the problem.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Detect no product error in the page_visit tracking.
