### PR TITLE
Add notices for important api exceptions

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -129,6 +129,18 @@ class Base {
 				do_action( 'pinterest_for_woocommerce_disconnect' );
 			}
 
+			/**
+			 * Action used to intercept the Pinterest API exception with code and a message and decide whether or not
+			 * to show an admin notice for the exception.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int    $http_code             Pinterest API HTTP response code.
+			 * @param int    $pinterest_api_code    Pinterest API error code.
+			 * @param string $pinterest_api_message Pinterest API error message.
+			 */
+			do_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', $e->getCode(), $e->get_pinterest_code(), $e->getMessage() );
+
 			throw $e;
 		}
 	}

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -8,7 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
-use Automattic\WooCommerce\Pinterest\Notes\AccountDisapproved;
+use Automattic\WooCommerce\Pinterest\Notes\AccountFailure;
 use Exception;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
@@ -67,7 +67,8 @@ class FeedRegistration {
 		// We do not want to disconnect the merchant if the authentication fails, since it running action can not be unscheduled.
 		add_filter( 'pinterest_for_woocommerce_disconnect_on_authentication_failure', '__return_false' );
 
-		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_disapproved_notice' ) );
+		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_failure_notice' ), 10, 3 );
+		add_action( 'pinterest_for_woocommerce_disconnect', array( AccountFailure::class, 'delete_note' ) );
 	}
 
 	/**
@@ -244,9 +245,9 @@ class FeedRegistration {
 	 *
 	 * @return void
 	 */
-	public static function maybe_account_disapproved_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
-		if ( 2625 === $pinterest_api_code ) {
-			AccountDisapproved::possibly_add_note();
+	public static function maybe_account_failure_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
+		if ( 403 === $http_code ) {
+			AccountFailure::maybe_add_note( $pinterest_api_message );
 		}
 	}
 }

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Notes\AccountDisapproved;
 use Exception;
 use Throwable;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
@@ -237,14 +238,15 @@ class FeedRegistration {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param $http_code
-	 * @param $pinterest_api_code
-	 * @param $pinterest_api_message
+	 * @param int    $http_code             Pinterest API HTTP response code.
+	 * @param int    $pinterest_api_code    Pinterest API error code.
+	 * @param string $pinterest_api_message Pinterest API error message.
+	 *
 	 * @return void
 	 */
-	public static function maybe_account_disapproved_notice( $http_code, $pinterest_api_code, $pinterest_api_message ) {
+	public static function maybe_account_disapproved_notice( int $http_code, int $pinterest_api_code, string $pinterest_api_message ): void {
 		if ( 2625 === $pinterest_api_code ) {
-
+			AccountDisapproved::possibly_add_note();
 		}
 	}
 }

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -65,6 +65,8 @@ class FeedRegistration {
 
 		// We do not want to disconnect the merchant if the authentication fails, since it running action can not be unscheduled.
 		add_filter( 'pinterest_for_woocommerce_disconnect_on_authentication_failure', '__return_false' );
+
+		add_action( 'pinterest_for_woocommerce_show_admin_notice_for_api_exception', array( self::class, 'maybe_account_disapproved_notice' ) );
 	}
 
 	/**
@@ -228,5 +230,21 @@ class FeedRegistration {
 	public static function deregister() {
 		Pinterest_For_Woocommerce()::save_data( 'feed_registered', false );
 		self::cancel_jobs();
+	}
+
+	/**
+	 * Maybe show admin notice about account being disapproved.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param $http_code
+	 * @param $pinterest_api_code
+	 * @param $pinterest_api_message
+	 * @return void
+	 */
+	public static function maybe_account_disapproved_notice( $http_code, $pinterest_api_code, $pinterest_api_message ) {
+		if ( 2625 === $pinterest_api_code ) {
+
+		}
 	}
 }

