### PR TITLE
Commerce Integration integrity check.

### DIFF
--- a/src/API/Settings.php
+++ b/src/API/Settings.php
@@ -48,7 +48,7 @@ class Settings extends VendorAPI {
 		$settings = Pinterest_For_Woocommerce()::get_settings( true );
 		if ( empty( $settings['account_data']['id'] ) ) {
 			$integration_data = Pinterest_For_Woocommerce::get_data( 'integration_data' );
-			$settings['account_data']['id'] = $integration_data['connected_user_id'] ?? '';
+			$settings['account_data']['id'] = $integration_data['connected_user_id'] ?? 'unknown';
 		}
 		return array(
 			PINTEREST_FOR_WOOCOMMERCE_OPTION_NAME => $settings,

--- a/src/CommerceIntegrationSync.php
+++ b/src/CommerceIntegrationSync.php
@@ -1,0 +1,178 @@
+<?php //phpcs:disable WordPress.WP.AlternativeFunctions --- Uses FS read/write in order to reliable append to an existing file.
+/**
+ * Pinterest for WooCommerce Commerce Integration Sync
+ *
+ * @package     Pinterest_For_WooCommerce/Classes/
+ * @version     1.0.0
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Pinterest\API\APIV5;
+use Exception;
+use Pinterest_For_Woocommerce;
+use WC_Log_Levels;
+
+/**
+ * Handling Pinterest Commerce Integration synchronisation.
+ * Pinterest is mostly interested in the `partner_metadata` part of it.
+ */
+class CommerceIntegrationSync {
+
+	/**
+	 * Check and schedule a weekly event.
+	 *
+	 * @return void
+	 */
+	public static function schedule_event() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
+		if ( ! has_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) ) ) {
+			add_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) );
+		}
+	}
+
+	/**
+	 * Handle Pinterest Commerce Integration weekly sync.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public static function handle_sync(): bool {
+		try {
+			$external_business_id = Pinterest_For_Woocommerce::get_data( 'integration_data' )['external_business_id'] ?? '';
+			if ( empty( $external_business_id ) ) {
+				Pinterest_For_Woocommerce::create_commerce_integration();
+				return true;
+			}
+
+			$integration = APIV5::get_commerce_integration( $external_business_id );
+			$data        = self::prepare_commerce_integration_data( $integration['external_business_id'] );
+			if ( $integration['partner_metadata'] === $data['partner_metadata'] ) {
+				return true;
+			}
+
+			$response = APIV5::update_commerce_integration( $integration['external_business_id'], $data );
+			Pinterest_For_Woocommerce::save_integration_data( $response );
+			return true;
+		} catch ( PinterestApiException $e ) {
+			Logger::log(
+				$e->getMessage(),
+				WC_Log_Levels::ERROR,
+				'pinterest-for-woocommerce-commerce-integration-sync'
+			);
+			return false;
+		} catch ( Exception $e ) {
+			/*
+			 * As thrown from create_commerce_integration call in case Advertiser ID is missing.
+			 * Extremely unlikely at this stage.
+			 */
+			Logger::log(
+				$e->getMessage(),
+				WC_Log_Levels::ERROR,
+				'pinterest-for-woocommerce-commerce-integration-sync'
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Prepares Commerce Integration Data.
+	 *
+	 * @param string $external_business_id Auto-generated if empty External Business ID to pass to Pinterest.
+	 *
+	 * @since x.x.x
+	 * @return array
+	 * @throws Exception In case of Advertiser ID is missing.
+	 */
+	public static function prepare_commerce_integration_data( string $external_business_id = '' ): array {
+		global $wp_version;
+
+		if ( empty( $external_business_id ) ) {
+			$external_business_id = self::generate_external_business_id();
+		}
+		$connection_data = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
+
+		// It does not make any sense to create integration without Advertiser ID.
+		if ( empty( $connection_data['advertiser_id'] ) ) {
+			throw new Exception(
+				sprintf(
+					esc_html__(
+						'Commerce Integration cannot be created: Advertiser ID is missing.',
+						'pinterest-for-woocommerce'
+					)
+				)
+			);
+		}
+
+		$integration_data = array(
+			'external_business_id'    => $external_business_id,
+			'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
+			'connected_advertiser_id' => $connection_data['advertiser_id'],
+			'partner_metadata'        => json_encode(
+				array(
+					'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+					'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+					'wp_version'     => $wp_version,
+					'locale'         => get_locale(),
+					'currency'       => get_woocommerce_currency(),
+				)
+			),
+		);
+
+		if ( ! empty( $connection_data['tag_id'] ) ) {
+			$integration_data['connected_tag_id'] = $connection_data['tag_id'];
+		}
+		/**
+		 * Allows modifications to commerce integration data when creating or updating Pinterest Commerce Integration.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $integration_data {
+		 *      An array of integration data as rquired by the Pinterest API endpoint documentation.
+		 *      @link https://developers.pinterest.com/docs/api/v5/integrations_commerce-post
+		 *
+		 *      @type string $external_business_id    - Woo's external business ID.
+		 *      @type string $connected_merchant_id   - Connected merchant ID for the integration.
+		 *      @type string $connected_advertiser_id - Connected advertiser ID for the integration.
+		 *      @type string $connected_tag_id        - Connected Pinterest Tag ID for the integration.
+		 *      @type string $partner_metadata        - Partner metadata for the integration.
+		 * }
+		 */
+		return apply_filters( 'pinterest_for_woocommerce_commerce_integration_data', $integration_data );
+	}
+
+	/**
+	 * Used to generate external business id to pass it Pinterest when creating a connection between WC and Pinterest.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	public static function generate_external_business_id(): string {
+		$name = (string) parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
+		if ( empty( $name ) ) {
+			$name = sanitize_title( get_bloginfo( 'name' ) );
+		}
+		$id = uniqid( sprintf( 'woo-%s-', $name ), false );
+
+		/**
+		 * Filters the shop's external business id.
+		 *
+		 * This is passed to Pinterest when connecting.
+		 * Should be non-empty and without special characters,
+		 * otherwise the ID will be obtained from the site's name as fallback.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param string $id the shop's external business id.
+		 */
+		return (string) apply_filters( 'wc_pinterest_external_business_id', $id );
+	}
+}

