### PR TITLE
Retrying Commerce Integration Creation on Falure.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -285,6 +285,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'init', array( Pinterest\Billing::class, 'schedule_event' ) );
 			add_action( 'init', array( Pinterest\AdCredits::class, 'schedule_event' ) );
 			add_action( 'init', array( Pinterest\RefreshToken::class, 'schedule_event' ) );
+			add_action( 'init', array( Pinterest\CommerceIntegration::class, 'init' ) );
 
 			// Register the marketing channel if the feature is included.
 			if ( defined( 'WC_MCM_EXISTS' ) ) {
@@ -805,6 +806,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public static function disconnect(): bool {
 			// Reset Feed file generation telemetry.
 			ProductFeedStatus::deregister();
+			Pinterest\CommerceIntegration::maybe_unregister_retries();
 
 			/*
 			 * If there is no business connected, disconnecting merchant will throw error.
@@ -970,10 +972,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @since 1.4.0
 		 */
 		public static function create_commerce_integration(): array {
-			global $wp_version;
-
-			$external_business_id = self::generate_external_business_id();
-			$connection_data      = self::get_data( 'connection_info_data', true );
+			$connection_data = self::get_data( 'connection_info_data', true );
 
 			// It does not make any sense to create integration without Advertiser ID.
 			if ( empty( $connection_data['advertiser_id'] ) ) {
@@ -987,41 +986,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				);
 			}
 
-			$integration_data = array(
-				'external_business_id'    => $external_business_id,
-				'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
-				'connected_advertiser_id' => $connection_data['advertiser_id'] ?? '',
-				'partner_metadata'        => json_encode(
-					array(
-						'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
-						'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
-						'wp_version'     => $wp_version,
-						'locale'         => get_locale(),
-						'currency'       => get_woocommerce_currency(),
-					)
-				),
-			);
-
-			if ( ! empty( $connection_data['tag_id'] ) ) {
-				$integration_data['connected_tag_id'] = $connection_data['tag_id'];
-			}
-
-			$response = Pinterest\API\APIV5::create_commerce_integration( $integration_data );
-
-			/*
-			 * In case of successful response we save our integration data into a database.
-			 * Data we save includes but not limited to:
-			 *  external business id,
-			 *  id,
-			 *  connected_user_id,
-			 *  etc.
-			 */
-			self::save_integration_data( $response );
-
-			self::save_setting( 'tracking_advertiser', $response['connected_advertiser_id'] );
-			self::save_setting( 'tracking_tag', $response['connected_tag_id'] );
-
-			return $response;
+			return Pinterest\CommerceIntegration::handle_create();
 		}
 
 		/**
@@ -1061,34 +1026,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 				Logger::log( $e->getMessage(), 'error' );
 				return false;
 			}
-		}
-
-		/**
-		 * Used to generate external business id to pass it Pinterest when creating a connection between WC and Pinterest.
-		 *
-		 * @since 1.4.0
-		 *
-		 * @return string
-		 */
-		public static function generate_external_business_id(): string {
-			$name = (string) parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
-			if ( empty( $name ) ) {
-				$name = sanitize_title( get_bloginfo( 'name' ) );
-			}
-			$id = uniqid( sprintf( 'woo-%s-', $name ), false );
-
-			/**
-			 * Filters the shop's external business id.
-			 *
-			 * This is passed to Pinterest when connecting.
-			 * Should be non-empty and without special characters,
-			 * otherwise the ID will be obtained from the site's name as fallback.
-			 *
-			 * @since 1.4.0
-			 *
-			 * @param string $id the shop's external business id.
-			 */
-			return (string) apply_filters( 'wc_pinterest_external_business_id', $id );
 		}
 
 		/**

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -9,6 +9,7 @@
 namespace Automattic\WooCommerce\Pinterest\API;
 
 use Automattic\WooCommerce\Pinterest\Logger;
+use Pinterest_For_Woocommerce;
 use Throwable;
 use WP_HTTP_Response;
 use WP_REST_Request;
@@ -119,6 +120,9 @@ class Auth extends VendorAPI {
 		unset( $info_data['feature_flags'] );
 
 		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
+
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', $info_data['advertiser_id'] );
+		Pinterest_For_Woocommerce::save_setting( 'tracking_tag', $info_data['tag_id'] ?? '' );
 
 		try {
 			/**

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -34,6 +34,10 @@ class CommerceIntegration {
 			10,
 			1
 		);
+
+		if ( ! has_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) ) ) {
+			add_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) );
+		}
 	}
 
 	/**
@@ -44,6 +48,7 @@ class CommerceIntegration {
 	 */
 	public static function maybe_unregister_retries() {
 		as_unschedule_all_actions( 'pinterest-for-woocommerce-create-commerce-integration-retry' );
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-sync-commerce-integration' );
 	}
 
 	/**
@@ -120,16 +125,69 @@ class CommerceIntegration {
 	}
 
 	/**
+	 * Handles Commerce Integration partner_metadata updates.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public static function handle_sync() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
+		/*
+		 * If there is a commerce integration retry action, we know not to run the sync yet,
+		 * since it will also try to create the commerce integration as well.
+		 */
+		if ( as_has_scheduled_action( 'pinterest-for-woocommerce-create-commerce-integration-retry' ) ) {
+			return;
+		}
+
+		try {
+			$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
+			$external_business_id = $integration_data['external_business_id'] ?? '';
+
+			if ( ! $external_business_id ) {
+				self::handle_create();
+				return;
+			}
+
+			$new_integration_data = self::get_integration_data( $external_business_id );
+
+			if ( $integration_data['partner_metadata'] !== $new_integration_data['partner_metadata'] ) {
+				$response = APIV5::update_commerce_integration( $external_business_id, $new_integration_data );
+				Pinterest_For_Woocommerce::save_integration_data( $response );
+			}
+		} catch ( PinterestApiException $e ) {
+			Logger::log(
+				sprintf(
+					/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
+					__(
+						'Commerce Integration Sync has failed with Pinterest code %1$s and the message %2$s. Next attempt in a week.',
+						'pinterest-for-woocommerce'
+					),
+					esc_html( $e->get_pinterest_code() ),
+					esc_html( $e->getMessage() )
+				),
+				'error'
+			);
+		}
+	}
+
+	/**
 	 * Prepares Commerce Integration data.
 	 *
 	 * @since x.x.x
 	 * @return array
 	 */
