### PR TITLE
Fix feed location check and force HTTPS over HTTP.

### DIFF
--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -301,7 +301,9 @@ class Feeds {
 			 * When trying to match remote feed to a local configuration, we need to check both cases
 			 * not to create a new feed if the feed was created by the extension in the past.
 			 */
-			$does_match = self::does_feed_match( $feed ) && ( $feed['location'] ?? '' ) === $config['feed_url'];
+			$remote_feed_location = self::normalize_feed_location_url( $feed['location'] ?? '' );
+			$local_feed_location  = self::normalize_feed_location_url( $config['feed_url'] );
+			$does_match           = self::does_feed_match( $feed ) && $remote_feed_location === $local_feed_location;
 			if ( $does_match ) {
 				return $feed['id'];
 			}
@@ -337,10 +339,20 @@ class Feeds {
 		}
 
 		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
-		$force_https   = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
+		$force_https   = self::normalize_feed_location_url( wp_get_upload_dir()['baseurl'] );
 		$feed_location = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 
-		return 0 === strpos( $feed['location'] ?? '', $feed_location );
+		return 0 === strpos( self::normalize_feed_location_url( $feed['location'] ?? '' ), $feed_location );
+	}
+
+	/**
+	 * Normalize feed location URLs before comparing local and remote values.
+	 *
+	 * @param string $url The feed location URL.
+	 * @return string
+	 */
+	private static function normalize_feed_location_url( string $url ): string {
+		return str_replace( 'http:', 'https:', $url );
 	}
 
 	/**

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -336,6 +336,7 @@ class Feeds {
 			return false;
 		}
 
+		// Some sites may be misconfigured and return HTTP schema for the feed location URL. We force it to become HTTPS.
 		$force_https   = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
 		$feed_location = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -336,7 +336,8 @@ class Feeds {
 			return false;
 		}
 
-		return 0 === strpos( $feed['location'] ?? '', get_site_url() );
+		$feed_location = trailingslashit( wp_get_upload_dir()['baseurl'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		return 0 === strpos( $feed['location'] ?? '', $feed_location );
 	}
 
 	/**

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -301,9 +301,8 @@ class Feeds {
 			 * When trying to match remote feed to a local configuration, we need to check both cases
 			 * not to create a new feed if the feed was created by the extension in the past.
 			 */
-			$remote_feed_location = self::normalize_feed_location_url( $feed['location'] ?? '' );
-			$local_feed_location  = self::normalize_feed_location_url( $config['feed_url'] );
-			$does_match           = self::does_feed_match( $feed ) && $remote_feed_location === $local_feed_location;
+			$does_match = self::does_feed_match( $feed )
+				&& self::normalize_feed_location_url( $feed['location'] ?? '' ) === $config['feed_url'];
 			if ( $does_match ) {
 				return $feed['id'];
 			}
@@ -338,15 +337,18 @@ class Feeds {
 			return false;
 		}
 
