### PR TITLE
Release/1.4.17 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.4.17 - 2025-03-18 =
+* Add - PHP 8.4 compatibility.
+* Fix - Add feed status data fallback to empty data sets.
+* Fix - Site locale is obtained from settings.
+* Tweak - WC 9.8 compatibility.
+
 = 1.4.16 - 2025-02-11 =
 * Add - UTM parameters to the products URLs used in the product feed.
 * Dev - Updating code styling rules.

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -350,7 +350,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			/**
 			 * Filters whether to disable CAPI tracking.
 			 *
-			 * @since x.x.x
+			 * @since 1.4.17
 			 *
 			 * @param bool $disable_capi_tracking Whether to disable CAPI tracking.
 			 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.16
+ * Version:           1.4.17
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 9.7
+ * WC tested up to: 9.8
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.16' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.17' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,12 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.17 - 2025-03-18 =
+* Add - PHP 8.4 compatibility.
+* Fix - Add feed status data fallback to empty data sets.
+* Fix - Site locale is obtained from settings.
+* Tweak - WC 9.8 compatibility.
+
 = 1.4.16 - 2025-02-11 =
 * Add - UTM parameters to the products URLs used in the product feed.
 * Dev - Updating code styling rules.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 6.7
 Requires PHP: 7.3
-Stable tag: 1.4.16
+Stable tag: 1.4.17
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/WPConsentAPI.php
+++ b/src/WPConsentAPI.php
@@ -3,7 +3,7 @@
  * Implement WP Consent API for Pinterest for WooCommerce.
  *
  * @package Pinterest_For_WooCommerce/Classes/
- * @version x.x.x
+ * @version 1.4.17
  */
 
 namespace Automattic\WooCommerce\Pinterest;
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class handling WP Consent API integration.
  *
- * @since x.x.x
+ * @since 1.4.17
  */
 class WPConsentAPI {
 


### PR DESCRIPTION
This PR merges the changes from [release v1.4.17](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.17) back into `develop`.