--- a/tests/Unit/CommerceIntegrationSyncTest.php
+++ b/tests/Unit/CommerceIntegrationSyncTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\CommerceIntegrationSync;
+use Automattic\WooCommerce\Pinterest\Heartbeat;
+use Pinterest_For_Woocommerce;
+use WP_UnitTestCase;
+
+class CommerceIntegrationSyncTest extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Pinterest_For_Woocommerce::remove_data( 'integration_data' );
+		remove_all_filters( 'pre_http_request' );
+	}
+
+	/**
+	 * Test daily refresh token action is added.
+	 *
+	 * @return void
+	 */
+	public function test_scheduled_event_added_with_plugin() {
+		Pinterest_For_Woocommerce()->init_plugin();
+		$this->assertEquals( 10, has_action( 'init', [ CommerceIntegrationSync::class, 'schedule_event' ] ) );
+	}
+
+	public function test_schedule_event_adds_weekly_action_if_integration_id_present() {
+		// Jobs will schedule only if Pinterest is connected (means integration data is set and has the ID).
+		Pinterest_For_Woocommerce::save_data( 'integration_data', array( 'id' => '678903145607896071' ) );
+
+		CommerceIntegrationSync::schedule_event();
+		$this->assertEquals( 20, has_action( Heartbeat::WEEKLY, array( CommerceIntegrationSync::class, 'handle_sync' ) ) );
+	}
+
+	public function test_schedule_event_doesnt_add_weekly_action_if_integration_id_missing() {
+		// Jobs will schedule only if Pinterest is connected (means integration data is set and has the ID).
+		Pinterest_For_Woocommerce::save_data( 'integration_data', [] );
+
+		CommerceIntegrationSync::schedule_event();
+		$this->assertFalse( has_action( Heartbeat::WEEKLY, array( CommerceIntegrationSync::class, 'handle_sync' ) ) );
+	}
+
+	public function test_schedule_event_doesnt_add_weekly_action_if_integration_data_missing() {
+		CommerceIntegrationSync::schedule_event();
+		$this->assertFalse( has_action( Heartbeat::WEEKLY, array( CommerceIntegrationSync::class, 'handle_sync' ) ) );
+	}
+
+	public function test_handle_sync_creates_commerce_integration_if_external_business_id_missing() {
+		global $wp_version;
+
+		Pinterest_For_Woocommerce::save_data(
+			'connection_info_data',
+			array(
+				'advertiser_id' => 'advertiser-id-jksd76788',
+				'merchant_id'   => 'merchant-id-hjkasdf',
+				'tag_id'        => 'tag-id-3245671356787',
+			)
+		);
+		add_filter(
+			'wc_pinterest_external_business_id',
+			function () {
+				return 'woo-example-2.com-2k3Gdf91D';
+			}
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				global $wp_version;
+
+				$this->assertEquals( 'https://api.pinterest.com/v5/integrations/commerce', $url );
+				return array(
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'body' => json_encode(
+						array(
+							'external_business_id'    => 'woo-example-2.com-2k3Gdf91D',
+							'connected_merchant_id'   => 'merchant-id-hjkasdf',
+							'connected_advertiser_id' => 'advertiser-id-jksd76788',
+							'connected_tag_id'        => 'tag-id-3245671356787',
+							'partner_metadata'        => json_encode(
+								array(
+									'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+									'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+									'wp_version'     => $wp_version,
+									'locale'         => get_locale(),
+									'currency'       => get_woocommerce_currency(),
+								)
+							),
+						)
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$result = CommerceIntegrationSync::handle_sync();
+		$this->assertTrue( $result );
+		$this->assertEquals(
+			array(
+				'external_business_id'    => 'woo-example-2.com-2k3Gdf91D',
+				'connected_merchant_id'   => 'merchant-id-hjkasdf',
+				'connected_advertiser_id' => 'advertiser-id-jksd76788',
+				'connected_tag_id'        => 'tag-id-3245671356787',
+				'partner_metadata'        => json_encode(
+					array(
+						'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+						'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+						'wp_version'     => $wp_version,
+						'locale'         => get_locale(),
+						'currency'       => get_woocommerce_currency(),
+					)
+				),
+			),
+			Pinterest_For_Woocommerce::get_data( 'integration_data' )
+		);
+		$this->assertEquals(
+			'advertiser-id-jksd76788',
+			Pinterest_For_Woocommerce::get_setting( 'tracking_advertiser' )
+		);
+		$this->assertEquals(
+			'tag-id-3245671356787',
+			Pinterest_For_Woocommerce::get_setting( 'tracking_tag' )
+		);
+	}
+
+	public function test_handle_sync_does_nothing_if_partner_metadata_matches() {
+		Pinterest_For_Woocommerce::save_data(
+			'connection_info_data',
+			array(
+				'advertiser_id' => 'advertiser-id-jksd76788',
+				'merchant_id'   => 'merchant-id-hjkasdf',
+				'tag_id'        => 'tag-id-3245671356787',
+			)
+		);
+		Pinterest_For_Woocommerce::save_data(
+			'integration_data',
+			array( 'external_business_id' => 'woo-example.com-2k3Gdf91D' )
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				global $wp_version;
+
+				$this->assertEquals( 'https://api.pinterest.com/v5/integrations/commerce/woo-example.com-2k3Gdf91D', $url );
+				return array(
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'body' => json_encode(
+						array(
+							'external_business_id'    => 'woo-example.com-2k3Gdf91D',
+							'connected_merchant_id'   => 'merchant-id-hjkasdf',
+							'connected_advertiser_id' => 'advertiser-id-jksd76788',
+							'connected_tag_id'        => 'tag-id-3245671356787',
+							'partner_metadata'        => json_encode(
+								array(
+									'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+									'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+									'wp_version'     => $wp_version,
+									'locale'         => get_locale(),
+									'currency'       => get_woocommerce_currency(),
+								)
+							),
+						)
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$result = CommerceIntegrationSync::handle_sync();
+		$this->assertTrue( $result );
+	}
+
+	public function test_handle_sync_updates_if_partner_metadata_mismatch() {
+		Pinterest_For_Woocommerce::save_data(
+			'connection_info_data',
+			array(
+				'advertiser_id' => 'advertiser-id-jksd76788',
+				'merchant_id'   => 'merchant-id-hjkasdf',
+				'tag_id'        => 'tag-id-3245671356787',
+			)
+		);
+		Pinterest_For_Woocommerce::save_data(
+			'integration_data',
+			array( 'external_business_id' => 'woo-example.com-2k3Gdf91D' )
+		);
+		add_filter(
+			'pinterest_for_woocommerce_commerce_integration_data',
+			function ( $data ) {
+				$data['partner_metadata'] = json_decode( $data['partner_metadata'], true );
+				$data['partner_metadata'] = json_encode(
+					array_merge(
+						$data['partner_metadata'],
+						array(
+							'plugin_version' => '99999.01',
+							'wc_version'     => '99999.02',
+							'wp_version'     => '99999.03',
+						)
+					)
+				);
+				return $data;
+			},
+			10,
+			1
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				global $wp_version;
+
+				$this->assertEquals( 'https://api.pinterest.com/v5/integrations/commerce/woo-example.com-2k3Gdf91D', $url );
+
+				$data = array(
+					'external_business_id'    => 'woo-example.com-2k3Gdf91D',
+					'connected_merchant_id'   => 'merchant-id-hjkasdf',
+					'connected_advertiser_id' => 'advertiser-id-jksd76788',
+					'connected_tag_id'        => 'tag-id-3245671356787',
+					'partner_metadata'        => json_encode(
+						array(
+							'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+							'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+							'wp_version'     => $wp_version,
+							'locale'         => get_locale(),
+							'currency'       => get_woocommerce_currency(),
+						)
+					),
+				);
+
+				if ( 'PATCH' === $parsed_args['method'] ) {
+					$data['partner_metadata'] = json_encode(
+						array(
+							'plugin_version' => '99999.01',
+							'wc_version'     => '99999.02',
+							'wp_version'     => '99999.03',
+							'locale'         => get_locale(),
+							'currency'       => get_woocommerce_currency(),
+						)
+					);
+					$this->assertEquals( $data, json_decode( $parsed_args['body'], true ) );
+				}
+
+				return array(
+					'headers' => array(
+						'content-type' => 'application/json',
+					),
+					'body' => json_encode( $data ),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$result = CommerceIntegrationSync::handle_sync();
+		$this->assertTrue( $result );
+		$this->assertEquals(
+			array(
+				'external_business_id'    => 'woo-example.com-2k3Gdf91D',
+				'connected_merchant_id'   => 'merchant-id-hjkasdf',
+				'connected_advertiser_id' => 'advertiser-id-jksd76788',
+				'connected_tag_id'        => 'tag-id-3245671356787',
+				'partner_metadata'        => json_encode(
+					array(
+						'plugin_version' => '99999.01',
+						'wc_version'     => '99999.02',
+						'wp_version'     => '99999.03',
+						'locale'         => get_locale(),
+						'currency'       => get_woocommerce_currency(),
+					)
+				),
+			),
+			Pinterest_For_Woocommerce::get_data( 'integration_data' )
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Originally this PR has been bigger but it was refactored into smaller pieced that have received their own PRs:

- #1074
- #1075 
- #1076 

Closes #1068 .

This PR aims to replay the Create Commerce Integration request in case of failure during the onboarding. 

Another PR task is to introduce a scheduled action to update Commerce Integration metadata every week, updating the `partner_metadata` property with a new string containing current WP, WC, and Pinterest for WooCommerce extension version numbers if those have changed recently.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Adjust the code to make create commerce integration calls fail.

By adding a filter

```php
add_filter(
			'pre_http_request',
			function ( $response, $parsed_args, $url ) {
				if (
					'https://api.pinterest.com/v5/integrations/commerce' === $url &&
					'POST' === $parsed_args['method']
				) {
					return array(
						'headers' => array(
							'content-type' => 'application/json',
						),
						'body' => json_encode(
							array(
								'code'    => 911,
								'message' => 'Oops! Something went wrong!',
							)
						),
						'response' => array(
							'code'    => 500,
							'message' => 'Unexpected error',
						),
						'cookies'  => array(),
						'filename' => '',
					);
				}

				return $response;
			},
			10,
			3
		);
```

2. Connect the plugin. Visually, you won't see anything that has failed.
3. Check Scheduled Actions for `pinterest_for_woocommerce_retry_commerce_integration` action. I am scheduling three attempts max.
4. Added a weekly action to run `CommerceIntegrationSync::handle_sync` which will also attempt to create and integration if the one is not present, otherwise, just update it if partner metadata doesn't match.

I am thinking now about adding a Notice if the create commerce integration attempt fails all three times, not to wait for a weekly task to run and retry to create commerce integration again. This is the only addition I can think of. Otherwise, the code is ready.    

### Changelog entry

> Add - Create Commerce Integration retry procedure.
> Add - Commerce Integration Upsert weekly task.
