### PR TITLE
Release/1.4.12 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.4.12 - 2024-11-07 =
+* Tweak - WC 9.4 compatibility.
+* Tweak - WP 6.7 compatibility.
+
 = 1.4.11 - 2024-10-23 =
 * Add - API method to get commerce integration.
 * Add - Commerce Integration `partner_metadata` weekly sync.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.11
+ * Version:           1.4.12
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -23,11 +23,11 @@
  * Requires Plugins:  woocommerce
  *
  * Requires at least: 5.6
- * Tested up to: 6.6
+ * Tested up to: 6.7
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 9.3
+ * WC tested up to: 9.4
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.11' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.12' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.12 - 2024-11-07 =
+* Tweak - WC 9.4 compatibility.
+* Tweak - WP 6.7 compatibility.
+
 = 1.4.11 - 2024-10-23 =
 * Add - API method to get commerce integration.
 * Add - Commerce Integration `partner_metadata` weekly sync.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: automattic, pinterest, woocommerce
 Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
-Tested up to: 6.6
+Tested up to: 6.7
 Requires PHP: 7.3
-Stable tag: 1.4.11
+Stable tag: 1.4.12
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR merges the changes from [release v1.4.12](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.12) back into `develop`.