### PR TITLE
Synchronising Commerce Integration `partner_metadata` weekly.

### DIFF
--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -34,6 +34,10 @@ class CommerceIntegration {
 			10,
 			1
 		);
+
+		if ( ! has_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) ) ) {
+			add_action( Heartbeat::WEEKLY, array( self::class, 'handle_sync' ) );
+		}
 	}
 
 	/**
@@ -44,6 +48,7 @@ class CommerceIntegration {
 	 */
 	public static function maybe_unregister_retries() {
 		as_unschedule_all_actions( 'pinterest-for-woocommerce-create-commerce-integration-retry' );
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-sync-commerce-integration' );
 	}
 
 	/**
@@ -120,16 +125,69 @@ class CommerceIntegration {
 	}
 
 	/**
+	 * Handles Commerce Integration partner_metadata updates.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public static function handle_sync() {
+		if ( ! Pinterest_For_Woocommerce::is_connected() ) {
+			return;
+		}
+
+		/*
+		 * If there is a commerce integration retry action, we know not to run the sync yet,
+		 * since it will also try to create the commerce integration as well.
+		 */
+		if ( as_has_scheduled_action( 'pinterest-for-woocommerce-create-commerce-integration-retry' ) ) {
+			return;
+		}
+
+		try {
+			$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
+			$external_business_id = $integration_data['external_business_id'] ?? '';
+
+			if ( ! $external_business_id ) {
+				self::handle_create();
+				return;
+			}
+
+			$new_integration_data = self::get_integration_data( $external_business_id );
+
+			if ( $integration_data['partner_metadata'] !== $new_integration_data['partner_metadata'] ) {
+				$response = APIV5::update_commerce_integration( $external_business_id, $new_integration_data );
+				Pinterest_For_Woocommerce::save_integration_data( $response );
+			}
+		} catch ( PinterestApiException $e ) {
+			Logger::log(
+				sprintf(
+					/* translators: 1: Pinterest internal code, 2: Pinterest response message. */
+					__(
+						'Commerce Integration Sync has failed with Pinterest code %1$s and the message %2$s. Next attempt in a week.',
+						'pinterest-for-woocommerce'
+					),
+					esc_html( $e->get_pinterest_code() ),
+					esc_html( $e->getMessage() )
+				),
+				'error'
+			);
+		}
+	}
+
+	/**
 	 * Prepares Commerce Integration data.
 	 *
 	 * @since x.x.x
 	 * @return array
 	 */
-	public static function get_integration_data(): array {
+	public static function get_integration_data( $external_business_id = '' ): array {
 		global $wp_version;
 
-		$external_business_id = self::generate_external_business_id();
-		$connection_data      = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
+		if ( empty( $external_business_id ) ) {
+			$external_business_id = self::generate_external_business_id();
+		}
+
+		$connection_data = Pinterest_For_Woocommerce::get_data( 'connection_info_data', true );
 
 		$integration_data = array(
 			'external_business_id'    => $external_business_id,

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -178,6 +178,7 @@ class CommerceIntegration {
 	 * Prepares Commerce Integration data.
 	 *
 	 * @since x.x.x
+	 * @param string $external_business_id External Business ID.
 	 * @return array
 	 */
 	public static function get_integration_data( $external_business_id = '' ): array {

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -111,7 +111,7 @@ class CommerceIntegration {
 				);
 				$frames = array( MINUTE_IN_SECONDS, HOUR_IN_SECONDS, DAY_IN_SECONDS );
 				as_schedule_single_action(
-					time() + $frames[ $attempt ],
+					time() + ( $frames[ $attempt ] ?? DAY_IN_SECONDS ),
 					'pinterest-for-woocommerce-create-commerce-integration-retry',
 					array(
 						'attempt' => $attempt + 1,

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -143,15 +143,15 @@ class CommerceIntegration {
 			return;
 		}
 
+		$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
+		$external_business_id = $integration_data['external_business_id'] ?? '';
+
+		if ( ! $external_business_id ) {
+			self::handle_create();
+			return;
+		}
+
 		try {
-			$integration_data     = Pinterest_For_Woocommerce::get_data( 'integration_data' );
-			$external_business_id = $integration_data['external_business_id'] ?? '';
-
-			if ( ! $external_business_id ) {
-				self::handle_create();
-				return;
-			}
-
 			$new_integration_data = self::get_integration_data( $external_business_id );
 
 			if ( $integration_data['partner_metadata'] !== $new_integration_data['partner_metadata'] ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The PR adds a weekly commerce integration `partner_metadata` sync action. The action will attempt to create the integration if the one is still missing. The integration will also run through a set of retries if the API is not responding successfully, delaying the synchronization until the integration is finally created.

### Detailed test instructions:

#### Commerce Integration Sync tries to create the integration if the one does not exist.
1. Add a filter to make the `APIV5::create_commerce_integration` call fail.

```php
add_filter(
	'pre_http_request',
	function ( $response, $parsed_args, $url ) {
		if (
			'https://api.pinterest.com/v5/integrations/commerce' === $url &&
			'POST' === $parsed_args['method']
		) {
			return array(
				'headers' => array(
					'content-type' => 'application/json',
				),
				'body' => json_encode(
					array(
						'code'    => 911,
						'message' => 'Oops! Something went wrong!',
					)
				),
				'response' => array(
					'code'    => 500,
					'message' => 'Unexpected error',
				),
				'cookies'  => array(),
				'filename' => '',
			);
		}

		return $response;
	},
	10,
	3
);
```

https://github.com/woocommerce/pinterest-for-woocommerce/blob/f48b082beb385d14ce6a1c6519cf982484739218/src/API/APIV5.php#L407-L413

2. If you are connected to Pinterest - disconnect. Otherwise, connect to your Pinterest account using the extension.
3. Manually trigger the Commerce Integration retry `pinterest-for-woocommerce-create-commerce-integration-retry` actions so they will all run (fail to create the integration).
4. Manually trigger the `pinterest_for_woocommerce_weekly_heartbeat` action.

Since integration was not created previously, the sync action will attempt to create it. Fail and start the same commerce integration retry cycle (three attempts).

#### Commerce Integration Sync updates the `parent_metadata` if it has changed.

1. Clean up the codebase so there is no more commerce integration endpoint failure.
2. Either manually run the `pinterest_for_woocommerce_weekly_heartbeat` action to create commerce integration or reconnect to your Pinterest account.
3. Update the code that collects the current platform data, such as the extension, WP, and WC versions used by the installation.

Replace any `partner_metadata` array value with something to your taste

https://github.com/woocommerce/pinterest-for-woocommerce/blob/2ec929558cf27ab550adf8a107bbe9a06cbeeb1a/src/CommerceIntegration.php#L198-L204

4. Manually trigger the `pinterest_for_woocommerce_weekly_heartbeat` action from the Pending section of the ScheduledActions tab.
5. Observe the database `wp_options` key with `pinterest_for_woocommerce_data` name updated. 

**NOTE:** It is not possible to watch how the data goes to Pinterest API and gets saved there (under returning me the response with the updated data, I am assuming that Pinterest is saving it) without using a debugger and settings breakpoints.

### Screenshots

<img width="1547" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-8" src="https://github.com/user-attachments/assets/f64feada-be9e-448b-8fce-b1321f5b46ab">

### Changelog entry

> Add - Commerce Integration `partner_metadata` weekly sync.