-		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
-		$force_https   = self::normalize_feed_location_url( wp_get_upload_dir()['baseurl'] );
-		$feed_location = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$upload_base_url = self::normalize_feed_location_url( wp_get_upload_dir()['baseurl'] );
+		$feed_location   = trailingslashit( $upload_base_url ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 
 		return 0 === strpos( self::normalize_feed_location_url( $feed['location'] ?? '' ), $feed_location );
 	}
 
 	/**
-	 * Normalize feed location URLs before comparing local and remote values.
+	 * Normalize a feed location URL to HTTPS before comparing local and remote values.
+	 *
+	 * Some sites may be misconfigured and return an HTTP scheme for the feed location URL while
+	 * Pinterest stores the URL as HTTPS (or vice versa). Forcing both sides to HTTPS prevents
+	 * scheme mismatches from breaking feed matching.
 	 *
 	 * @param string $url The feed location URL.
 	 * @return string

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -336,7 +336,7 @@ class Feeds {
 			return false;
 		}
 
-		// Some sites may be misconfigured and return HTTP schema for the feed location URL. We force it to become HTTPS.
+		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
 		$force_https   = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
 		$feed_location = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -352,7 +352,7 @@ class Feeds {
 	 * @return string
 	 */
 	private static function normalize_feed_location_url( string $url ): string {
-		return str_replace( 'http:', 'https:', $url );
+		return set_url_scheme( $url, 'https' );
 	}
 
 	/**

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -336,7 +336,9 @@ class Feeds {
 			return false;
 		}
 
-		$feed_location = trailingslashit( wp_get_upload_dir()['baseurl'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$force_https   = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
+		$feed_location = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+
 		return 0 === strpos( $feed['location'] ?? '', $feed_location );
 	}
 

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -91,8 +91,9 @@ class LocalFeedConfigs {
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_ids', $feed_ids );
 
 		$file_name_base = trailingslashit( wp_get_upload_dir()['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
-		$force_https    = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
-		$url_base       = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		// Some sites may be misconfigured and return HTTP schema for the feed location URL. We force it to become HTTPS.
+		$force_https = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
+		$url_base    = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,
 			function ( &$id ) use ( $file_name_base, $url_base ) {

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -91,7 +91,8 @@ class LocalFeedConfigs {
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_ids', $feed_ids );
 
 		$file_name_base = trailingslashit( wp_get_upload_dir()['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
-		$url_base       = trailingslashit( wp_get_upload_dir()['baseurl'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$force_https    = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
+		$url_base       = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,
 			function ( &$id ) use ( $file_name_base, $url_base ) {

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -90,11 +90,11 @@ class LocalFeedConfigs {
 		// Store generated ids for each location.
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_ids', $feed_ids );
 
-		$upload_dir     = wp_get_upload_dir();
-		$file_name_base = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$upload_dir          = wp_get_upload_dir();
+		$file_name_base      = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
-		$force_https = set_url_scheme( $upload_dir['baseurl'], 'https' );
-		$url_base    = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$upload_baseurl_https = set_url_scheme( $upload_dir['baseurl'], 'https' );
+		$url_base            = trailingslashit( $upload_baseurl_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,
 			function ( &$id ) use ( $file_name_base, $url_base ) {

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -90,9 +90,10 @@ class LocalFeedConfigs {
 		// Store generated ids for each location.
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_ids', $feed_ids );
 
-		$file_name_base = trailingslashit( wp_get_upload_dir()['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
-		// Some sites may be misconfigured and return HTTP schema for the feed location URL. We force it to become HTTPS.
-		$force_https = str_replace( 'http:', 'https:', wp_get_upload_dir()['baseurl'] );
+		$upload_dir     = wp_get_upload_dir();
+		$file_name_base = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
+		$force_https = str_replace( 'http:', 'https:', $upload_dir['baseurl'] );
 		$url_base    = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -90,11 +90,11 @@ class LocalFeedConfigs {
 		// Store generated ids for each location.
 		Pinterest_For_Woocommerce()::save_data( 'local_feed_ids', $feed_ids );
 
-		$upload_dir          = wp_get_upload_dir();
-		$file_name_base      = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$upload_dir     = wp_get_upload_dir();
+		$file_name_base = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
 		$upload_baseurl_https = set_url_scheme( $upload_dir['baseurl'], 'https' );
-		$url_base            = trailingslashit( $upload_baseurl_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
+		$url_base             = trailingslashit( $upload_baseurl_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,
 			function ( &$id ) use ( $file_name_base, $url_base ) {

--- a/src/LocalFeedConfigs.php
+++ b/src/LocalFeedConfigs.php
@@ -93,7 +93,7 @@ class LocalFeedConfigs {
 		$upload_dir     = wp_get_upload_dir();
 		$file_name_base = trailingslashit( $upload_dir['basedir'] ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		// Some sites may be misconfigured and return an HTTP scheme for the feed location URL. We force it to become HTTPS.
-		$force_https = str_replace( 'http:', 'https:', $upload_dir['baseurl'] );
+		$force_https = set_url_scheme( $upload_dir['baseurl'], 'https' );
 		$url_base    = trailingslashit( $force_https ) . PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-';
 		array_walk(
 			$feed_ids,

--- a/tests/E2e/LocalFeedConfigsE2eTest.php
+++ b/tests/E2e/LocalFeedConfigsE2eTest.php
@@ -59,6 +59,37 @@ class LocalFeedConfigsE2eTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests feed URLs are generated with HTTPS when the upload base URL is HTTP.
+	 *
+	 * @return void
+	 */
+	public function test_feed_url_uses_https_when_upload_dir_baseurl_is_http() {
+		Pinterest_For_Woocommerce::save_data(
+			'local_feed_ids',
+			array(
+				'US' => 'taLlmN',
+			)
+		);
+		add_filter(
+			'upload_dir',
+			function ( $data ) {
+				$data['baseurl'] = 'http://example-2.com/wp-content/uploads';
+				return $data;
+			},
+			20
+		);
+
+		$local_feed_configs = LocalFeedConfigs::get_instance();
+
+		$configurations = $local_feed_configs->get_configurations();
+
+		$this->assertEquals(
+			'https://example-2.com/wp-content/uploads/pinterest-for-woocommerce-taLlmN.xml',
+			$configurations['US']['feed_url']
+		);
+	}
+
 	public function test_when_local_feed_config_is_empty_and_no_matching_feeds_at_pinterest() {
 		add_filter( 'pre_http_request', array( self::class, 'get_feeds_no_match' ), 10, 3 );
 

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -41,7 +41,7 @@ class FeedsTest extends WP_UnitTestCase {
 	public function test_maybe_remote_feed_returns_feed_id() {
 		add_filter(
 			'upload_dir',
-			function( $uploads ) {
+			function ( $uploads ) {
 				$uploads['baseurl'] = 'https://example-1.com';
 				return $uploads;
 			}
@@ -56,7 +56,7 @@ class FeedsTest extends WP_UnitTestCase {
 	public function test_maybe_remote_feed_returns_empty_feed_id() {
 		add_filter(
 			'upload_dir',
-			function( $uploads ) {
+			function ( $uploads ) {
 				$uploads['baseurl'] = 'https://example-11.com';
 				return $uploads;
 			}

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
 
 use Automattic\WooCommerce\Pinterest\Exception\FeedNotFoundException;
 use Automattic\WooCommerce\Pinterest\Feeds;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\Notes\FeedDeletionFailure;
 use Pinterest_For_Woocommerce;
 use WP_UnitTestCase;
@@ -15,6 +16,7 @@ class FeedsTest extends WP_UnitTestCase {
 
 		Pinterest_For_Woocommerce::set_default_settings();
 		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '114141241212' );
+		LocalFeedConfigs::deregister();
 	}
 
 	public function tearDown(): void {
@@ -23,6 +25,7 @@ class FeedsTest extends WP_UnitTestCase {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'site_url' );
 		remove_all_filters( 'upload_dir' );
+		LocalFeedConfigs::deregister();
 	}
 
 	/**
@@ -52,6 +55,60 @@ class FeedsTest extends WP_UnitTestCase {
 		$feed = Feeds::maybe_remote_feed();
 
 		$this->assertEquals( 'fIOasjj', $feed );
+	}
+
+	/**
+	 * Tests matching an HTTPS remote feed when the local upload URL is HTTP.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_remote_feed_matches_when_upload_dir_is_http() {
+		add_filter(
+			'upload_dir',
+			function ( $uploads ) {
+				$uploads['baseurl'] = 'http://example-1.com';
+				return $uploads;
+			}
+		);
+		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
+
+		$feed = Feeds::maybe_remote_feed();
+
+		$this->assertEquals( 'fIOasjj', $feed );
+	}
+
+	/**
+	 * Tests registered feed matching normalizes the remote feed URL scheme.
+	 *
+	 * @return void
+	 */
+	public function test_registered_feed_match_normalizes_remote_location_scheme() {
+		Pinterest_For_Woocommerce::save_data(
+			'local_feed_ids',
+			array(
+				'US' => 'fIOasjj',
+			)
+		);
+		add_filter(
+			'upload_dir',
+			function ( $uploads ) {
+				$uploads['baseurl'] = 'https://example-1.com';
+				return $uploads;
+			}
+		);
+
+		$feed = Feeds::match_local_feed_configuration_to_registered_feeds(
+			array(
+				array(
+					'id'              => '278913891236895123895',
+					'location'        => 'http://example-1.com/pinterest-for-woocommerce-fIOasjj.xml',
+					'default_locale'  => 'en-US',
+					'default_country' => 'US',
+				),
+			)
+		);
+
+		$this->assertEquals( '278913891236895123895', $feed );
 	}
 
 	public function test_maybe_remote_feed_returns_empty_feed_id() {

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -39,7 +39,10 @@ class FeedsTest extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_remote_feed_returns_feed_id() {
-		add_filter( 'site_url', fn() => 'https://example-1.com' );
+		add_filter( 'upload_dir', function( $uploads ) {
+			$uploads['baseurl'] = 'https://example-1.com';
+			return $uploads;
+		});
 		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();
@@ -48,7 +51,10 @@ class FeedsTest extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_remote_feed_returns_empty_feed_id() {
-		add_filter( 'site_url', fn() => 'https://example-11.com' );
+		add_filter( 'upload_dir', function( $uploads ) {
+			$uploads['baseurl'] = 'https://example-11.com';
+			return $uploads;
+		});
 		add_filter( 'pre_http_request', array( self::class, 'get_feeds_with_empty_tail_for_the_feed_location' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -22,6 +22,7 @@ class FeedsTest extends WP_UnitTestCase {
 
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'site_url' );
+		remove_all_filters( 'upload_dir' );
 	}
 
 	/**

--- a/tests/Unit/FeedsTest.php
+++ b/tests/Unit/FeedsTest.php
@@ -39,10 +39,13 @@ class FeedsTest extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_remote_feed_returns_feed_id() {
-		add_filter( 'upload_dir', function( $uploads ) {
-			$uploads['baseurl'] = 'https://example-1.com';
-			return $uploads;
-		});
+		add_filter(
+			'upload_dir',
+			function( $uploads ) {
+				$uploads['baseurl'] = 'https://example-1.com';
+				return $uploads;
+			}
+		);
 		add_filter( 'pre_http_request', array( self::class, 'get_feeds' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();
@@ -51,10 +54,13 @@ class FeedsTest extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_remote_feed_returns_empty_feed_id() {
-		add_filter( 'upload_dir', function( $uploads ) {
-			$uploads['baseurl'] = 'https://example-11.com';
-			return $uploads;
-		});
+		add_filter(
+			'upload_dir',
+			function( $uploads ) {
+				$uploads['baseurl'] = 'https://example-11.com';
+				return $uploads;
+			}
+		);
 		add_filter( 'pre_http_request', array( self::class, 'get_feeds_with_empty_tail_for_the_feed_location' ), 10, 3 );
 
 		$feed = Feeds::maybe_remote_feed();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Replacing `get_site_url` with `wp_get_upload_dir` for the feed location check. 
- Forcing HTTPS over HTTP for the feed location URI.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Feed location URL matching.
