### PR TITLE
Reuse existing feed

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -188,17 +188,20 @@ install_wc() {
     # Grab the necessary plugins.
     if [ $WC_VERSION == 'trunk' ]; then
       rm -rf "$TMPDIR"/woocommerce-trunk
-      git clone --quiet --depth=1 --branch="$LATEST_WC_VERSION" https://github.com/woocommerce/woocommerce.git "${TMPDIR}/woocommerce-trunk"
+      git clone --quiet --depth=1 --branch="$LATEST_WC_VERSION" https://github.com/woocommerce/woocommerce.git "$TMPDIR"/woocommerce-trunk
+
+      # Install composer for WooCommerce
+      cd "$TMPDIR"/woocommerce-trunk/plugins/woocommerce
+      composer install --ignore-platform-reqs --no-interaction --no-dev
+
+      # Symlink woocommerce plugin
       mv "$TMPDIR"/woocommerce-trunk/plugins/woocommerce/* "$WC_DIR"
     else
       echo "Test with specified WooCommerce version ${WC_VERSION} is not yet supported."
       exit 1
     fi
 
-    # Install composer for WooCommerce
-    cd "${WC_DIR}"
-    composer install --ignore-platform-reqs --no-interaction --no-dev
-
+    cd "$WC_DIR"
 	# Generate feature config for WooCommerce
 	GENERATE_FEATURE_CONFIG=bin/generate-feature-config.php
 	if [ -f $GENERATE_FEATURE_CONFIG ]; then

--- a/composer.lock
+++ b/composer.lock
@@ -232,12 +232,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/grow.git",
-                "reference": "6be1d45dec71c31ab6b118c9d359d141f16a6aae"
+                "reference": "cfb01a73eb6207e00ba375fefc707c1e12f8cd4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/grow/zipball/6be1d45dec71c31ab6b118c9d359d141f16a6aae",
-                "reference": "6be1d45dec71c31ab6b118c9d359d141f16a6aae",
+                "url": "https://api.github.com/repos/woocommerce/grow/zipball/cfb01a73eb6207e00ba375fefc707c1e12f8cd4e",
+                "reference": "cfb01a73eb6207e00ba375fefc707c1e12f8cd4e",
                 "shasum": ""
             },
             "require-dev": {
@@ -257,7 +257,7 @@
                 "source": "https://github.com/woocommerce/grow/tree/compat-checker",
                 "issues": "https://github.com/woocommerce/grow/issues"
             },
-            "time": "2024-05-16T09:57:13+00:00"
+            "time": "2024-06-18T07:01:27+00:00"
         }
     ],
     "packages-dev": [
@@ -775,16 +775,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.16.2",
+            "version": "v1.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe"
+                "reference": "645ec21b650bc2aced18285c85f220d22afc1430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/2791b08ffcc1862fe18eef85675da3aa58c406fe",
-                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/645ec21b650bc2aced18285c85f220d22afc1430",
+                "reference": "645ec21b650bc2aced18285c85f220d22afc1430",
                 "shasum": ""
             },
             "require": {
@@ -797,7 +797,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.2-dev"
+                    "dev-master": "1.16.3-dev"
                 }
             },
             "autoload": {
@@ -818,9 +818,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.16.2"
+                "source": "https://github.com/mck89/peast/tree/v1.16.3"
             },
-            "time": "2024-03-05T09:16:03+00:00"
+            "time": "2024-07-23T14:00:32+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -874,16 +874,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -891,11 +891,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -921,7 +922,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -929,20 +930,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -953,7 +954,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -985,9 +986,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1391,22 +1392,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -1475,39 +1476,39 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-24T11:47:18+00:00"
+            "time": "2024-05-20T13:34:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1516,7 +1517,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1545,7 +1546,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1553,7 +1554,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1798,45 +1799,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1881,7 +1882,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -1897,7 +1898,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2864,16 +2865,16 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.11.4",
+            "version": "v2.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93"
+                "reference": "aaa144eb4f14697b6b06e3dcf74081b5a02f85f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/acc946731ec65053e49cb0d3185c8ffe74895f93",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/aaa144eb4f14697b6b06e3dcf74081b5a02f85f6",
+                "reference": "aaa144eb4f14697b6b06e3dcf74081b5a02f85f6",
                 "shasum": ""
             },
             "require": {
@@ -2912,22 +2913,22 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.4"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.5"
             },
-            "time": "2023-09-29T21:27:51+00:00"
+            "time": "2024-05-23T20:01:41+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.2",
+            "version": "3.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/86e5f5dd9a840c46810ebe5ff1885581c42a3017",
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017",
                 "shasum": ""
             },
             "require": {
@@ -2994,7 +2995,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-23T20:25:34+00:00"
+            "time": "2024-07-21T23:26:44+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3065,16 +3066,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.39",
+            "version": "v5.4.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a"
+                "reference": "ae25a9145a900764158d439653d5630191155ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/f6a96e4fcd468a25fede16ee665f50ced856bd0a",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ae25a9145a900764158d439653d5630191155ca0",
+                "reference": "ae25a9145a900764158d439653d5630191155ca0",
                 "shasum": ""
             },
             "require": {
@@ -3108,7 +3109,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.39"
+                "source": "https://github.com/symfony/finder/tree/v5.4.43"
             },
             "funding": [
                 {
@@ -3124,24 +3125,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-08-13T14:03:51+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -3188,7 +3189,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -3204,7 +3205,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3297,16 +3298,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "2.6.1",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1"
+                "reference": "53518a11f314119e320597c7a8274f11b1295bdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
-                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/53518a11f314119e320597c7a8274f11b1295bdc",
+                "reference": "53518a11f314119e320597c7a8274f11b1295bdc",
                 "shasum": ""
             },
             "require": {
@@ -3360,9 +3361,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/2.6.1"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.2"
             },
-            "time": "2024-02-28T11:27:34+00:00"
+            "time": "2024-07-03T12:50:00+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -3480,16 +3481,16 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685"
+                "reference": "53f0df112901fcf95099d0f501912a209429b6a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/a339dca576df73c31af4b4d8054efc2dab9a0685",
-                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/53f0df112901fcf95099d0f501912a209429b6a9",
+                "reference": "53f0df112901fcf95099d0f501912a209429b6a9",
                 "shasum": ""
             },
             "require": {
@@ -3519,7 +3520,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.10.x-dev"
+                    "dev-main": "2.11.x-dev"
                 }
             },
             "autoload": {
@@ -3546,7 +3547,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-02-08T16:52:43+00:00"
+            "time": "2024-08-08T03:04:55+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3616,16 +3617,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "a0f7d708794a738f328d7b6c94380fd1d6c40446"
+                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/a0f7d708794a738f328d7b6c94380fd1d6c40446",
-                "reference": "a0f7d708794a738f328d7b6c94380fd1d6c40446",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
+                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
                 "shasum": ""
             },
             "require": {
@@ -3640,7 +3641,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -3675,7 +3676,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-04-05T16:01:51+00:00"
+            "time": "2024-09-06T22:03:10+00:00"
         }
     ],
     "aliases": [],
@@ -3693,5 +3694,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/i18n/languages/pinterest-for-woocommerce.pot
+++ b/i18n/languages/pinterest-for-woocommerce.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pinterest for WooCommerce 1.4.6\n"
+"Project-Id-Version: Pinterest for WooCommerce 1.4.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/pinterest-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-08-26T09:32:11+00:00\n"
+"POT-Creation-Date: 2024-09-19T14:58:29+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.10.0\n"
+"X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pinterest-for-woocommerce\n"
 
 #. Plugin Name of the plugin
@@ -243,7 +243,7 @@ msgstr ""
 
 #: src/API/Base.php:421
 #: src/API/Base.php:806
-#: src/Merchants.php:140
+#: src/Merchants.php:141
 msgid "Auto-created by Pinterest for WooCommerce"
 msgstr ""
 
@@ -523,11 +523,11 @@ msgid "Could not register feed."
 msgstr ""
 
 #. translators: %1$s is a country ISO 2 code, %2$s is a currency ISO 3 code.
-#: src/Feeds.php:119
+#: src/Feeds.php:125
 msgid "Created by Pinterest for WooCommerce at %1$s %2$s|%3$s|%4$s"
 msgstr ""
 
-#: src/Feeds.php:143
+#: src/Feeds.php:149
 msgid "There was a previous error trying to create a feed."
 msgstr ""
 
@@ -538,32 +538,32 @@ msgid "Pinterest says: %1$s"
 msgstr ""
 
 #. translators: %s is the locale code.
-#: src/LocaleMapper.php:107
+#: src/LocaleMapper.php:109
 msgid "No matching Pinterest API locale found for %s"
 msgstr ""
 
-#: src/Merchants.php:71
+#: src/Merchants.php:72
 msgid "Wrong response when trying to create or update merchant."
 msgstr ""
 
-#: src/Merchants.php:79
+#: src/Merchants.php:80
 msgid "There was an error trying to get the merchant object."
 msgstr ""
 
-#: src/Merchants.php:84
-#: src/Merchants.php:177
+#: src/Merchants.php:85
+#: src/Merchants.php:183
 msgid "Response error when trying to create a merchant or update the existing one."
 msgstr ""
 
-#: src/Merchants.php:107
+#: src/Merchants.php:108
 msgid "Response error when trying to get advertisers."
 msgstr ""
 
-#: src/Merchants.php:113
+#: src/Merchants.php:114
 msgid "No merchant returned in the advertiser's response."
 msgstr ""
 
-#: src/Merchants.php:160
+#: src/Merchants.php:166
 msgid "There was a previous error trying to create or update merchant."
 msgstr ""
 
@@ -617,14 +617,14 @@ msgstr ""
 
 #. translators: %1$s: Pinterest API message (reason of the failure).
 #: src/Notes/FeedDeletionFailure.php:63
-msgid "The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>%1$s<br/>Please, contact support to resolve the issue."
+msgid "The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>%1$s<br/>Please, contact Pinterest support to resolve the issue."
 msgstr ""
 
-#: src/Notes/FeedDeletionFailure.php:75
+#: src/Notes/FeedDeletionFailure.php:80
 msgid "Pinterest For WooCommerce Feed Deletion Failed."
 msgstr ""
 
-#: src/Notes/FeedDeletionFailure.php:84
+#: src/Notes/FeedDeletionFailure.php:89
 msgid "Dismiss"
 msgstr ""
 
@@ -658,12 +658,12 @@ msgid "Tracking advertiser or tag missing"
 msgstr ""
 
 #. translators: plugin version.
-#: src/PluginUpdate.php:176
+#: src/PluginUpdate.php:181
 msgid "Plugin updated to version: %s."
 msgstr ""
 
 #. translators: 1: plugin version, 2: failed procedure, 3: error message.
-#: src/PluginUpdate.php:199
+#: src/PluginUpdate.php:204
 msgid "Plugin update to version %1$s. Procedure: %2$s. Error: %3$s"
 msgstr ""
 
@@ -685,17 +685,17 @@ msgid "The product [%s] has a description longer than the allowed limit."
 msgstr ""
 
 #. translators: 1: The URL of the connection page
-#: src/ProductSync.php:156
+#: src/ProductSync.php:157
 msgid "The domain is not verified, visit the <a href=\"%1$s\">connection</a> page to verify it."
 msgstr ""
 
 #. translators: 1: The URL of the connection page
-#: src/ProductSync.php:172
+#: src/ProductSync.php:173
 msgid "The tracking tag is not configured, visit the <a href=\"%1$s\">connection</a> page to configure it."
 msgstr ""
 
 #. translators: 1: The URL of the settings page
-#: src/ProductSync.php:187
+#: src/ProductSync.php:188
 msgid "Visit the <a href=\"%1$s\">settings</a> page to enable it."
 msgstr ""
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -120,7 +120,7 @@ class Base {
 				'pinterest_for_woocommerce_disconnect_on_authentication_failure',
 				'__return_true'
 			);
-			if ( in_array( $e->getCode(), array( 401, 403 ) ) && $do_disconnect ) {
+			if ( $do_disconnect && 401 === $e->getCode() ) {
 				/**
 				 * Actions to perform disconnecting the merchant from the Pinterest platform.
 				 *

--- a/src/Exception/FeedNotFoundException.php
+++ b/src/Exception/FeedNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * FeedNotFoundException class.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use Exception;
+
+/**
+ * Exception thrown when there is no matching feed at Pinterest.
+ */
+class FeedNotFoundException extends Exception {}

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -315,8 +315,8 @@ class Feeds {
 	private static function does_feed_match( $feed ): bool {
 		$local_country = Pinterest_For_Woocommerce::get_base_country();
 		$local_locale  = LocaleMapper::get_locale_for_api();
-		$does_match = $local_country === $feed['default_country'] ?? '';
-		$does_match = $does_match && $local_locale === $feed['default_locale'] ?? '';
+		$does_match    = $local_country === $feed['default_country'] ?? '';
+		$does_match    = $does_match && $local_locale === $feed['default_locale'] ?? '';
 		return $does_match && 0 === strpos( $feed['location'] ?? '', get_site_url() );
 	}
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -329,7 +329,7 @@ class Feeds {
 	}
 
 	/**
-	 * Tries to match remote feeds against local website configuration to find an existing feed, if any.
+	 * Compare remote feeds to local configuration to find a matching feed.
 	 *
 	 * @since x.x.x
 	 * @return string - Remote feed ID that matches.

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -302,6 +302,15 @@ class Feeds {
 		return '';
 	}
 
+	/**
+	 * Tests if the feed is a match.
+	 *
+	 * @param $feed
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 * @throws PinterestApiLocaleException
+	 */
 	private static function does_feed_match( $feed ): bool {
 		$local_country = Pinterest_For_Woocommerce()::get_base_country();
 		$local_locale  = LocaleMapper::get_locale_for_api();
@@ -313,6 +322,7 @@ class Feeds {
 	/**
 	 * Tries to match remote feeds against local website configuration to find an existing feed, if any.
 	 *
+	 * @since x.x.x
 	 * @return string - Remote feed ID that matches.
 	 */
 	public static function maybe_remote_feed(): string {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Pinterest\API\APIV5;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Exception;
+use Pinterest_For_Woocommerce;
 use Throwable;
 
 /**
@@ -312,7 +313,7 @@ class Feeds {
 	 * @throws PinterestApiLocaleException
 	 */
 	private static function does_feed_match( $feed ): bool {
-		$local_country = Pinterest_For_Woocommerce()::get_base_country();
+		$local_country = Pinterest_For_Woocommerce::get_base_country();
 		$local_locale  = LocaleMapper::get_locale_for_api();
 		$does_match = $local_country === $feed['default_country'] ?? '';
 		$does_match = $does_match && $local_locale === $feed['default_locale'] ?? '';

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -326,16 +326,20 @@ class Feeds {
 	 * @return string - Remote feed ID that matches.
 	 */
 	public static function maybe_remote_feed(): string {
-		$feeds = self::get_feeds();
-		foreach ( $feeds as $feed ) {
-			if ( self::does_feed_match( $feed ) ) {
-				$last_dash_position = strrpos( $feed['location'], '-' ) + 1;
-				$last_dot_position  = strrpos( $feed['location'], '.' );
-				$length_of_the_id   = $last_dot_position - $last_dash_position;
-				return substr( $feed['location'], $last_dash_position, $length_of_the_id );
+		try {
+			$feeds = self::get_feeds();
+			foreach ( $feeds as $feed ) {
+				if ( self::does_feed_match( $feed ) ) {
+					$last_dash_position = strrpos( $feed['location'], '-' ) + 1;
+					$last_dot_position  = strrpos( $feed['location'], '.' );
+					$length_of_the_id   = $last_dot_position - $last_dash_position;
+					return substr( $feed['location'], $last_dash_position, $length_of_the_id );
+				}
 			}
+			return '';
+		} catch ( PinterestApiLocaleException $e ) {
+			return '';
 		}
-		return '';
 	}
 
 	/**

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -306,11 +306,11 @@ class Feeds {
 	/**
 	 * Tests if the feed is a match.
 	 *
-	 * @param $feed
+	 * @param array $feed A feed information array from Pinterest API response.
 	 *
 	 * @since x.x.x
 	 * @return bool
-	 * @throws PinterestApiLocaleException
+	 * @throws PinterestApiLocaleException If we could not match any of WP locales to Pinterest locales list.
 	 */
 	private static function does_feed_match( $feed ): bool {
 		$local_country = Pinterest_For_Woocommerce::get_base_country();

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -299,7 +299,7 @@ class Feeds {
 			 * When trying to match remote feed to a local configuration, we need to check both cases
 			 * not to create a new feed if the feed was created by the extension in the past.
 			 */
-			$does_match = self::does_feed_match( $feed ) && $config['feed_url'] === $feed['location'] ?? '';
+			$does_match = self::does_feed_match( $feed ) && $config['feed_url'] === ( $feed['location'] ?? '' );
 			if ( $does_match ) {
 				return $feed['id'];
 			}
@@ -316,16 +316,25 @@ class Feeds {
 	 * @since x.x.x
 	 * @return bool
 	 */
-	private static function does_feed_match( $feed ): bool {
+	private static function does_feed_match( array $feed ): bool {
 		$local_country = Pinterest_For_Woocommerce::get_base_country();
 		try {
 			$local_locale = LocaleMapper::get_locale_for_api();
 		} catch ( PinterestApiLocaleException $e ) {
 			$local_locale = LocaleMapper::PINTEREST_DEFAULT_LOCALE;
 		}
-		$does_match    = $local_country === $feed['default_country'] ?? '';
-		$does_match    = $does_match && $local_locale === $feed['default_locale'] ?? '';
-		return $does_match && 0 === strpos( $feed['location'] ?? '', get_site_url() );
+
+		$does_match = $local_country === ( $feed['default_country'] ?? '' );
+		if ( ! $does_match ) {
+			return false;
+		}
+
+		$does_match = $local_locale === ( $feed['default_locale'] ?? '' );
+		if ( ! $does_match ) {
+			return false;
+		}
+
+		return 0 === strpos( $feed['location'] ?? '', get_site_url() );
 	}
 
 	/**

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -299,7 +299,7 @@ class Feeds {
 			 * When trying to match remote feed to a local configuration, we need to check both cases
 			 * not to create a new feed if the feed was created by the extension in the past.
 			 */
-			$does_match = self::does_feed_match( $feed ) && $config['feed_url'] === ( $feed['location'] ?? '' );
+			$does_match = self::does_feed_match( $feed ) && ( $feed['location'] ?? '' ) === $config['feed_url'];
 			if ( $does_match ) {
 				return $feed['id'];
 			}
@@ -324,12 +324,12 @@ class Feeds {
 			$local_locale = LocaleMapper::PINTEREST_DEFAULT_LOCALE;
 		}
 
-		$does_match = $local_country === ( $feed['default_country'] ?? '' );
+		$does_match = ( $feed['default_country'] ?? '' ) === $local_country;
 		if ( ! $does_match ) {
 			return false;
 		}
 
-		$does_match = $local_locale === ( $feed['default_locale'] ?? '' );
+		$does_match = ( $feed['default_locale'] ?? '' ) === $local_locale;
 		if ( ! $does_match ) {
 			return false;
 		}

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -7,6 +7,8 @@
  */
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Exception\FeedNotFoundException;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -68,12 +70,12 @@ class LocalFeedConfigs {
 	private function initialize_local_feeds_config( $locations ) {
 		$feed_ids = Pinterest_For_Woocommerce()::get_data( 'local_feed_ids' );
 		if ( empty( $feed_ids ) ) {
-			$remote_feed_id = Feeds::maybe_remote_feed();
-			if ( $remote_feed_id ) {
-				$feed_ids = array(
+			try {
+				$remote_feed_id = Feeds::maybe_remote_feed();
+				$feed_ids       = array(
 					Pinterest_For_Woocommerce()::get_base_country() => $remote_feed_id,
 				);
-			} else {
+			} catch ( FeedNotFoundException $e ) {
 				$feed_ids = array();
 			}
 		}

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -68,7 +68,8 @@ class LocalFeedConfigs {
 	private function initialize_local_feeds_config( $locations ) {
 		$feed_ids = Pinterest_For_Woocommerce()::get_data( 'local_feed_ids' );
 		if ( empty( $feed_ids ) ) {
-			if ( $remote_feed_id = Feeds::maybe_remote_feed() ) {
+			$remote_feed_id = Feeds::maybe_remote_feed();
+			if ( $remote_feed_id ) {
 				$feed_ids = array(
 					Pinterest_For_Woocommerce()::get_base_country() => $remote_feed_id,
 				);

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -68,7 +68,13 @@ class LocalFeedConfigs {
 	private function initialize_local_feeds_config( $locations ) {
 		$feed_ids = Pinterest_For_Woocommerce()::get_data( 'local_feed_ids' );
 		if ( empty( $feed_ids ) ) {
-			$feed_ids = array();
+			if ( $remote_feed_id = Feeds::maybe_remote_feed() ) {
+				$feed_ids = array(
+					Pinterest_For_Woocommerce()::get_base_country() => $remote_feed_id,
+				);
+			} else {
+				$feed_ids = array();
+			}
 		}
 
 		foreach ( $locations as $location ) {

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -77,6 +77,8 @@ class LocaleMapper {
 		'pt-BR'  => 1,
 	);
 
+	const PINTEREST_DEFAULT_LOCALE = 'en-US';
+
 	/**
 	 * Get Pinterest locale code for API.
 	 * Pinterest API uses hyphens instead of underscores in locale codes so we need to replace them.
@@ -112,6 +114,7 @@ class LocaleMapper {
 
 	/**
 	 * Get WordPress locale code.
+	 * WordPress defaults to en_US locale if nothing is found.
 	 *
 	 * @since 1.2.13
 	 * @return string

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Pinterest\API\Base;
+use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 use \Exception;
 use \Throwable;
 
@@ -143,12 +144,17 @@ class Merchants {
 		$feed_location = parse_url( $config['feed_url'] );
 		$feed_location = ! empty( $feed_location['host'] ) ? $config['feed_url'] : get_home_url() . $feed_location['path'];
 
+		try {
+			$locale = LocaleMapper::get_locale_for_api();
+		} catch ( PinterestApiLocaleException $e ) {
+			$locale = LocaleMapper::PINTEREST_DEFAULT_LOCALE;
+		}
 		$args = array(
 			'merchant_domains' => get_home_url(),
 			'feed_location'    => $feed_location,
 			'feed_format'      => 'XML',
 			'country'          => Pinterest_For_Woocommerce()::get_base_country(),
-			'locale'           => LocaleMapper::get_locale_for_api(),
+			'locale'           => $locale,
 			'currency'         => get_woocommerce_currency(),
 			'merchant_name'    => $merchant_name,
 		);

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -61,7 +61,7 @@ class FeedDeletionFailure {
 		$content = sprintf(
 			// translators: %1$s: Pinterest API message (reason of the failure).
 			__(
-				'The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>%1$s<br/>Please, contact support to resolve the issue.',
+				'The Pinterest For WooCommerce plugin has failed to delete the feed.<br/>%1$s<br/>Please, contact Pinterest support to resolve the issue.',
 				'pinterest-for-woocommerce'
 			),
 			$message

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -67,22 +67,29 @@ class FeedDeletionFailure {
 			$message
 		);
 
-		$additional_data = array(
-			'role' => 'administrator',
-		);
+		if ( self::note_exists() ) {
+			$data_store = Notes::load_data_store();
+			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+			$note       = Notes::get_note( current( $note_ids ) );
+		} else {
+			$additional_data = array(
+				'role' => 'administrator',
+			);
 
-		$note = new Note();
-		$note->set_title( __( 'Pinterest For WooCommerce Feed Deletion Failed.', 'pinterest-for-woocommerce' ) );
-		$note->set_content( $content );
-		$note->set_content_data( (object) $additional_data );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
-		$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
-		$note->set_name( self::NOTE_NAME );
-		$note->set_source( 'pinterest-for-woocommerce' );
-		$note->add_action(
-			'dismiss',
-			__( 'Dismiss', 'pinterest-for-woocommerce' )
-		);
+			$note = new Note();
+			$note->set_title( __( 'Pinterest For WooCommerce Feed Deletion Failed.', 'pinterest-for-woocommerce' ) );
+			$note->set_content( $content );
+			$note->set_content_data( (object) $additional_data );
+			$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+			$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
+			$note->set_name( self::NOTE_NAME );
+			$note->set_source( 'pinterest-for-woocommerce' );
+			$note->add_action(
+				'dismiss',
+				__( 'Dismiss', 'pinterest-for-woocommerce' )
+			);
+		}
+
 		return $note;
 	}
 

--- a/src/Notes/FeedDeletionFailure.php
+++ b/src/Notes/FeedDeletionFailure.php
@@ -95,7 +95,7 @@ class FeedDeletionFailure {
 	 */
 	public static function possibly_add_note( int $code ) {
 		try {
-			if ( self::note_exists() && ! self::has_note_been_actioned() ) {
+			if ( self::note_exists() ) {
 				return;
 			}
 

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -403,7 +403,7 @@ class PluginUpdate {
 	 */
 	private function feed_deletion_notice_cleanup(): void {
 		try {
-			FeedDeletionFailure::possibly_update_note();
+			FeedDeletionFailure::possibly_delete_note();
 		} catch ( NotesUnavailableException $e ) {
 			return;
 		}

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -13,8 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Pinterest\API\UserInteraction;
 use Automattic\WooCommerce\Pinterest\API\TokenExchangeV3ToV5;
+use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Automattic\WooCommerce\Pinterest\Notes\TokenExchangeFailure;
 use Exception;
 use Throwable;
@@ -131,6 +133,9 @@ class PluginUpdate {
 			'1.4.0'  => array(
 				'token_update',
 				'feed_status_migration',
+			),
+			'1.4.10' => array(
+				'feed_deletion_notice_cleanup',
 			),
 		);
 	}
@@ -387,6 +392,20 @@ class PluginUpdate {
 			$value = ( false !== $value ) ? $value : $default_value;
 			update_option( $name, $value );
 			delete_transient( $name );
+		}
+	}
+
+	/**
+	 * Clears all Feed Deletion Failure admin notices created by mistake.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private function feed_deletion_notice_cleanup(): void {
+		try {
+			FeedDeletionFailure::possibly_update_note();
+		} catch ( NotesUnavailableException $e ) {
+			return;
 		}
 	}
 }

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -105,9 +105,10 @@ class ProductSync {
 			return;
 		}
 
-		$product_sync_enabled = $value['product_sync_enabled'] ?? false;
-
-		if ( ! $product_sync_enabled ) {
+		$isset             = isset( $value['product_sync_enabled'] );
+		$has_changed       = $isset && ( $old_value['product_sync_enabled'] ?? '' ) !== $value['product_sync_enabled'];
+		$should_deregister = $has_changed && false === $value['product_sync_enabled'];
+		if ( $should_deregister ) {
 			self::deregister();
 		}
 	}

--- a/tests/E2e/FeedDeletionFailureE2eTest.php
+++ b/tests/E2e/FeedDeletionFailureE2eTest.php
@@ -35,7 +35,21 @@ class FeedDeletionFailureE2eTest extends \WP_UnitTestCase {
 
 	public function test_deletes_multiple_notes() {
 		for ( $i = 0; $i < 10; $i ++ ) {
-			$note = FeedDeletionFailure::get_note( 'Some message' );
+			$additional_data = array(
+				'role' => 'administrator',
+			);
+			$note = new Note();
+			$note->set_title( __( 'Pinterest For WooCommerce Feed Deletion Failed.', 'pinterest-for-woocommerce' ) );
+			$note->set_content( 'Notice text.' );
+			$note->set_content_data( (object) $additional_data );
+			$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+			$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
+			$note->set_name( FeedDeletionFailure::NOTE_NAME );
+			$note->set_source( 'pinterest-for-woocommerce' );
+			$note->add_action(
+				'dismiss',
+				__( 'Dismiss', 'pinterest-for-woocommerce' )
+			);
 			$note->save();
 		}
 

--- a/tests/E2e/FeedDeletionFailureE2eTest.php
+++ b/tests/E2e/FeedDeletionFailureE2eTest.php
@@ -1,0 +1,53 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Tests\E2e;
+
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
+use Automattic\WooCommerce\Pinterest\PinterestApiException;
+
+class FeedDeletionFailureE2eTest extends \WP_UnitTestCase {
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		FeedDeletionFailure::possibly_delete_note();
+	}
+
+	/**
+	 * Tests if local feed config is empty we attempt to fetch a feed from Pinterest in case it exists.
+	 * This test aims to check if we restore empty local feed config from the server in case of auto-disconnect.
+	 *
+	 * @return void
+	 */
+	public function test_there_is_a_single_note_only() {
+		FeedDeletionFailure::possibly_add_note( PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS );
+		FeedDeletionFailure::possibly_add_note( PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS );
+		FeedDeletionFailure::possibly_add_note( PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS );
+		FeedDeletionFailure::possibly_add_note( PinterestApiException::CATALOGS_FEED_HAS_ACTIVE_PROMOTIONS );
+
+		$data_store = Notes::load_data_store();
+		$note_ids   = $data_store->get_notes_with_name( FeedDeletionFailure::NOTE_NAME );
+
+		$this->assertCount( 1, $note_ids );
+	}
+
+	public function test_deletes_multiple_notes() {
+		for ( $i = 0; $i < 10; $i ++ ) {
+			$note = FeedDeletionFailure::get_note( 'Some message' );
+			$note->save();
+		}
+
+		$data_store = Notes::load_data_store();
+		$note_ids   = $data_store->get_notes_with_name( FeedDeletionFailure::NOTE_NAME );
+
+		$this->assertCount( 10, $note_ids );
+
+		FeedDeletionFailure::possibly_delete_note();
+
+		$data_store = Notes::load_data_store();
+		$note_ids   = $data_store->get_notes_with_name( FeedDeletionFailure::NOTE_NAME );
+
+		$this->assertCount( 0, $note_ids );
+	}
+}

--- a/tests/E2e/LocalFeedConfigsE2eTest.php
+++ b/tests/E2e/LocalFeedConfigsE2eTest.php
@@ -1,0 +1,104 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Tests\E2e;
+
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\Notes\TokenInvalidFailure;
+use Pinterest_For_Woocommerce;
+
+class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		self::get_feeds_request_stub();
+
+		Pinterest_For_Woocommerce::save_data('local_feed_ids', array());
+		Pinterest_For_Woocommerce::save_setting('tracking_advertiser', '8901267167247612734708');
+		add_filter('woocommerce_get_base_location', 'US:CA');
+		add_filter('locale', 'en_US');
+		add_filter(
+			'site_url',
+			function ($url) {
+				return 'https://pinterest.dima.works';
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Tests if local feed config is empty we attempt to fetch a feed from Pinterest in case it exists.
+	 * This test aims to check if we restore empty local feed config from the server in case of auto-disconnect.
+	 *
+	 * @return void
+	 */
+	public function test_when_local_feed_config_is_empty_we_attempt_to_get_active_feed_from_pinterest() {
+		$local_feed_configs = LocalFeedConfigs::get_instance();
+
+		$configurations = $local_feed_configs->get_configurations();
+
+		$this->assertEquals(
+			array(
+				array(
+					'feed_id'   => 'taLlmN',
+					'feed_file' => '/taLlmN.xml',
+					'tmp_file'  => '/taLlmN-tmp.xml',
+					'feed_url'  => 'https://pinterest.dima.works/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml',
+				),
+			),
+			$configurations
+		);
+	}
+
+	private static function get_feeds_request_stub() {
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=8901267167247612734708' === $url ) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode(
+							array (
+								'items' => array(
+									"created_at"                    => "2022-03-14T15:15:22Z",
+									"id"                            => "547381235776346598",
+									"updated_at"                    => "2022-03-14T15:16:34Z",
+									"name"                          => "string",
+									"format"                        => "TSV",
+									"catalog_type"                  => "RETAIL",
+									"credentials"                   => array(
+										"password" => "string",
+										"username" => "string",
+									),
+									"location"                      => "https://pinterest.dima.works/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml",
+									"preferred_processing_schedule" => array(
+										"time"     => "02:59",
+										"timezone" => "Africa/Abidjan",
+									),
+									"status"                        => "ACTIVE",
+									"default_currency"              => "USD",
+									"default_locale"                => "en-US",
+									"default_country"               => "US",
+									"default_availability"          => "IN_STOCK",
+								),
+							)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+	}
+}

--- a/tests/E2e/LocalFeedConfigsE2eTest.php
+++ b/tests/E2e/LocalFeedConfigsE2eTest.php
@@ -49,9 +49,9 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 			array(
 				'US' => array(
 					'feed_id'   => 'taLlmN',
-					'feed_file' => '/var/folders/2h/88p1y74545vd1bb3_vc684n80000gn/T/wordpress/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml',
-					'tmp_file'  => '/var/folders/2h/88p1y74545vd1bb3_vc684n80000gn/T/wordpress/wp-content/uploads/pinterest-for-woocommerce-taLlmN-tmp.xml',
-					'feed_url'  => 'https://example-2.com/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml',
+					'feed_file' => wp_upload_dir()['basedir'] . '/pinterest-for-woocommerce-taLlmN.xml',
+					'tmp_file'  => wp_upload_dir()['basedir'] . '/pinterest-for-woocommerce-taLlmN-tmp.xml',
+					'feed_url'  => wp_upload_dir()['baseurl'] . '/pinterest-for-woocommerce-taLlmN.xml',
 				),
 			),
 			$configurations

--- a/tests/E2e/LocalFeedConfigsE2eTest.php
+++ b/tests/E2e/LocalFeedConfigsE2eTest.php
@@ -21,7 +21,6 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 		add_filter( 'locale', fn() => 'en_US' );
 		add_filter( 'site_url', fn( $url ) => 'https://example-2.com' );
 		add_filter( 'upload_dir', fn( $data ) => array_merge( $data, array( 'baseurl' => 'https://example-2.com/wp-content/uploads' ) ) );
-		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
 	}
 
 	public function tearDown(): void {
@@ -41,6 +40,8 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_when_local_feed_config_is_empty_we_attempt_to_get_active_feed_from_pinterest() {
+		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
+
 		$local_feed_configs = LocalFeedConfigs::get_instance();
 
 		$configurations = $local_feed_configs->get_configurations();
@@ -58,6 +59,28 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 		);
 	}
 
+	public function test_when_local_feed_config_is_empty_and_no_matching_feeds_at_pinterest() {
+		add_filter( 'pre_http_request', array( self::class, 'get_feeds_no_match' ), 10, 3 );
+
+		$local_feed_configs = LocalFeedConfigs::get_instance();
+
+		$configurations = $local_feed_configs->get_configurations();
+
+		$this->assertNotEmpty( $configurations['US']['feed_id'] );
+		$this->assertNotEquals( 'taLlmN', $configurations['US']['feed_id'] );
+	}
+
+	public function test_when_local_feed_config_is_empty_and_no_feeds_at_pinterest() {
+		add_filter( 'pre_http_request', array( self::class, 'get_no_feeds' ), 10, 3 );
+
+		$local_feed_configs = LocalFeedConfigs::get_instance();
+
+		$configurations = $local_feed_configs->get_configurations();
+
+		$this->assertNotEmpty( $configurations['US']['feed_id'] );
+		$this->assertNotEquals( 'taLlmN', $configurations['US']['feed_id'] );
+	}
+
 	public static function get_feeds( $response, $parsed_args, $url ) {
 		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=475245723456346' === $url ) {
 			return array(
@@ -69,10 +92,24 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 						'items' => array(
 							array(
 								"created_at"           => "2022-03-14T15:15:22Z",
+								"id"                   => "7689378468829304869",
+								"updated_at"           => "2022-03-14T15:16:34Z",
+								"name"                 => "string",
+								"format"               => "XML",
+								"catalog_type"         => "RETAIL",
+								"location"             => "https://example-3.com/wp-content/uploads/pinterest-for-woocommerce-KJhJas.xml",
+								"status"               => "ACTIVE",
+								"default_currency"     => "USD",
+								"default_locale"       => "en-US",
+								"default_country"      => "US",
+								"default_availability" => "IN_STOCK",
+							),
+							array(
+								"created_at"           => "2022-03-14T15:15:22Z",
 								"id"                   => "547381235776346598",
 								"updated_at"           => "2022-03-14T15:16:34Z",
 								"name"                 => "string",
-								"format"               => "TSV",
+								"format"               => "CSV",
 								"catalog_type"         => "RETAIL",
 								"location"             => "https://example-2.com/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml",
 								"status"               => "ACTIVE",
@@ -80,8 +117,95 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 								"default_locale"       => "en-US",
 								"default_country"      => "US",
 								"default_availability" => "IN_STOCK",
-							)
+							),
 						),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
+	}
+
+	public static function get_feeds_no_match( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=475245723456346' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array (
+						'items' => array(
+							array(
+								"created_at"           => "2022-03-14T15:15:22Z",
+								"id"                   => "7689378468829304869",
+								"updated_at"           => "2022-03-14T15:16:34Z",
+								"name"                 => "string",
+								"format"               => "XML",
+								"catalog_type"         => "RETAIL",
+								"location"             => "https://example-3.com/wp-content/uploads/pinterest-for-woocommerce-KJhJas.xml",
+								"status"               => "ACTIVE",
+								"default_currency"     => "USD",
+								"default_locale"       => "en-US",
+								"default_country"      => "US",
+								"default_availability" => "IN_STOCK",
+							),
+							array(
+								"created_at"           => "2022-03-14T15:15:22Z",
+								"id"                   => "1345136789312412469",
+								"updated_at"           => "2022-03-14T15:16:34Z",
+								"name"                 => "string",
+								"format"               => "XML",
+								"catalog_type"         => "RETAIL",
+								"location"             => "https://example-5.com/wp-content/uploads/pinterest-for-woocommerce-hhRJgh.xml",
+								"status"               => "ACTIVE",
+								"default_currency"     => "USD",
+								"default_locale"       => "en-US",
+								"default_country"      => "US",
+								"default_availability" => "IN_STOCK",
+							),
+							array(
+								"created_at"           => "2022-03-14T15:15:22Z",
+								"id"                   => "123123510511560562",
+								"updated_at"           => "2022-03-14T15:16:34Z",
+								"name"                 => "string",
+								"format"               => "CSV",
+								"catalog_type"         => "RETAIL",
+								"location"             => "https://example-4.com/wp-content/uploads/pinterest-for-woocommerce-jkAadD.xml",
+								"status"               => "ACTIVE",
+								"default_currency"     => "USD",
+								"default_locale"       => "en-US",
+								"default_country"      => "US",
+								"default_availability" => "IN_STOCK",
+							),
+						),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
+	}
+
+	public static function get_no_feeds( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=475245723456346' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array (
+						'items' => array(),
 					)
 				),
 				'response' => array(

--- a/tests/E2e/Pinterest401DisconnectE2eTest.php
+++ b/tests/E2e/Pinterest401DisconnectE2eTest.php
@@ -47,6 +47,12 @@ class Pinterest401DisconnectE2eTest extends \WP_UnitTestCase
 		do_action( 'pinterest_for_woocommerce_token_saved' );
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests .
 	 *

--- a/tests/E2e/PinterestConnectE2eTest.php
+++ b/tests/E2e/PinterestConnectE2eTest.php
@@ -13,6 +13,12 @@ class PinterestConnectE2eTest extends \WP_UnitTestCase {
 		Pinterest_For_Woocommerce::save_settings( [] );
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests successful Pinterest auth produces proper settings after all pinterest_for_woocommerce_token_saved hooks are fired.
 	 *

--- a/tests/Integration/FeedsTest.php
+++ b/tests/Integration/FeedsTest.php
@@ -8,6 +8,12 @@ use Pinterest_For_Woocommerce;
 
 class FeedsTest extends \WP_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests emulates Pinterest create feed endpoint response when a feed with the same name already exists.
 	 *

--- a/tests/Unit/Api/APIV5Test.php
+++ b/tests/Unit/Api/APIV5Test.php
@@ -15,6 +15,12 @@ use WP_UnitTestCase;
 
 class APIV5Test extends WP_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	public function test_create_tag_returns_successful_response() {
 		add_filter(
 			'pinterest_for_woocommerce_default_tag_name',

--- a/tests/Unit/Api/AdvertiserConnectTest.php
+++ b/tests/Unit/Api/AdvertiserConnectTest.php
@@ -13,6 +13,12 @@ use Exception;
 
 class AdvertiserConnectTest extends \WP_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	public function test_connect_advertiser_and_tag_successfully_connects() {
 		add_filter(
 			'pre_http_request',

--- a/tests/Unit/Api/AdvertisersTest.php
+++ b/tests/Unit/Api/AdvertisersTest.php
@@ -14,6 +14,12 @@ use WP_Test_REST_TestCase;
 
 class AdvertisersTest extends WP_Test_REST_TestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests if the advertisers route is registered.
 	 *

--- a/tests/Unit/Api/DomainVerificationTest.php
+++ b/tests/Unit/Api/DomainVerificationTest.php
@@ -8,10 +8,24 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit\Api;
 
+use Automattic\WooCommerce\Pinterest\Tests\Unit\PinterestForWoocommerceTest;
+use Pinterest_For_Woocommerce;
 use WP_REST_Request;
 use WP_Test_REST_TestCase;
 
 class DomainVerificationTest extends WP_Test_REST_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Pinterest_For_Woocommerce::set_default_settings();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
 
 	/**
 	 * Tests if the domain verification route is registered.

--- a/tests/Unit/Api/FeedIssuesTest.php
+++ b/tests/Unit/Api/FeedIssuesTest.php
@@ -156,7 +156,7 @@ class FeedIssuesTest extends WP_Test_REST_TestCase {
 												),
 										)
 								)
-								)
+							)
 						),
 						'response' => array(
 							'code'    => 200,

--- a/tests/Unit/Api/FeedIssuesTest.php
+++ b/tests/Unit/Api/FeedIssuesTest.php
@@ -10,6 +10,12 @@ use WP_Test_REST_TestCase;
 
 class FeedIssuesTest extends WP_Test_REST_TestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests if the feed issues route is registered.
 	 *
@@ -58,9 +64,9 @@ class FeedIssuesTest extends WP_Test_REST_TestCase {
 		);
 		$mock_feed_id      = uniqid();
 
+		Pinterest_For_Woocommerce::set_default_settings();
 		Pinterest_For_WooCommerce::save_setting( 'tracking_advertiser', 'ai-123456789' );
 		Pinterest_For_WooCommerce::save_setting( 'account_data', $mock_account_data );
-		Pinterest_For_Woocommerce::save_setting( 'product_sync_enabled', true );
 		Pinterest_For_Woocommerce::save_data( 'feed_registered', $mock_feed_id  );
 
 		add_filter(

--- a/tests/Unit/Api/SyncSettingsTest.php
+++ b/tests/Unit/Api/SyncSettingsTest.php
@@ -14,6 +14,12 @@ use WP_Test_REST_TestCase;
 
 class SyncSettingsTest extends WP_Test_REST_TestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests if the sync settings route is registered.
 	 *

--- a/tests/Unit/Api/TagsTest.php
+++ b/tests/Unit/Api/TagsTest.php
@@ -13,6 +13,12 @@ use WP_Test_REST_TestCase;
 
 class TagsTest extends WP_Test_REST_TestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests if the tags route is registered.
 	 *

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
+use Automattic\WooCommerce\Pinterest\Exception\FeedNotFoundException;
 use Automattic\WooCommerce\Pinterest\Feeds;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Pinterest_For_Woocommerce;
@@ -35,8 +36,6 @@ class FeedsTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result );
 		$this->assertTrue( FeedDeletionFailure::note_exists() );
-
-		remove_all_filters( 'pre_http_request' );
 	}
 
 	public function test_maybe_remote_feed_returns_feed_id() {
@@ -46,21 +45,24 @@ class FeedsTest extends WP_UnitTestCase {
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( 'fIOasjj', $feed );
-
-		remove_all_filters( 'pre_http_request' );
 	}
 
-	public function test_maybe_remote_feed_returns_empty_string() {
-		add_filter( 'pre_http_request', array( self::class, 'get_empty_feeds' ), 10, 3 );
+	public function test_maybe_remote_feed_returns_empty_feed_id() {
+		add_filter( 'site_url', fn() => 'https://example-11.com' );
+		add_filter( 'pre_http_request', array( self::class, 'get_feeds_with_empty_tail_for_the_feed_location' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( '', $feed );
-
-		remove_all_filters( 'pre_http_request' );
 	}
 
-	public static function feed_delete_failure( $response, $parsed_args, $url ) {
+	public function test_maybe_remote_feed_returns_empty_string() {
+		add_filter( 'pre_http_request', array( self::class, 'get_empty_feeds' ), 10, 3 );
+		$this->expectException( FeedNotFoundException::class );
+		Feeds::maybe_remote_feed();
+	}
+
+	public static function feed_delete_failure( $response, $parsed_args, $url ): array {
 		if ( 'https://api.pinterest.com/v5/catalogs/feeds/1574695656968?ad_account_id=114141241212' === $url ) {
 			return array(
 				'headers' => array(
@@ -83,7 +85,7 @@ class FeedsTest extends WP_UnitTestCase {
 		return $response;
 	}
 
-	public static function get_feeds( $response, $parsed_args, $url ) {
+	public static function get_feeds( $response, $parsed_args, $url ): array {
 		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
 			return array(
 				'headers' => array(
@@ -120,7 +122,7 @@ class FeedsTest extends WP_UnitTestCase {
 		return $response;
 	}
 
-	public static function get_empty_feeds( $response, $parsed_args, $url ) {
+	public static function get_empty_feeds( $response, $parsed_args, $url ): array {
 		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
 			return array(
 				'headers' => array(
@@ -136,6 +138,43 @@ class FeedsTest extends WP_UnitTestCase {
 					'message' => 'OK',
 				),
 				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
+	}
+
+	public static function get_feeds_with_empty_tail_for_the_feed_location( $response, $parsed_args, $url ): array {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array(
+						'items' => array(
+							array(
+								"created_at"           => "2022-03-14T15:15:22Z",
+								"id"                   => "278913891236895123895",
+								"updated_at"           => "2022-03-14T15:16:34Z",
+								"name"                 => "WooCommerce",
+								"format"               => "TSV",
+								"catalog_type"         => "RETAIL",
+								"location"             => "https://example-11.com/pinterest-for-woocommerce-.xml",
+								"status"               => "ACTIVE",
+								"default_currency"     => "USD",
+								"default_locale"       => "en-US",
+								"default_country"      => "US",
+								"default_availability" => "IN_STOCK",
+							),
+						),
+					),
+				),
+				'response' => array(
+					'code' => 200,
+					'message' => 'OK',
+				),
+				'cookies' => array(),
 				'filename' => '',
 			);
 		}

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -4,8 +4,24 @@ namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use Automattic\WooCommerce\Pinterest\Feeds;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
+use Pinterest_For_Woocommerce;
+use WP_UnitTestCase;
 
-class FeedsTest extends \WP_UnitTestCase {
+class FeedsTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Pinterest_For_Woocommerce::set_default_settings();
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '114141241212' );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'site_url' );
+	}
 
 	/**
 	 * Tests feed deletion produces an admin notice in case feed deletion has failed.
@@ -13,115 +29,116 @@ class FeedsTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_feed_delete_produces_an_admin_notification() {
-		add_filter(
-			'pre_http_request',
-			function ( $response, $parsed_args, $url ) {
-				return array(
-					'headers'  => array(
-						'content-type' => 'application/json',
-					),
-					'body'     => json_encode(
-						array(
-							'code'    => 4162,
-							'message' => 'We can\'t disable a Product Group with active promotions.',
-						)
-					),
-					'response' => array(
-						'code'    => 409,
-						'message' => 'Conflict. Can\'t delete a feed with active promotions.',
-					),
-					'cookies'  => array(),
-					'filename' => '',
-				);
-			},
-			10,
-			3
-		);
+		add_filter( 'pre_http_request', array( self::class, 'feed_delete_failure' ), 10, 3 );
 
 		$result = Feeds::delete_feed( '1574695656968' );
 
 		$this->assertFalse( $result );
 		$this->assertTrue( FeedDeletionFailure::note_exists() );
+
+		remove_all_filters( 'pre_http_request' );
 	}
 
 	public function test_maybe_remote_feed_returns_feed_id() {
-		add_filter(
-			'site_url',
-			function () {
-				return 'https://example.org';
-			}
-		);
+		add_filter( 'site_url', fn() => 'https://example-1.com' );
+		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
 
-		add_filter(
-			'pre_http_request',
-			function ( $response, $parsed_args, $url ) {
-				return array(
-					'headers' => array(
-						'content-type' => 'application/json',
-					),
-					'body' => json_encode(
-						array(
-							'items' => array(
-								array(
-									"created_at"                    => "2022-03-14T15:15:22Z",
-									"id"                            => "278913891236895123895",
-									"updated_at"                    => "2022-03-14T15:16:34Z",
-									"name"                          => "Created by Pinterest for WooCommerce at pinterest.dima.works US|en-US|USD",
-									"format"                        => "TSV",
-									"catalog_type"                  => "RETAIL",
-									"location"                      => "https://example.org/pinterest-for-woocommerce-fIOasjj.xml",
-									"status"                        => "ACTIVE",
-									"default_currency"              => "USD",
-									"default_locale"                => "en-US",
-									"default_country"               => "US",
-									"default_availability"          => "IN_STOCK",
-								),
-							),
-						),
-					),
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'cookies'  => array(),
-					'filename' => '',
-				);
-			},
-			10,
-			3
-		);
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( 'fIOasjj', $feed );
+
+		remove_all_filters( 'pre_http_request' );
 	}
 
 	public function test_maybe_remote_feed_returns_empty_string() {
-		add_filter(
-			'pre_http_request',
-			function ( $response, $parsed_args, $url ) {
-				return array(
-					'headers' => array(
-						'content-type' => 'application/json',
-					),
-					'body' => json_encode(
-						array(
-							'items' => array(),
-						),
-					),
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'cookies'  => array(),
-					'filename' => '',
-				);
-			},
-			10,
-			3
-		);
+		add_filter( 'pre_http_request', array( self::class, 'get_empty_feeds' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( '', $feed );
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
+	public static function feed_delete_failure( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds/1574695656968?ad_account_id=114141241212' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array(
+						'code' => 4162,
+						'message' => 'We can\'t disable a Product Group with active promotions.',
+					)
+				),
+				'response' => array(
+					'code' => 409,
+					'message' => 'Conflict. Can\'t delete a feed with active promotions.',
+				),
+				'cookies' => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
+	}
+
+	public static function get_feeds( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array(
+						'items' => array(
+							array(
+								"created_at" => "2022-03-14T15:15:22Z",
+								"id" => "278913891236895123895",
+								"updated_at" => "2022-03-14T15:16:34Z",
+								"name" => "Created by Pinterest for WooCommerce at pinterest.dima.works US|en-US|USD",
+								"format" => "TSV",
+								"catalog_type" => "RETAIL",
+								"location" => "https://example-1.com/pinterest-for-woocommerce-fIOasjj.xml",
+								"status" => "ACTIVE",
+								"default_currency" => "USD",
+								"default_locale" => "en-US",
+								"default_country" => "US",
+								"default_availability" => "IN_STOCK",
+							),
+						),
+					),
+				),
+				'response' => array(
+					'code' => 200,
+					'message' => 'OK',
+				),
+				'cookies' => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
+	}
+
+	public static function get_empty_feeds( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
+			return array(
+				'headers' => array(
+					'content-type' => 'application/json',
+				),
+				'body' => json_encode(
+					array(
+						'items' => array(),
+					),
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+		return $response;
 	}
 }

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -4,30 +4,8 @@ namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use Automattic\WooCommerce\Pinterest\Feeds;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
-use Pinterest_For_Woocommerce;
-use WC_Helper_Product;
 
 class FeedsTest extends \WP_UnitTestCase {
-
-	public function setUp(): void {
-		parent::setUp();
-
-		// Cleanup API call stub before each test.
-		remove_filter( 'pre_http_request', array( self::class, 'get_feeds_request_stub' ) );
-
-		Pinterest_For_Woocommerce::save_data('local_feed_ids', array());
-		Pinterest_For_Woocommerce::save_setting('tracking_advertiser', '8901267167247612734708');
-		add_filter('woocommerce_get_base_location', 'US:CA');
-		add_filter('locale', 'en_US');
-		add_filter(
-			'site_url',
-			function ($url) {
-				return 'https://pinterest.dima.works';
-			},
-			10,
-			1
-		);
-	}
 
 	/**
 	 * Tests feed deletion produces an admin notice in case feed deletion has failed.
@@ -35,31 +13,26 @@ class FeedsTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_feed_delete_produces_an_admin_notification() {
-		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '549765662491' );
-
 		add_filter(
 			'pre_http_request',
 			function ( $response, $parsed_args, $url ) {
-				if ( 'https://api.pinterest.com/v5/catalogs/feeds/1574695656968?ad_account_id=549765662491' === $url ) {
-					$response = array(
-						'headers'  => array(
-							'content-type' => 'application/json',
-						),
-						'body'     => json_encode(
-							array(
-								'code'    => 4162,
-								'message' => 'We can\'t disable a Product Group with active promotions.',
-							)
-						),
-						'response' => array(
-							'code'    => 409,
-							'message' => 'Conflict. Can\'t delete a feed with active promotions.',
-						),
-						'cookies'  => array(),
-						'filename' => '',
-					);
-				}
-				return $response;
+				return array(
+					'headers'  => array(
+						'content-type' => 'application/json',
+					),
+					'body'     => json_encode(
+						array(
+							'code'    => 4162,
+							'message' => 'We can\'t disable a Product Group with active promotions.',
+						)
+					),
+					'response' => array(
+						'code'    => 409,
+						'message' => 'Conflict. Can\'t delete a feed with active promotions.',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
 			},
 			10,
 			3
@@ -72,75 +45,83 @@ class FeedsTest extends \WP_UnitTestCase {
 	}
 
 	public function test_maybe_remote_feed_returns_feed_id() {
-		self::get_feeds_request_stub(
-			array(
-				'items' => array(
-					array(
-						"created_at"                    => "2022-03-14T15:15:22Z",
-						"id"                            => "278913891236895123895",
-						"updated_at"                    => "2022-03-14T15:16:34Z",
-						"name"                          => "Created by Pinterest for WooCommerce at pinterest.dima.works US|en-US|USD",
-						"format"                        => "TSV",
-						"catalog_type"                  => "RETAIL",
-						"credentials"                   => array(
-							"password" => "string",
-							"username" => "string",
-						),
-						"location"                      => "https://pinterest.dima.works/pinterest-for-woocommerce-fIOasjj.xml",
-						"preferred_processing_schedule" => array(
-							"time"     => "02:59",
-							"timezone" => "Africa/Abidjan",
-						),
-						"status"                        => "ACTIVE",
-						"default_currency"              => "USD",
-						"default_locale"                => "en-US",
-						"default_country"               => "US",
-						"default_availability"          => "IN_STOCK",
-					),
-				),
-			)
+		add_filter(
+			'site_url',
+			function () {
+				return 'https://example.org';
+			}
 		);
 
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				return array(
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'body' => json_encode(
+						array(
+							'items' => array(
+								array(
+									"created_at"                    => "2022-03-14T15:15:22Z",
+									"id"                            => "278913891236895123895",
+									"updated_at"                    => "2022-03-14T15:16:34Z",
+									"name"                          => "Created by Pinterest for WooCommerce at pinterest.dima.works US|en-US|USD",
+									"format"                        => "TSV",
+									"catalog_type"                  => "RETAIL",
+									"location"                      => "https://example.org/pinterest-for-woocommerce-fIOasjj.xml",
+									"status"                        => "ACTIVE",
+									"default_currency"              => "USD",
+									"default_locale"                => "en-US",
+									"default_country"               => "US",
+									"default_availability"          => "IN_STOCK",
+								),
+							),
+						),
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
 		$feed = Feeds::maybe_remote_feed();
 
-		$this->assertEquals( '278913891236895123895', $feed );
+		$this->assertEquals( 'fIOasjj', $feed );
 	}
 
 	public function test_maybe_remote_feed_returns_empty_string() {
-		self::get_feeds_request_stub(
-			array(
-				'items' => array(),
-			)
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				return array(
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'body' => json_encode(
+						array(
+							'items' => array(),
+						),
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
 		);
 
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( '', $feed );
-	}
-
-	private static function get_feeds_request_stub( array $body ) {
-		add_filter(
-			'pre_http_request',
-			function ( $response, $parsed_args, $url ) use ( $body ) {
-				if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=8901267167247612734708' === $url ) {
-					$response = array(
-						'headers' => array(
-							'content-type' => 'application/json',
-						),
-						'body' => json_encode( $body ),
-						'response' => array(
-							'code'    => 200,
-							'message' => 'OK',
-						),
-						'cookies'  => array(),
-						'filename' => '',
-					);
-				}
-
-				return $response;
-			},
-			10,
-			3
-		);
 	}
 }

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -9,6 +9,26 @@ use WC_Helper_Product;
 
 class FeedsTest extends \WP_UnitTestCase {
 
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Cleanup API call stub before each test.
+		remove_filter( 'pre_http_request', array( self::class, 'get_feeds_request_stub' ) );
+
+		Pinterest_For_Woocommerce::save_data('local_feed_ids', array());
+		Pinterest_For_Woocommerce::save_setting('tracking_advertiser', '8901267167247612734708');
+		add_filter('woocommerce_get_base_location', 'US:CA');
+		add_filter('locale', 'en_US');
+		add_filter(
+			'site_url',
+			function ($url) {
+				return 'https://pinterest.dima.works';
+			},
+			10,
+			1
+		);
+	}
+
 	/**
 	 * Tests feed deletion produces an admin notice in case feed deletion has failed.
 	 *
@@ -49,5 +69,78 @@ class FeedsTest extends \WP_UnitTestCase {
 
 		$this->assertFalse( $result );
 		$this->assertTrue( FeedDeletionFailure::note_exists() );
+	}
+
+	public function test_maybe_remote_feed_returns_feed_id() {
+		self::get_feeds_request_stub(
+			array(
+				'items' => array(
+					array(
+						"created_at"                    => "2022-03-14T15:15:22Z",
+						"id"                            => "278913891236895123895",
+						"updated_at"                    => "2022-03-14T15:16:34Z",
+						"name"                          => "Created by Pinterest for WooCommerce at pinterest.dima.works US|en-US|USD",
+						"format"                        => "TSV",
+						"catalog_type"                  => "RETAIL",
+						"credentials"                   => array(
+							"password" => "string",
+							"username" => "string",
+						),
+						"location"                      => "",
+						"preferred_processing_schedule" => array(
+							"time"     => "02:59",
+							"timezone" => "Africa/Abidjan",
+						),
+						"status"                        => "ACTIVE",
+						"default_currency"              => "USD",
+						"default_locale"                => "en-US",
+						"default_country"               => "US",
+						"default_availability"          => "IN_STOCK",
+					),
+				),
+			)
+		);
+
+		$feed = Feeds::maybe_remote_feed();
+
+		$this->assertEquals( '278913891236895123895', $feed );
+	}
+
+	public function test_maybe_remote_feed_returns_empty_string() {
+		self::get_feeds_request_stub(
+			array(
+				'items' => array(),
+			)
+		);
+
+		$feed = Feeds::maybe_remote_feed();
+
+		$this->assertEquals( '', $feed );
+	}
+
+	private static function get_feeds_request_stub( array $response ) {
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) use ( $response ) {
+				if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=8901267167247612734708' === $url ) {
+					$response = array(
+						'headers' => array(
+							'content-type' => 'application/json',
+						),
+						'body' => json_encode( $response ),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => '',
+					);
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
 	}
 }

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -9,7 +9,7 @@ use WC_Helper_Product;
 
 class FeedsTest extends \WP_UnitTestCase {
 
-	protected function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Cleanup API call stub before each test.
@@ -86,7 +86,7 @@ class FeedsTest extends \WP_UnitTestCase {
 							"password" => "string",
 							"username" => "string",
 						),
-						"location"                      => "",
+						"location"                      => "https://pinterest.dima.works/pinterest-for-woocommerce-fIOasjj.xml",
 						"preferred_processing_schedule" => array(
 							"time"     => "02:59",
 							"timezone" => "Africa/Abidjan",
@@ -118,16 +118,16 @@ class FeedsTest extends \WP_UnitTestCase {
 		$this->assertEquals( '', $feed );
 	}
 
-	private static function get_feeds_request_stub( array $response ) {
+	private static function get_feeds_request_stub( array $body ) {
 		add_filter(
 			'pre_http_request',
-			function ( $response, $parsed_args, $url ) use ( $response ) {
+			function ( $response, $parsed_args, $url ) use ( $body ) {
 				if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=8901267167247612734708' === $url ) {
 					$response = array(
 						'headers' => array(
 							'content-type' => 'application/json',
 						),
-						'body' => json_encode( $response ),
+						'body' => json_encode( $body ),
 						'response' => array(
 							'code'    => 200,
 							'message' => 'OK',

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Automattic\WooCommerce\Pinterest\LocaleMapper;
 
@@ -59,7 +60,7 @@ class PinterestTestLocaleMapper extends TestCase {
 	 */
 	public function test_locale_with_no_match() {
 		$this->locale = 'me_ME';
-		$this->expectException( Exception::class );
+		$this->expectException( PinterestApiLocaleException::class );
 		LocaleMapper::get_locale_for_api();
 	}
 }

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -12,6 +12,12 @@ use WP_UnitTestCase;
 
 class PinterestForWoocommerceTest extends WP_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	/**
 	 * Tests default settings are set.
 	 *

--- a/tests/Unit/RefreshTokenTest.php
+++ b/tests/Unit/RefreshTokenTest.php
@@ -6,8 +6,15 @@ use Automattic\WooCommerce\Pinterest\Crypto;
 use Automattic\WooCommerce\Pinterest\Heartbeat;
 use Automattic\WooCommerce\Pinterest\RefreshToken;
 use Pinterest_For_Woocommerce;
+use WP_UnitTestCase;
 
-class RefreshTokenTest extends \WP_UnitTestCase {
+class RefreshTokenTest extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
 
 	/**
 	 * Test daily refresh token action is added.

--- a/tests/Unit/TasksTest.php
+++ b/tests/Unit/TasksTest.php
@@ -64,6 +64,7 @@ class TasksTest extends WP_UnitTestCase {
 		$this->assertFalse( $is_complete, 'Cannot assert task not completed.' );
 
 		// Setup complete data.
+		Pinterest_For_Woocommerce::set_default_settings();
 		$account_data = array(
 			'is_any_website_verified' => true,
 			'verified_user_websites'  => array( 'somedomain.com' ),

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -9,6 +9,12 @@ use WP_UnitTestCase;
 
 class ConversionsTest extends WP_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_filters( 'pre_http_request' );
+	}
+
 	public function test_conversions_track_page_visit_event() {
 		Pinterest_For_Woocommerce::save_settings(
 			array(

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -6,10 +6,6 @@ use Pinterest_For_Woocommerce;
 
 class TagTest extends \WP_UnitTestCase {
 
-	function setUp(): void {
-		parent::setUp();
-	}
-
 	public function test_adds_hooks() {
 		$tag = new Tag();
 		$tag->init_hooks();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1060

The PR aims to fix multiple things related to the feed deletion issue.

- The update procedure will remove duplicates of the Feed Deletion Failure notice.
- Feed deletion failure notice also got an updated text.
- Existing feeds to be fetched from Pinterest and reactivated, if any.
- Removing the condition to auto-disconnect the plugin in case of 403 Pinterest API error response (Pinterest returns 403 when an unapproved merchant can not delete their feed, which is not an access token-related issue, and we do not need to disconnect in this case).

### Changelog entry

> Fix - Feed Deletion Failure notice duplicates removal.
> Fix - Reuse existing feed, if any.
> Fix - 403 Pinterest API error response is not the reason to auto-disconnect.
> Dev - Tests suits update.
