### PR TITLE
Feed status data missing

### DIFF
--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -285,11 +285,11 @@ class FeedStatusService {
 			'warnings' => 0,
 		);
 
-		$sums['errors'] += array_sum( $processing_results['ingestion_details']['errors'] );
-		$sums['errors'] += array_sum( $processing_results['validation_details']['errors'] );
+		$sums['errors'] += array_sum( $processing_results['ingestion_details']['errors'] ?? array() );
+		$sums['errors'] += array_sum( $processing_results['validation_details']['errors'] ?? array() );
 
-		$sums['warnings'] += array_sum( $processing_results['ingestion_details']['warnings'] );
-		$sums['warnings'] += array_sum( $processing_results['validation_details']['warnings'] );
+		$sums['warnings'] += array_sum( $processing_results['ingestion_details']['warnings'] ?? array() );
+		$sums['warnings'] += array_sum( $processing_results['validation_details']['warnings'] ?? array() );
 
 		$original = $processing_results['product_counts']['original'] ?? 0;
 		$ingested = $processing_results['product_counts']['ingested'] ?? 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When there are some problems with the feed, the extension may display an empty UI. To fix this we add a fallback to empty data if the feed status data is missing at Pinterest.

### Screenshots:

#### Pinterest side

<img width="1884" alt="_3__Pinterest" src="https://github.com/user-attachments/assets/ba92b9f6-fbf7-48ba-9b8c-6e8289524b8f" />

#### Plugin side

<img width="1499" alt="Products_Catalog_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/user-attachments/assets/338c577f-09b4-4f41-82ca-c0b9eb599d98" />

### Detailed test instructions:

Not sure how to test this, this is not a common behaviour. The fix is more like a defensive measure to the issue rathen than the fix. The issue itself is not related to the extension or website, but to the feed processing by Pinterest. Nothing to fix.

After the PR we should see some feed data e.g.

<img width="1499" alt="Products_Catalog_‹_Pinterest_‹_Marketing_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce-2" src="https://github.com/user-attachments/assets/c40025f9-05f3-4a41-9d27-554bef83900a" />

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add feed status data fallback to empty data sets.
