### PR TITLE
Replacing `get_locale()` with `WPLANG` option for feed registration.

### DIFF
--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -120,6 +120,7 @@ class LocaleMapper {
 	 * @return string
 	 */
 	private static function get_wordpress_locale() {
+		// Using `WPLANG` instead `get_locale()` since the last may return inconsistent results depending on the user session language.
 		$wordpress_locale = get_option( 'WPLANG', self::PINTEREST_DEFAULT_LOCALE );
 		return str_replace( '_', '-', $wordpress_locale );
 	}

--- a/src/LocaleMapper.php
+++ b/src/LocaleMapper.php
@@ -120,7 +120,7 @@ class LocaleMapper {
 	 * @return string
 	 */
 	private static function get_wordpress_locale() {
-		$wordpress_locale = get_locale();
+		$wordpress_locale = get_option( 'WPLANG', self::PINTEREST_DEFAULT_LOCALE );
 		return str_replace( '_', '-', $wordpress_locale );
 	}
 }

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -18,8 +18,11 @@ class LocaleMapperTest extends TestCase {
 	 * Using this allows us to modify the value that is used by
 	 * the determine_locale() function in WordPress.
 	 */
-	public function locale_filter() {
-		return $this->locale ?: 'en_US';
+	public function locale_filter(): string {
+		if ( ! $this->locale ) {
+			return 'en_US';
+		}
+		return $this->locale;
 	}
 
 	/**

--- a/tests/Unit/LocaleMapperTest.php
+++ b/tests/Unit/LocaleMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
 use Automattic\WooCommerce\Pinterest\Exception\PinterestApiLocaleException;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Automattic\WooCommerce\Pinterest\LocaleMapper;
@@ -7,7 +9,7 @@ use Automattic\WooCommerce\Pinterest\LocaleMapper;
 /**
  * Class for testing locale mapper.
  */
-class PinterestTestLocaleMapper extends TestCase {
+class LocaleMapperTest extends TestCase {
 
 	private $locale;
 
@@ -17,23 +19,21 @@ class PinterestTestLocaleMapper extends TestCase {
 	 * the determine_locale() function in WordPress.
 	 */
 	public function locale_filter() {
-		return $this->locale;
+		return $this->locale ?: 'en_US';
 	}
 
 	/**
 	 * Set up the filter for the locale.
 	 */
-	protected function setUp(): void
-	{
-		add_filter( 'locale', array( $this, 'locale_filter' ) );
+	protected function setUp(): void {
+		add_filter( 'pre_option_WPLANG', array( $this, 'locale_filter' ) );
 	}
 
 	/**
 	 * Remove the filter for the locale.
 	 */
-	protected function tearDown(): void
-	{
-		remove_filter( 'locale', array( $this, 'locale_filter' ) );
+	protected function tearDown(): void {
+		remove_filter( 'pre_option_WPLANG', array( $this, 'locale_filter' ) );
 	}
 
 	/**
@@ -41,7 +41,6 @@ class PinterestTestLocaleMapper extends TestCase {
 	 * @group locale_mapper
 	 */
 	public function test_locale_with_full_match() {
-		$this->locale = 'en_US';
 		$this->assertEquals( 'en-US', LocaleMapper::get_locale_for_api() );
 	}
 
@@ -51,6 +50,7 @@ class PinterestTestLocaleMapper extends TestCase {
 	 */
 	public function test_locale_with_partial_match() {
 		$this->locale = 'de_DE';
+
 		$this->assertEquals( 'de', LocaleMapper::get_locale_for_api() );
 	}
 
@@ -60,8 +60,9 @@ class PinterestTestLocaleMapper extends TestCase {
 	 */
 	public function test_locale_with_no_match() {
 		$this->locale = 'me_ME';
+
 		$this->expectException( PinterestApiLocaleException::class );
+
 		LocaleMapper::get_locale_for_api();
 	}
 }
-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

```
A merchant with a Pinterest for WooCommerce reporting continues to get emails with a "Your data source Created by Pinterest for WooCommerce has been deleted" message.
Their feed is resetting automatically a few times per day.
```

The issue is related to a feed registration process we have with Pinterest. Each 10 minutes we check if the feed parameters have changed, e.g. locale, currency

The change is related to how we obtain the locale. Since this particular issue was at one of the Canadian websites where there are two official languages and users were chaning locale from en to fr, the feed registration was detecting locale changes and re-registering the feed. Instead of using `get_local()` WP function we now take a `WPLANG` option value which is a site-wide setting and should not change frequently.

### Changelog entry

> Fix - Site locale is obtained from settings.
