### PR TITLE
Add UTM parameters to product URLs in feed.

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -299,13 +299,39 @@ class ProductsXmlFeed {
 	/**
 	 * Returns the permalink.
 	 *
+	 * @since x.x.x Url has UTM parameters used for tracking.
+	 *
 	 * @param WC_Product $product the product.
 	 * @param string     $property The name of the property.
 	 *
 	 * @return string
 	 */
 	private static function get_property_link( $product, $property ) {
-		return '<' . $property . '><![CDATA[' . $product->get_permalink() . ']]></' . $property . '>';
+		$product_url          = $product->get_permalink();
+		$product_url_with_utm = self::add_utm_parameters( $product_url );
+
+		return '<' . $property . '><![CDATA[' . $product_url_with_utm . ']]></' . $property . '>';
+	}
+
+	/**
+	 * Add UTM parameters to the product URL.
+	 * This is used to track the performance of the product pins.
+	 * The parameters are:
+	 * - utm_source: pinterest
+	 * - utm_medium: social
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $product_url The product URL.
+	 * @return string
+	 */
+	private static function add_utm_parameters( $product_url ) {
+		$utm_params = array(
+			'utm_source'   => 'pinterest',
+			'utm_medium'   => 'social',
+		);
+
+		return add_query_arg( $utm_params, $product_url );
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -88,7 +88,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Uncategorized', $g_children['product_type'] );
 
 		// This should be the permalink.
-		$this->assertEquals( 'http://example.org/?product=dummy-product', $children['link'] );
+		$this->assertEquals( 'http://example.org/?product=dummy-product&utm_source=pinterest&utm_medium=social', $children['link'] );
 
 		// No description set.
 		$this->assertArrayNotHasKey( 'image_link', $g_children, 'By default product does not have an image link.' );
@@ -414,7 +414,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$product     = WC_Helper_Product::create_simple_product();
 		$xml         = $link_method( $product );
 		// create_simple_product gives the product 'Uncategorized' type.
-		$this->assertEquals( '<link><![CDATA[http://example.org/?product=dummy-product]]></link>', $xml );
+		$this->assertEquals( '<link><![CDATA[http://example.org/?product=dummy-product&utm_source=pinterest&utm_medium=social]]></link>', $xml );
 	}
 
 	/**


### PR DESCRIPTION
## Adding UTM parameters to the products URLs in the feed

With this change the order attribution feature in
WooCommerce will be able to correctly attribute
purchase coming from the Pinterest platform.

### Changes proposed in this Pull Request:

Each link in the product feed will have the UTM parameteres added:
``` diff
-'http://example.org/?product=dummy-product'
+'http://example.org/?product=dummy-product&utm_source=pinterest&utm_medium=social'
```
Closes https://github.com/woocommerce/woocommerce-analytics/issues/497

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Wait for the feed creation or trigger it manually
2. Inspect the created XML feed file.

### Additional details:

- this may require followup in WooCommerce Analytics backend

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - UTM parameters to the products URLs used in the product feed. 