--- a/src/Notes/AccountDisapproved.php
+++ b/src/Notes/AccountDisapproved.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WooCommerce Admin: Add First Product.
+ *
+ * Adds a note (type `email`) to bring the client back to the store setup flow.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Add_First_Product.
+ */
+class AccountDisapproved {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-account-disapproved';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$content_lines = array(
+			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
+		);
+
+		$additional_data = array(
+			'role' => 'administrator',
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
+		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content_data( (object) $additional_data );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
+			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true,
+			'primary'
+		);
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 *
+	 * @return void
+	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 */
+	public static function possibly_add_note() {
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Delete the note.
+	 *
+	 * @return void
+	 */
+	public static function delete_failure_note() {
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -56,7 +56,7 @@ class AccountFailure {
 	 *
 	 * @param string $message Pinterest API error message.
 	 * @return void
-	 * @throws NotesUnavailableException
+	 * @throws NotesUnavailableException An exception when notes are unavailable.
 	 */
 	public static function maybe_add_note( string $message ): void {
 		if ( self::note_exists() ) {

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 /**
  * Add_First_Product.
  */
-class AccountDisapproved {
+class AccountFailure {
 	/**
 	 * Note traits.
 	 */
@@ -28,52 +28,42 @@ class AccountDisapproved {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'pinterest-for-woocommerce-account-disapproved';
+	const NOTE_NAME = 'pinterest-for-woocommerce-account-failure';
 
 	/**
 	 * Get the note.
 	 *
+	 * @param string $message Pinterest API error message.
 	 * @return Note
 	 */
-	public static function get_note() {
-		$content_lines = array(
-			__( 'The Pinterest For WooCommerce plugin has detected an issue with your access token.<br/>No operations are possible until you reconnect to Pinterest.', 'pinterest-for-woocommerce' ),
-		);
-
+	public static function get_note( string $message ) {
 		$additional_data = array(
 			'role' => 'administrator',
 		);
 
 		$note = new Note();
 		$note->set_title( __( 'Pinterest For WooCommerce action required.', 'pinterest-for-woocommerce' ) );
-		$note->set_content( implode( '', $content_lines ) );
+		$note->set_content( esc_html( $message ) );
 		$note->set_content_data( (object) $additional_data );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action(
-			'pinterest-for-woocommerce-token-invalid-failure-go-to-settings',
-			__( 'Re-authenticate with Pinterest', 'pinterest-for-woocommerce' ),
-			admin_url( 'admin.php?page=wc-admin&path=/pinterest/onboarding' ),
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true,
-			'primary'
-		);
 		return $note;
 	}
 
 	/**
-	 * Add the note if it passes predefined conditions.
+	 * Used to add an account failure note if the one does not exist.
 	 *
+	 * @param string $message Pinterest API error message.
 	 * @return void
-	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 * @throws NotesUnavailableException
 	 */
-	public static function possibly_add_note() {
+	public static function maybe_add_note( string $message ): void {
 		if ( self::note_exists() ) {
 			return;
 		}
 
-		$note = self::get_note();
+		$note = self::get_note( $message );
 		$note->save();
 	}
 
@@ -82,7 +72,7 @@ class AccountDisapproved {
 	 *
 	 * @return void
 	 */
-	public static function delete_failure_note() {
+	public static function delete_note() {
 		Notes::delete_notes_with_name( self::NOTE_NAME );
 	}
 }

--- a/src/Notes/AccountFailure.php
+++ b/src/Notes/AccountFailure.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * WooCommerce Admin: Add First Product.
+ * Adds an error note to display Pinterest API account status failure responses.
  *
- * Adds a note (type `email`) to bring the client back to the store setup flow.
- *
+ * @since x.x.x
  * @package Automattic\WooCommerce\Pinterest\Notes
  */
 
@@ -17,7 +16,9 @@ use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
- * Add_First_Product.
+ * Account Failure admin notice.
+ *
+ * @since x.x.x
  */
 class AccountFailure {
 	/**
@@ -33,6 +34,7 @@ class AccountFailure {
 	/**
 	 * Get the note.
 	 *
+	 * @since x.x.x
 	 * @param string $message Pinterest API error message.
 	 * @return Note
 	 */
@@ -54,6 +56,7 @@ class AccountFailure {
 	/**
 	 * Used to add an account failure note if the one does not exist.
 	 *
+	 * @since x.x.x
 	 * @param string $message Pinterest API error message.
 	 * @return void
 	 * @throws NotesUnavailableException An exception when notes are unavailable.
@@ -70,6 +73,7 @@ class AccountFailure {
 	/**
 	 * Delete the note.
 	 *
+	 * @since x.x.x
 	 * @return void
 	 */
 	public static function delete_note() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adding an action to hook into Pinterest API exceptions to control Admin Notices. Adding an account failure notice into WooCommerce admin area in case there is a problem with the account while registering the feed (the most common scenario at the moment).

The note is dismissable and will show itself only once per connect-disconnect cycle. The note is removed on the disconnect event.

### Detailed test instructions:

1. Download the extension and connect to your Pinterest account.
2. Edit the code lines below by adding a filter to emulate the request failure

https://github.com/woocommerce/pinterest-for-woocommerce/blob/1552a0fe3744376e36133a6ac8b2cce9456e856f/src/API/APIV5.php#L524-L530

add exactly before the `return` statement:

```php
add_filter(
	'pre_http_request',
	function ( $response, $parsed_args, $url ) use ( $ad_account_id ) {
		if ( "https://api.pinterest.com/v5/catalogs/feeds?ad_account_id={$ad_account_id}" === $url ) {
			return array(
				'headers'  => array(
					'content-type' => 'application/json',
				),
				'body'     => json_encode(
					array(
						'code'    => 2625,
						'message' => 'Sorry, you cannot perform this action as your account has been disapproved. Please see business hub for more details. https://www.pinterest.com/business/hub/',
					)
				),
				'response' => array(
					'code'    => 403,
					'message' => 'Forbidden',
				),
				'cookies'  => array(),
				'filename' => '',
			);
		}
	},
	10,
	3
);
```

3. Go to WooCommerce - Status - Scheduler Actions - Pending

<img width="1767" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress" src="https://github.com/user-attachments/assets/80d0613c-687e-4eb5-ba11-1f2d8046ce21">

4. Force run the `pinterest-for-woocommerce-handle-feed-registration` action. 
5. Go to WooCommerce - Status - Scheduler Actions - Failed
6. Observe there is the failed action.
7. Observe there is an admin error notice duplicating the error of the action.

<img width="1767" alt="WooCommerce_status_‹_WordPress_Pinterest_—_WordPress-4" src="https://github.com/user-attachments/assets/b72a939b-14b0-4481-9dfd-e608c4dec7a7">

### Changelog entry

> Add - Admin notice of a failed Pinterest account status.
