### PR TITLE
Update Action Scheduler actions to fail with exceptions.

### DIFF
--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -9,7 +9,6 @@
 
 namespace Automattic\WooCommerce\Pinterest\API;
 
-use Automattic\WooCommerce\Pinterest\Feeds;
 use Automattic\WooCommerce\Pinterest\PinterestApiException;
 use Exception;
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -129,6 +129,18 @@ class Base {
 				do_action( 'pinterest_for_woocommerce_disconnect' );
 			}
 
+			/**
+			 * Action used to intercept the Pinterest API exception with code and a message and decide whether or not
+			 * to show an admin notice for the exception.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int    $http_code             Pinterest API HTTP response code.
+			 * @param int    $pinterest_api_code    Pinterest API error code.
+			 * @param string $pinterest_api_message Pinterest API error message.
+			 */
+			do_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', $e->getCode(), $e->get_pinterest_code(), $e->getMessage() );
+
 			throw $e;
 		}
 	}

--- a/src/CommerceIntegration.php
+++ b/src/CommerceIntegration.php
@@ -128,6 +128,7 @@ class CommerceIntegration {
 	 * Handles Commerce Integration partner_metadata updates.
 	 *
 	 * @since 1.4.11
+	 * @throws PinterestApiException Pinterest API exception.
 	 * @return void
 	 */
 	public static function handle_sync() {
@@ -171,6 +172,7 @@ class CommerceIntegration {
 				),
 				'error'
 			);
+			throw $e;
 		}
 	}
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -8,7 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
-use Automattic\WooCommerce\Pinterest\Notes\AccountDisapproved;
+use Automattic\WooCommerce\Pinterest\Notes\AccountFailure;
 use Exception;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
@@ -67,7 +67,8 @@ class FeedRegistration {
 		// We do not want to disconnect the merchant if the authentication fails, since it running action can not be unscheduled.
 		add_filter( 'pinterest_for_woocommerce_disconnect_on_authentication_failure', '__return_false' );
 
-		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_disapproved_notice' ) );
+		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_failure_notice' ), 10, 3 );
+		add_action( 'pinterest_for_woocommerce_disconnect', array( AccountFailure::class, 'delete_note' ) );
 	}
 
 	/**
@@ -244,9 +245,9 @@ class FeedRegistration {
 	 *
 	 * @return void
 	 */
-	public static function maybe_account_disapproved_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
-		if ( 2625 === $pinterest_api_code ) {
-			AccountDisapproved::possibly_add_note();
+	public static function maybe_account_failure_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
+		if ( 403 === $http_code ) {
+			AccountFailure::maybe_add_note( $pinterest_api_message );
 		}
 	}
 }

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Notes\AccountDisapproved;
 use Exception;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