-	public static function get_integration_data(): array {
+	public static function get_integration_data( $external_business_id = '' ): array {
 		global $wp_version;
 
-		$external_business_id = self::generate_external_business_id();
-		$connection_data      = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
+		if ( empty( $external_business_id ) ) {
+			$external_business_id = self::generate_external_business_id();
+		}
+
+		$connection_data = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
 
 		$integration_data = array(
 			'external_business_id'    => $external_business_id,

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -73,8 +73,8 @@ class CommerceIntegration {
 			if ( self::MAX_RETRIES < $attempt ) {
 				Logger::log(
 					sprintf(
+						/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
 						__(
-							/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
 							'Create Pinterest Commerce Integration retries has stopped. No further attempts to be scheduled.',
 							'pinterest-for-woocommerce'
 						),
@@ -94,8 +94,8 @@ class CommerceIntegration {
 			if ( false === $has_retry_scheduled ) {
 				Logger::log(
 					sprintf(
+						/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
 						__(
-							/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
 							'Create Pinterest Commerce Integration has failed due to Pinterest API code %1$s with message %2$s. Scheduling a retry attempt.',
 							'pinterest-for-woocommerce'
 						),

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -178,6 +178,7 @@ class CommerceIntegration {
 	 * Prepares Commerce Integration data.
 	 *
 	 * @since x.x.x
+	 * @param string $external_business_id External Business ID.
 	 * @return array
 	 */
 	public static function get_integration_data( $external_business_id = '' ): array {

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -111,7 +111,7 @@ class CommerceIntegration {
 				);
 				$frames = array( MINUTE_IN_SECONDS, HOUR_IN_SECONDS, DAY_IN_SECONDS );
 				as_schedule_single_action(
-					time() + $frames[ $attempt ],
+					time() + ( $frames[ $attempt ] ?? DAY_IN_SECONDS ),
 					'pinterest-for-woocommerce-create-commerce-integration-retry',
 					array(
 						'attempt' => $attempt + 1,

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -143,15 +143,15 @@ class CommerceIntegration {
 			return;
 		}
 
+		$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
+		$external_business_id = $integration_data['external_business_id'] ?? '';
+
+		if ( ! $external_business_id ) {
+			self::handle_create();
+			return;
+		}
+
 		try {
-			$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
-			$external_business_id = $integration_data['external_business_id'] ?? '';
-
-			if ( ! $external_business_id ) {
-				self::handle_create();
-				return;
-			}
-
 			$new_integration_data = self::get_integration_data( $external_business_id );
 
 			if ( $integration_data['partner_metadata'] !== $new_integration_data['partner_metadata'] ) {

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -70,7 +70,7 @@ class CommerceIntegration {
 
 			return $response;
 		} catch ( PinterestApiException $e ) {
-			if ( self::MAX_RETRIES < $attempt ) {
+			if ( self::MAX_RETRIES === $attempt ) {
 				Logger::log(
 					sprintf(
 						/* translators: 1: Pinterest internal code, 2: Pinterest response message. */

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -1,0 +1,184 @@
+<?php //phpcs:disable WordPress.WP.AlternativeFunctions --- Uses FS read/write in order to reliably append to an existing file.
+/**
+ * Pinterest for WooCommerce Commerce Integration controller class.
+ *
+ * @package     Pinterest_For_WooCommerce/Classes/
+ * @since       x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Pinterest\API\APIV5;
+use Pinterest_For_Woocommerce;
+
+/**
+ * Class Handling Commerce Integration operations.
+ */
+class CommerceIntegration {
+
+	public const MAX_RETRIES = 3;
+
+	/**
+	 * Registers a retry hook.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action(
+			'pinterest-for-woocommerce-create-commerce-integration-retry',
+			array( self::class, 'handle_create' ),
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Removes all scheduled actions.
+	 * Called during disconnect procedure.
+	 *
+	 * @return void
+	 */
+	public static function maybe_unregister_retries() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-create-commerce-integration-retry' );
+	}
+
+	/**
+	 * Attempts to create Commerce Integration with Pinterest and schedules a retry in case of a failure.
+	 *
+	 * @param int $attempt Create Commerce Integration attempt number.
+	 * @return array
+	 */
+	public static function handle_create( $attempt = 0 ): array {
+		try {
+			$integration_data = self::get_integration_data();
+
+			$response = APIV5::create_commerce_integration( $integration_data );
+
+			/*
+			 * In case of successful response we save our integration data into a database.
+			 * Data we save includes but not limited to:
+			 *  external business id,
+			 *  id,
+			 *  connected_user_id,
+			 *  etc.
+			 */
+			Pinterest_For_Woocommerce::save_integration_data( $response );
+
+			return $response;
+		} catch ( PinterestApiException $e ) {
+			if ( self::MAX_RETRIES < $attempt ) {
+				Logger::log(
+					sprintf(
+						__(
+							/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
+							'Create Pinterest Commerce Integration retries has stopped. No further attempts to be scheduled.',
+							'pinterest-for-woocommerce'
+						),
+						esc_html( $e->get_pinterest_code() ),
+						esc_html( $e->getMessage() ),
+					),
+					'error'
+				);
+				return array();
+			}
+
+			$has_retry_scheduled = as_has_scheduled_action(
+				'pinterest-for-woocommerce-create-commerce-integration-retry',
+				array( 'attempt' => $attempt + 1 ),
+				'pinterest-for-woocommerce'
+			);
+			if ( false === $has_retry_scheduled ) {
+				Logger::log(
+					sprintf(
+						__(
+							/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
+							'Create Pinterest Commerce Integration has failed due to Pinterest API code %1$s with message %2$s. Scheduling a retry attempt.',
+							'pinterest-for-woocommerce'
+						),
+						esc_html( $e->get_pinterest_code() ),
+						esc_html( $e->getMessage() ),
+					),
+					'error'
+				);
+				$frames = array( MINUTE_IN_SECONDS, HOUR_IN_SECONDS, DAY_IN_SECONDS );
+				as_schedule_single_action(
+					time() + $frames[ $attempt ],
+					'pinterest-for-woocommerce-create-commerce-integration-retry',
+					array(
+						'attempt' => $attempt + 1,
+					),
+					'pinterest-for-woocommerce'
+				);
+			}
+
+			return array();
+		}
+	}
+
+	/**
+	 * Prepares Commerce Integration data.
+	 *
+	 * @since x.x.x
+	 * @return array
+	 */
+	public static function get_integration_data(): array {
+		global $wp_version;
+
+		$external_business_id = self::generate_external_business_id();
+		$connection_data      = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
+
+		$integration_data = array(
+			'external_business_id'    => $external_business_id,
+			'connected_merchant_id'   => $connection_data['merchant_id'] ?? '',
+			'connected_advertiser_id' => $connection_data['advertiser_id'] ?? '',
+			'partner_metadata'        => json_encode(
+				array(
+					'plugin_version' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+					'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'unknown',
+					'wp_version'     => $wp_version,
+					'locale'         => get_locale(),
+					'currency'       => get_woocommerce_currency(),
+				)
+			),
+		);
+
+		if ( ! empty( $connection_data['tag_id'] ) ) {
+			$integration_data['connected_tag_id'] = $connection_data['tag_id'];
+		}
+
+		return $integration_data;
+	}
+
+	/**
+	 * Generates External Business ID for Pinterest Commerce Integration.
+	 *
+	 * @NOTE: ID generation logic is as requested by Pinterest.
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private static function generate_external_business_id(): string {
+		$name = (string) parse_url( esc_url( get_site_url() ), PHP_URL_HOST );
+		if ( empty( $name ) ) {
+			$name = sanitize_title( get_bloginfo( 'name' ) );
+		}
+		$id = uniqid( sprintf( 'woo-%s-', $name ), false );
+
+		/**
+		 * Filters the shop's external business id.
+		 *
+		 * This is passed to Pinterest when connecting.
+		 * Should be non-empty and without special characters,
+		 * otherwise the ID will be obtained from the site's name as fallback.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param string $id the shop's external business id.
+		 */
+		return (string) apply_filters( 'wc_pinterest_external_business_id', $id );
+	}
+}

--- a/tests/E2e/PinterestConnectE2eTest.php
+++ b/tests/E2e/PinterestConnectE2eTest.php
@@ -44,6 +44,8 @@ class PinterestConnectE2eTest extends \WP_UnitTestCase {
 			'clientHash'    => 'MTQ4NjE3MzpkNWJjNTM4ZmVhMTZhYzIwMmZiNDZhMTFjMGNkZGVmNzFhOWU1YWY0',
 		);
 		Pinterest_For_Woocommerce()::save_connection_info_data( $info_data );
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '549765662491' );
+		Pinterest_For_Woocommerce::save_setting( 'tracking_tag', '2613286171854' );
 
 		// API Request filters to stub Pinterest API requests.
 		$this->create_commerce_integration_request_stub();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces the initial create Commerce Integration call retry procedure. It may happen that the Create Integration API will fail. We have to retry its creation since the integration data is crucial for assigning customers to a proper Pinterest advertisement platform on the Pinterest side.

The code will try three times: in a minute after the initial failure; in an hour; in a day.

### Detailed test instructions:


1. Add a filter to make the `APIV5::create_commerce_integration` call fail.

```php
add_filter(
	'pre_http_request',
	function ( $response, $parsed_args, $url ) {
		if (
			'https://api.pinterest.com/v5/integrations/commerce' === $url &&
			'POST' === $parsed_args['method']
		) {
			return array(
				'headers' => array(
					'content-type' => 'application/json',
				),
				'body' => json_encode(
					array(
						'code'    => 911,
						'message' => 'Oops! Something went wrong!',
					)
				),
				'response' => array(
					'code'    => 500,
					'message' => 'Unexpected error',
				),
				'cookies'  => array(),
				'filename' => '',
			);
		}

		return $response;
	},
	10,
	3
);
```

https://github.com/woocommerce/pinterest-for-woocommerce/blob/f48b082beb385d14ce6a1c6519cf982484739218/src/API/APIV5.php#L407-L413

2. If you are connected to Pinterest - disconnect. Otherwise, connect to your Pinterest account using the extension.
3. During the connection procedure, the commerce integration call will fail. Look into Pending Scheduled Actions for a retry scheduled to run within a minute of the connection time.

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-2" src="https://github.com/user-attachments/assets/4e2cf45d-372b-47e7-be77-8fe9915e4612">

It should also have an `attempt` number parameter set to `1`, meaning this is the first attempt of a retry.

4. Look into `pinterest-for-woocommerce` log for a message about the failure and the retry procedure.

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-3" src="https://github.com/user-attachments/assets/7d98e2d0-07a2-43a8-bcb2-8cc80ea9730d">

5. Wait until the action triggers itself or force-run it. Since we still have a code to make the endpoint fail, we should see another retry attempt scheduled and the log message.

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-4" src="https://github.com/user-attachments/assets/284f8d95-840c-48a9-92f6-af2c7dda386e">

6. Do not wait an hour 🤡 to pass and force-run the action.
7. Look for the last, third attempt to get scheduled.

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-5" src="https://github.com/user-attachments/assets/a5fe9406-1ee5-44bf-a7ff-93deeb3878ef">

8. Force-run it and check no more actions scheduled and the last attempt log message written.

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-7" src="https://github.com/user-attachments/assets/7fc114ea-f64e-472d-bb06-e0e2b7ebd449">

### Changelog entry

> Add - Failed Create Commerce Integration API call retries procedure.
