### PR TITLE
WP Consent API integration.

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -341,18 +341,24 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			 */
 			$is_tracking_disabled             = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
 			$is_tracking_conversions_disabled = ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
-			$is_tracking_conversions_capi_disabled = apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false );
 			$is_not_a_site                    = wp_doing_cron() || is_admin();
 
 			if ( $is_tracking_disabled || $is_tracking_conversions_disabled || $is_not_a_site ) {
 				return false;
 			}
 
-			$is_tracking_conversions_capi_enabled = ! $is_tracking_conversions_capi_disabled && Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
+			/**
+			 * Filters whether to disable CAPI tracking.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool $disable_capi_tracking Whether to disable CAPI tracking.
+			 */
+			$is_tracking_conversions_capi_disabled = apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false );
+			$tracking                              = new Tracking( array( new Tag() ) );
 
-			$tracking = new Tracking( array( new Tag() ) );
-
-			if ( $is_tracking_conversions_capi_enabled ) {
+			if ( ! $is_tracking_conversions_capi_disabled
+				&& Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' ) ) {
 				$user                = new User( WC_Geolocation::get_ip_address(), wc_get_user_agent() );
 				$conversions_tracker = new Conversions( $user );
 				$tracking->add_tracker( $conversions_tracker );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -354,11 +354,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			 *
 			 * @param bool $disable_capi_tracking Whether to disable CAPI tracking.
 			 */
-			$is_tracking_conversions_capi_disabled = apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false );
-			$tracking                              = new Tracking( array( new Tag() ) );
+			$is_tracking_conversions_capi_enabled = ! apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false )
+													&& Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
+			$tracking                             = new Tracking( array( new Tag() ) );
 