@@ -237,14 +238,15 @@ class FeedRegistration {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param $http_code
-	 * @param $pinterest_api_code
-	 * @param $pinterest_api_message
+	 * @param int    $http_code             Pinterest API HTTP response code.
+	 * @param int    $pinterest_api_code    Pinterest API error code.
+	 * @param string $pinterest_api_message Pinterest API error message.
+	 *
 	 * @return void
 	 */
-	public static function maybe_account_disapproved_notice( $http_code, $pinterest_api_code, $pinterest_api_message ) {
+	public static function maybe_account_disapproved_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
 		if ( 2625 === $pinterest_api_code ) {
-
+			AccountDisapproved::possibly_add_note();
 		}
 	}
 }

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -94,10 +94,7 @@ class FeedRegistration {
 		}
 
 		try {
-			if ( self::register_feed() ) {
-				return true;
-			}
-			throw new Exception( esc_html__( 'Could not register feed.', 'pinterest-for-woocommerce' ) );
+			return self::register_feed();
 		} catch ( PinterestApiLocaleException $e ) {
 			Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', true );
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -9,7 +9,6 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Exception;
-use Pinterest_For_Woocommerce;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
@@ -136,7 +135,7 @@ class FeedRegistration {
 	 *
 	 * @return boolean
 	 *
-	 * @throws Exception PHP Exception.
+	 * @throws PinterestApiException PHP Exception.
 	 */
 	private static function register_feed(): bool {
 		$feed_id = Feeds::match_local_feed_configuration_to_registered_feeds();

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -78,8 +78,9 @@ class FeedRegistration {
 	 *
 	 * @return bool
 	 *
-	 * @throws Exception PHP Exception.
-	 * @throws PinterestApiException Pinterest API Exception.
+	 * @throws PinterestApiLocaleException Pinterest API does not support the locale.
+	 * @throws PinterestApiException       Pinterest API exception.
+	 * @throws Throwable                   Any other exception.
 	 */
 	public function handle_feed_registration(): bool {
 
@@ -101,18 +102,14 @@ class FeedRegistration {
 			Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', true );
 
 			// translators: %s: Error message.
-			$error_message = "Could not register feed. Error: {$e->getMessage()}";
+			$error_message = "Could not register the feed. Error: {$e->getMessage()}";
 			self::log( $error_message, 'error' );
-			return false;
+			throw $e;
 		} catch ( PinterestApiException $e ) {
 			throw $e;
 		} catch ( Throwable $th ) {
-			if ( method_exists( $th, 'get_pinterest_code' ) && 4163 === $th->get_pinterest_code() ) {
-				Pinterest_For_Woocommerce()::save_data( 'merchant_connected_diff_platform', true );
-			}
-
 			self::log( $th->getMessage(), 'error' );
-			return false;
+			throw $th;
 		}
 	}
 

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -65,6 +65,8 @@ class FeedRegistration {
 
 		// We do not want to disconnect the merchant if the authentication fails, since it running action can not be unscheduled.
 		add_filter( 'pinterest_for_woocommerce_disconnect_on_authentication_failure', '__return_false' );
+
+		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_disapproved_notice' ) );
 	}
 
 	/**
@@ -228,5 +230,21 @@ class FeedRegistration {
 	public static function deregister() {
 		Pinterest_For_Woocommerce()::save_data( 'feed_registered', false );
 		self::cancel_jobs();
+	}
+
+	/**
+	 * Maybe show admin notice about account being disapproved.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param $http_code
+	 * @param $pinterest_api_code
+	 * @param $pinterest_api_message
+	 * @return void
+	 */
+	public static function maybe_account_disapproved_notice( $http_code, $pinterest_api_code, $pinterest_api_message ) {
+		if ( 2625 === $pinterest_api_code ) {
+
+		}
 	}
 }

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -93,7 +93,6 @@ class Feeds {
 	 * @since 1.4.0
 	 *
 	 * @return string The Feed ID or an empty string if failed.
-	 * @throws Exception PHP Exception if there is an error creating the feed, and we are throttling the requests.
 	 * @throws PinterestApiException Pinterest API Exception if there is an error creating the feed.
 	 */
 	public static function create_feed(): string {
@@ -141,13 +140,21 @@ class Feeds {
 			'default_availability' => 'IN_STOCK',
 		);
 
-		$cache_key = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_request_' . md5( wp_json_encode( $data ) . (string) $ad_account_id );
-		$cache     = get_transient( $cache_key );
+		$cache_key    = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_request_' . md5( wp_json_encode( $data ) . (string) $ad_account_id );
+		$cached_error = get_transient( $cache_key );
 
-		if ( false !== $cache ) {
-			throw new Exception(
-				esc_html__( 'There was a previous error trying to create a feed.', 'pinterest-for-woocommerce' ),
-				(int) $cache
+		if ( false !== $cached_error ) {
+			// Faking Pinterest API response to 425 Too early.
+			throw new PinterestApiException(
+				sprintf(
+					/* translators: Pinterest API error code and message. 1: Cached error string. */
+					esc_html__(
+						'Previous request for the same action failed due to: %1$s. Delaying the next call to prevent repeating errors.',
+						'pinterest-for-woocommerce'
+					),
+					$cached_error
+				),
+				425
 			);
 		}
 
@@ -161,7 +168,7 @@ class Feeds {
 			$feed = APIV5::create_feed( $data, $ad_account_id );
 		} catch ( PinterestApiException $e ) {
 			$delay = Pinterest_For_Woocommerce()::get_data( 'create_feed_delay' ) ?? MINUTE_IN_SECONDS;
-			set_transient( $cache_key, $e->getCode(), $delay );
+			set_transient( $cache_key, esc_html__( "{$e->get_pinterest_code()} - {$e->getMessage()}" ), $delay );
 			// Double the delay.
 			Pinterest_For_Woocommerce()::save_data(
 				'create_feed_delay',
@@ -172,11 +179,7 @@ class Feeds {
 
 		static::invalidate_feeds_cache();
 
-		try {
-			$feed_id = static::match_local_feed_configuration_to_registered_feeds( array( $feed ) );
-		} catch ( Throwable $th ) {
-			$feed_id = '';
-		}
+		$feed_id = static::match_local_feed_configuration_to_registered_feeds( array( $feed ) );
 
 		// Clean the cached delay.
 		Pinterest_For_Woocommerce()::save_data( 'create_feed_delay', false );
@@ -278,8 +281,6 @@ class Feeds {
 	 *
 	 * @param array $feeds The list of feeds to check against. If not set, the list will be fetched from the API.
 	 * @return string Returns the ID of the feed if properly registered or an empty string otherwise.
-	 *
-	 * @throws PinterestApiLocaleException No valid locale found to check for the registered feed.
 	 */
 	public static function match_local_feed_configuration_to_registered_feeds( array $feeds = array() ): string {
 		if ( empty( $feeds ) ) {

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -148,11 +148,11 @@ class Feeds {
 			throw new PinterestApiException(
 				sprintf(
 					/* translators: Pinterest API error code and message. 1: Cached error string. */
-					esc_html__(
+					__(
 						'Previous request for the same action failed due to: %1$s. Delaying the next call to prevent repeating errors.',
 						'pinterest-for-woocommerce'
 					),
-					$cached_error
+					esc_html( $cached_error )
 				),
 				425
 			);
@@ -167,8 +167,9 @@ class Feeds {
 		try {
 			$feed = APIV5::create_feed( $data, $ad_account_id );
 		} catch ( PinterestApiException $e ) {
-			$delay = Pinterest_For_Woocommerce()::get_data( 'create_feed_delay' ) ?? MINUTE_IN_SECONDS;
-			set_transient( $cache_key, esc_html__( "{$e->get_pinterest_code()} - {$e->getMessage()}" ), $delay );
+			$delay   = Pinterest_For_Woocommerce()::get_data( 'create_feed_delay' ) ?? MINUTE_IN_SECONDS;
+			$message = sprintf( '%1$s - %2$s', esc_html( $e->get_pinterest_code() ), esc_html( $e->getMessage() ) );
+			set_transient( $cache_key, $message, $delay );
 			// Double the delay.
 			Pinterest_For_Woocommerce()::save_data(
 				'create_feed_delay',

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -148,7 +148,7 @@ class Feeds {
 			throw new PinterestApiException(
 				sprintf(
 					/* translators: Pinterest API error code and message. 1: Cached error string. */
-					__(
+					esc_html__(
 						'Previous request for the same action failed due to: %1$s. Delaying the next call to prevent repeating errors.',
 						'pinterest-for-woocommerce'
 					),

--- a/src/Notes/AccountDisapproved.php
+++ b/src/Notes/AccountDisapproved.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WooCommerce Admin: Add First Product.
+ *
+ * Adds a note (type `email`) to bring the client back to the store setup flow.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Add_First_Product.
+ */
+class AccountDisapproved {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-account-disapproved';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$content_lines = array(
+			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
+		);
+
+		$additional_data = array(
+			'role' => 'administrator',
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
+		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content_data( (object) $additional_data );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
+			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true,
+			'primary'
+		);
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 *
+	 * @return void
+	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 */
+	public static function possibly_add_note() {
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Delete the note.
+	 *
+	 * @return void
+	 */
+	public static function delete_failure_note() {
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -56,7 +56,7 @@ class AccountFailure {
 	 *
 	 * @param string $message Pinterest API error message.
 	 * @return void
-	 * @throws NotesUnavailableException
+	 * @throws NotesUnavailableException An exception when notes are unavailable.
 	 */
 	public static function maybe_add_note( string $message ): void {
 		if ( self::note_exists() ) {

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 /**
  * Add_First_Product.
  */
-class AccountDisapproved {
+class AccountFailure {
 	/**
 	 * Note traits.
 	 */
@@ -28,52 +28,42 @@ class AccountDisapproved {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'pinterest-for-woocommerce-account-disapproved';
+	const NOTE_NAME = 'pinterest-for-woocommerce-account-failure';
 
 	/**
 	 * Get the note.
 	 *
+	 * @param string $message Pinterest API error message.
 	 * @return Note
 	 */
-	public static function get_note() {
-		$content_lines = array(
-			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
-		);
-
+	public static function get_note( string $message ) {
 		$additional_data = array(
 			'role' => 'administrator',
 		);
 
 		$note = new Note();
 		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
-		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content( esc_html( $message ) );
 		$note->set_content_data( (object) $additional_data );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action(
-			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
-			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
-			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true,
-			'primary'
-		);
 		return $note;
 	}
 
 	/**
-	 * Add the note if it passes predefined conditions.
+	 * Used to add an account failure note if the one does not exist.
 	 *
+	 * @param string $message Pinterest API error message.
 	 * @return void
-	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 * @throws NotesUnavailableException
 	 */
-	public static function possibly_add_note() {
+	public static function maybe_add_note( string $message ): void {
 		if ( self::note_exists() ) {
 			return;
 		}
 
-		$note = self::get_note();
+		$note = self::get_note( $message );
 		$note->save();
 	}
 
@@ -82,7 +72,7 @@ class AccountDisapproved {
 	 *
 	 * @return void
 	 */
-	public static function delete_failure_note() {
+	public static function delete_note() {
 		Notes::delete_notes_with_name( self::NOTE_NAME );
 	}
 }

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * WooCommerce Admin: Add First Product.
+ * Adds an error note to display Pinterest API account status failure responses.
  *
- * Adds a note (type `email`) to bring the client back to the store setup flow.
- *
+ * @since x.x.x
  * @package Automattic\WooCommerce\Pinterest\Notes
  */
 
@@ -17,7 +16,9 @@ use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
- * Add_First_Product.
+ * Account Failure admin notice.
+ *
+ * @since x.x.x
  */
 class AccountFailure {
 	/**
@@ -33,6 +34,7 @@ class AccountFailure {
 	/**
 	 * Get the note.
 	 *
+	 * @since x.x.x
 	 * @param string $message Pinterest API error message.
 	 * @return Note
 	 */
@@ -54,6 +56,7 @@ class AccountFailure {
 	/**
 	 * Used to add an account failure note if the one does not exist.
 	 *
+	 * @since x.x.x
 	 * @param string $message Pinterest API error message.
 	 * @return void
 	 * @throws NotesUnavailableException An exception when notes are unavailable.
@@ -70,6 +73,7 @@ class AccountFailure {
 	/**
 	 * Delete the note.
 	 *
+	 * @since x.x.x
 	 * @return void
 	 */
 	public static function delete_note() {

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -88,13 +88,13 @@ class PinterestApiException extends \Exception {
 	 * Pinterest_API_Exception constructor.
 	 *
 	 * @param string|array $error The error message or an array containing the error message + additional data.
-	 * @param int          $response_code The HTTP response code of the API call. e.g. 200, 401, 403, 404, etc.
+	 * @param int|array    $response_code The error code of the API response body or the whole response body as array.
 	 */
 	public function __construct( $error, $response_code ) {
 		$message              = $error['message'] ?? $error;
-		$this->pinterest_code = (int) $error['response_body']['code'] ?? 0;
+		$this->pinterest_code = (int) ( $error['response_body']['code'] ?? $response_code ) ?? 0;
 
-		parent::__construct( $message ?? $error, $response_code );
+		parent::__construct( $message, $response_code );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The PR proposes propagating exceptions thrown from the Action Scheduler actions further so the failed actions could have a meaningful error message describing the failure. 

### Detailed test instructions:

1. Download the extension and connect to your Pinterest account.
2. Edit the code lines below by adding a filter to emulate the request failure

https://github.com/woocommerce/pinterest-for-woocommerce/blob/8b87c15c654cac6d0e84a4f418ec1fee8f011efb/src/API/APIV5.php#L523-L529

add exactly before the `return` statement:

```php
add_filter(
	'pre_http_request',
	function ( $response, $parsed_args, $url ) use ( $ad_account_id ) {
		if ( "https://api.pinterest.com/v5/catalogs/feeds?ad_account_id={$ad_account_id}" === $url ) {
			return array(
				'headers'  => array(
					'content-type' => 'application/json',
				),
				'body'     => json_encode(
					array(
						'code'    => 2625,
						'message' => 'Sorry, you cannot perform this action as your account has been disapproved. Please see business hub for more details. https://www.pinterest.com/business/hub/',
					)
				),
				'response' => array(
					'code'    => 403,
					'message' => 'Forbidden',
				),
				'cookies'  => array(),
				'filename' => '',
			);
		}
	},
	10,
	3
);
```

3. Go to WooCommerce - Status - Scheduler Actions - Pending
4. Force run the `pinterest-for-woocommerce-handle-feed-registration` action. 
5. Go to WooCommerce - Status - Scheduler Actions - Failed
6. Observer the action failed and the exception message caught.

<img width="1728" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/user-attachments/assets/d8656c79-9be1-4676-bea4-6493552d98e3">

### Changelog entry

> Update - Failed actions to log the errors.
