### PR TITLE
Fixes PHP 8.4 deprecated warnings

### DIFF
--- a/src/View/PHPView.php
+++ b/src/View/PHPView.php
@@ -124,7 +124,7 @@ class PHPView implements View {
 	 *
 	 * @throws ViewException If the view could not be loaded or the provided path was not valid.
 	 */
-	public function render_partial( string $path, array $context = null ): string {
+	public function render_partial( string $path, ?array $context = null ): string {
 		if ( ! $context ) {
 			$context = $this->context;
 		}

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -41,7 +41,7 @@ interface View extends Renderable {
 	 *
 	 * @throws ViewException If the view could not be loaded or provided path was not valid.
 	 */
-	public function render_partial( string $path, array $context = null ): string;
+	public function render_partial( string $path, ?array $context = null ): string;
 
 	/**
 	 * Return the raw value of a context property.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1084.

This PR explicitly marks `$context` array parameter as nullable to fix the PHP 8.4 deprecated warning raised in #1084.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  On a PHP 8.4 WooCommerce website, with Pinterest for WooCommerce plugin activated, navigate to the product editor.
2. View the `debug.log` to observer the warnings reported in #1084.
3. Apply this patch. 
4. Ensure the warnings no longer appear.
5. Test with PHP version 7.4 and 8.2 to ensure backward compatibility.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - PHP 8.4 compatibility