-			if ( ! $is_tracking_conversions_capi_disabled
-				&& Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' ) ) {
+			if ( $is_tracking_conversions_capi_enabled ) {
 				$user                = new User( WC_Geolocation::get_ip_address(), wc_get_user_agent() );
 				$conversions_tracker = new Conversions( $user );
 				$tracking->add_tracker( $conversions_tracker );

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -341,13 +341,14 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			 */
 			$is_tracking_disabled             = apply_filters( 'woocommerce_pinterest_disable_tracking', false );
 			$is_tracking_conversions_disabled = ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' );
+			$is_tracking_conversions_capi_disabled = apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false );
 			$is_not_a_site                    = wp_doing_cron() || is_admin();
 
 			if ( $is_tracking_disabled || $is_tracking_conversions_disabled || $is_not_a_site ) {
 				return false;
 			}
 
-			$is_tracking_conversions_capi_enabled = Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
+			$is_tracking_conversions_capi_enabled = ! $is_tracking_conversions_capi_disabled && Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' );
 
 			$tracking = new Tracking( array( new Tag() ) );
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -328,6 +328,10 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return Pinterest\Tracking|false
 		 */
 		public static function init_tracking() {
+
+			// Init WP Consent API integration.
+			new Pinterest\WPConsentAPI();
+
 			/**
 			 * Filters whether to disable tracking.
 			 *
@@ -1019,7 +1023,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function update_account_data() {
 			try {
-				$account_data     = Pinterest\API\APIV5::get_account_info();
+				$account_data = Pinterest\API\APIV5::get_account_info();
 
 				$data = array(
 					'username'         => $account_data['username'] ?? '',
@@ -1091,6 +1095,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		}
 
 		/**
+		 * Maybe check billing setup.
 		 *
 		 * @since 1.2.5
 		 *
@@ -1252,7 +1257,6 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @return boolean
 		 */
 		public static function set_default_settings() {
-
 			$settings = self::get_settings( true );
 			$settings = wp_parse_args( $settings, self::$default_settings );
 
@@ -1335,7 +1339,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		public static function is_domain_verified(): bool {
 			$account_data     = self::get_setting( 'account_data' );
 			$verified_domains = $account_data['verified_user_websites'] ?? array();
-			return in_array( wp_parse_url( get_home_url() )['host'] ?? '', $verified_domains );
+			return in_array( wp_parse_url( get_home_url() )['host'] ?? '', $verified_domains ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		}
 
 		/**

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -153,7 +153,7 @@ class Auth extends VendorAPI {
 	 */
 	private function apply_oauth_flow_features( array $features ): void {
 		Pinterest_For_Woocommerce()::save_setting( 'track_conversions', $features['tags'] ?? false );
-		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
+		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', $features['CAPI'] ?? false );
 		Pinterest_For_Woocommerce()::save_setting( 'product_sync_enabled', $features['catalog'] ?? false );
 	}
 

--- a/src/WPConsentAPI.php
+++ b/src/WPConsentAPI.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Implement WP Consent API for Pinterest for WooCommerce.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ * @version x.x.x
+ */
+
+namespace Automattic\WooCommerce\Pinterest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WPConsentAPI
+ *
+ * @since x.x.x
+ */
+class WPConsentAPI {
+
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		if ( ! $this->is_wp_consent_api_active() ) {
+			return;
+		}
+
+		add_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME, '__return_true' );
+
+		add_filter(
+			'woocommerce_pinterest_disable_tracking',
+			function () {
+				return ! wp_has_consent( 'marketing' );
+			}
+		);
+	}
+
+	/**
+	 * Check if WP Cookie Consent API is active
+	 *
+	 * @return bool
+	 */
+	protected function is_wp_consent_api_active() {
+		return function_exists( 'wp_has_consent' );
+	}
+}

--- a/src/WPConsentAPI.php
+++ b/src/WPConsentAPI.php
@@ -34,7 +34,7 @@ class WPConsentAPI {
 		add_filter(
 			'woocommerce_pinterest_disable_tracking',
 			function () {
-				return $this->disable_tracking();
+				return $this->should_disable_tracking();
 			}
 		);
 	}
@@ -49,11 +49,11 @@ class WPConsentAPI {
 	}
 
 	/**
-	 * Disable tracking if marketing consent is not granted
+	 * Check if we should disable tracking if marketing consent is not granted
 	 *
 	 * @return bool
 	 */
-	public function disable_tracking() {
+	public function should_disable_tracking() {
 		return ! wp_has_consent( 'marketing' );
 	}
 }

--- a/src/WPConsentAPI.php
+++ b/src/WPConsentAPI.php
@@ -34,17 +34,26 @@ class WPConsentAPI {
 		add_filter(
 			'woocommerce_pinterest_disable_tracking',
 			function () {
-				return ! wp_has_consent( 'marketing' );
+				return $this->disable_tracking();
 			}
 		);
 	}
 
 	/**
-	 * Check if WP Cookie Consent API is active
+	 * Check if WP Consent API is active
 	 *
 	 * @return bool
 	 */
 	protected function is_wp_consent_api_active() {
 		return function_exists( 'wp_has_consent' );
+	}
+
+	/**
+	 * Disable tracking if marketing consent is not granted
+	 *
+	 * @return bool
+	 */
+	public function disable_tracking() {
+		return ! wp_has_consent( 'marketing' );
 	}
 }

--- a/src/WPConsentAPI.php
+++ b/src/WPConsentAPI.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class WPConsentAPI
+ * Class handling WP Consent API integration.
  *
  * @since x.x.x
  */
@@ -21,8 +21,6 @@ class WPConsentAPI {
 
 	/**
 	 * Constructor.
-	 *
-	 * @return void
 	 */
 	public function __construct() {
 		if ( ! $this->is_wp_consent_api_active() ) {
@@ -30,30 +28,24 @@ class WPConsentAPI {
 		}
 
 		add_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME, '__return_true' );
-
-		add_filter(
-			'woocommerce_pinterest_disable_tracking',
-			function () {
-				return $this->should_disable_tracking();
-			}
-		);
+		add_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking', array( $this, 'should_disable_tracking' ) );
 	}
 
 	/**
-	 * Check if WP Consent API is active
+	 * Check if WP Consent API is active.
 	 *
 	 * @return bool
 	 */
-	protected function is_wp_consent_api_active() {
+	protected function is_wp_consent_api_active(): bool {
 		return function_exists( 'wp_has_consent' );
 	}
 
 	/**
-	 * Check if we should disable tracking if marketing consent is not granted
+	 * Check if tracking should be disabled based on marketing consent.
 	 *
 	 * @return bool
 	 */
-	public function should_disable_tracking() {
+	public function should_disable_tracking(): bool {
 		return ! wp_has_consent( 'marketing' );
 	}
 }

--- a/tests/Unit/WPConsentAPITest.php
+++ b/tests/Unit/WPConsentAPITest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest;
+
+use WP_UnitTestCase;
+
+class WPConsentAPITest extends WP_UnitTestCase {
+
+	/**
+	 * @var WPConsentAPI
+	 */
+	private WPConsentAPI $wp_consent_api;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->wp_consent_api = $this->getMockBuilder( WPConsentAPI::class )
+			->onlyMethods( array( 'is_wp_consent_api_active', 'disable_tracking' ) )
+			->getMock();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		unset( $this->wp_consent_api );
+		remove_all_filters( 'woocommerce_pinterest_disable_tracking' );
+		remove_all_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME );
+	}
+
+	public function test_wp_consent_api_not_available(): void {
+		$this->wp_consent_api->expects( $this->once() )
+			->method( 'is_wp_consent_api_active' )
+			->willReturn( false );
+
+		$this->wp_consent_api->__construct();
+
+		// When API is not available, no filters should be registered
+		$this->assertFalse( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
+		$this->assertFalse( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+	}
+
+	public function test_wp_consent_api_available_with_marketing_consent(): void {
+		$this->wp_consent_api->expects( $this->once() )
+			->method( 'is_wp_consent_api_active' )
+			->willReturn( true );
+
+		$this->wp_consent_api->expects( $this->once() )
+			->method( 'disable_tracking' )
+			->willReturn( false );
+
+		$this->wp_consent_api->__construct();
+
+		// When API is available, both filters should be registered
+		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
+		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+
+		// Plugin registration filter should return true
+		$this->assertTrue( apply_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME, false ) );
+
+		// When marketing consent is granted, tracking should be enabled
+		$this->assertFalse( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
+	}
+
+	public function test_wp_consent_api_available_without_marketing_consent(): void {
+		$this->wp_consent_api->expects( $this->once() )
+			->method( 'is_wp_consent_api_active' )
+			->willReturn( true );
+
+		$this->wp_consent_api->expects( $this->once() )
+			->method( 'disable_tracking' )
+			->willReturn( true );
+
+		$this->wp_consent_api->__construct();
+
+		// When API is available, both filters should be registered
+		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
+		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+
+		// When marketing consent is not granted, tracking should be disabled
+		$this->assertTrue( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
+	}
+}

--- a/tests/Unit/WPConsentAPITest.php
+++ b/tests/Unit/WPConsentAPITest.php
@@ -30,7 +30,7 @@ class WPConsentAPITest extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		unset( $this->wp_consent_api );
-		remove_all_filters( 'woocommerce_pinterest_disable_tracking' );
+		remove_all_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking' );
 		remove_all_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME );
 	}
 
@@ -47,7 +47,7 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		// When API is not available, no filters should be registered.
 		$this->assertFalse( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
-		$this->assertFalse( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+		$this->assertFalse( has_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking' ) );
 	}
 
 	/**
@@ -67,12 +67,12 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		// When API is available, both filters should be registered.
 		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
-		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking' ) );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertTrue( apply_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME, false ) );
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$this->assertFalse( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
+		$this->assertFalse( apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false ) );
 	}
 
 	/**
@@ -92,9 +92,45 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		// When API is available, both filters should be registered.
 		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
-		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
+		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking' ) );
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$this->assertTrue( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
+		$this->assertTrue( apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false ) );
+	}
+
+	/**
+	 * Test that CAPI tracking can be disabled.
+	 *
+	 * @return void
+	 */
+	public function test_capi_tracking_disabled_by_default(): void {
+		$this->assertFalse(
+			//	phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false ),
+			'CAPI tracking should be disabled by default'
+		);
+	}
+
+	/**
+	 * Test CAPI tracking control via filter.
+	 *
+	 * @return void
+	 */
+	public function test_capi_tracking_control(): void {
+		// By default, CAPI tracking should not be disabled.
+		$this->assertFalse(
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false ),
+			'CAPI tracking should not be disabled by default'
+		);
+
+		// Can be disabled via filter.
+		add_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking', '__return_true' );
+		$this->assertTrue(
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			apply_filters( 'woocommerce_pinterest_disable_conversions_capi_tracking', false ),
+			'CAPI tracking should be disabled when filter returns true'
+		);
+		remove_filter( 'woocommerce_pinterest_disable_conversions_capi_tracking', '__return_true' );
 	}
 }

--- a/tests/Unit/WPConsentAPITest.php
+++ b/tests/Unit/WPConsentAPITest.php
@@ -4,6 +4,9 @@ namespace Automattic\WooCommerce\Pinterest;
 
 use WP_UnitTestCase;
 
+/**
+ * Class WPConsentAPITest.
+ */
 class WPConsentAPITest extends WP_UnitTestCase {
 
 	/**
@@ -31,6 +34,10 @@ class WPConsentAPITest extends WP_UnitTestCase {
 		remove_all_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME );
 	}
 
+	/**
+	 * Test that WP Consent API is not available.
+	 * @return void
+	 */
 	public function test_wp_consent_api_not_available(): void {
 		$this->wp_consent_api->expects( $this->once() )
 			->method( 'is_wp_consent_api_active' )
@@ -38,11 +45,15 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		$this->wp_consent_api->__construct();
 
-		// When API is not available, no filters should be registered
+		// When API is not available, no filters should be registered.
 		$this->assertFalse( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
 		$this->assertFalse( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
 	}
 
+	/**
+	 * Test that WP Consent API is available.
+	 * @return void
+	 */
 	public function test_wp_consent_api_available_with_marketing_consent(): void {
 		$this->wp_consent_api->expects( $this->once() )
 			->method( 'is_wp_consent_api_active' )
@@ -54,17 +65,20 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		$this->wp_consent_api->__construct();
 
-		// When API is available, both filters should be registered
+		// When API is available, both filters should be registered.
 		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
 		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
-
-		// Plugin registration filter should return true
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertTrue( apply_filters( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME, false ) );
 
-		// When marketing consent is granted, tracking should be enabled
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertFalse( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
 	}
 
+	/**
+	 * Test that WP Consent API is available but marketing consent is not granted.
+	 * @return void
+	 */
 	public function test_wp_consent_api_available_without_marketing_consent(): void {
 		$this->wp_consent_api->expects( $this->once() )
 			->method( 'is_wp_consent_api_active' )
@@ -76,11 +90,11 @@ class WPConsentAPITest extends WP_UnitTestCase {
 
 		$this->wp_consent_api->__construct();
 
-		// When API is available, both filters should be registered
+		// When API is available, both filters should be registered.
 		$this->assertTrue( has_filter( 'wp_consent_api_registered_' . PINTEREST_FOR_WOOCOMMERCE_PLUGIN_BASENAME ) );
 		$this->assertTrue( has_filter( 'woocommerce_pinterest_disable_tracking' ) );
 
-		// When marketing consent is not granted, tracking should be disabled
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertTrue( apply_filters( 'woocommerce_pinterest_disable_tracking', false ) );
 	}
 }

--- a/tests/Unit/WPConsentAPITest.php
+++ b/tests/Unit/WPConsentAPITest.php
@@ -17,7 +17,7 @@ class WPConsentAPITest extends WP_UnitTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->wp_consent_api = $this->getMockBuilder( WPConsentAPI::class )
-			->onlyMethods( array( 'is_wp_consent_api_active', 'disable_tracking' ) )
+			->onlyMethods( array( 'is_wp_consent_api_active', 'should_disable_tracking' ) )
 			->getMock();
 	}
 
@@ -49,7 +49,7 @@ class WPConsentAPITest extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->wp_consent_api->expects( $this->once() )
-			->method( 'disable_tracking' )
+			->method( 'should_disable_tracking' )
 			->willReturn( false );
 
 		$this->wp_consent_api->__construct();
@@ -71,7 +71,7 @@ class WPConsentAPITest extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->wp_consent_api->expects( $this->once() )
-			->method( 'disable_tracking' )
+			->method( 'should_disable_tracking' )
 			->willReturn( true );
 
 		$this->wp_consent_api->__construct();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds WP Consent API support. When WP Consent API  is enabled with a cookie consent plugin that implements it, Pinterest for WooCommerce will obey this consent setting.

### Screenshots:


https://github.com/user-attachments/assets/7277b31f-d654-4535-a7b0-9dfbcdb9a93f



### Detailed test instructions:

1. Install [WP Consent API](https://wordpress.org/plugins/wp-consent-api/)
2. Install a cookie banner plugin with WP Consent API] support, [Complianz GDPR](https://wordpress.org/plugins/complianz-gdpr/), for example
3. Configure the basic cookie banner.
4. Install Pinterest Pixel Helper.
5. Connect your site to Pinterest, don't forget to allow conversion tag
6. Open your site in a new tab. Accept the consent, then refresh ( confirm the Pinterest Events are firing ).
7. Delete all consent cookies, then refresh, this time deny the consent. Confirm that the Pinterest Events are not firing.

### Changelog entry

>Add - WP Consent API integration.
