### PR TITLE
Add basic QIT

### DIFF
--- a/.github/workflows/build-upload-zip.yml
+++ b/.github/workflows/build-upload-zip.yml
@@ -1,0 +1,45 @@
+name: Build and Upload zip
+
+on: workflow_call
+jobs:
+  build_project:
+        name: Build and upload
+        runs-on: ubuntu-latest
+
+        steps:
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup node version
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
+            - name: Restore node_modules
+              id: cache-node-modules
+              uses: actions/cache@v4
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Install WP-CLI
+              run: |
+                  mkdir tools
+                  wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -P ${PWD}/tools/
+                  chmod +x tools/wp-cli.phar && mv tools/wp-cli.phar tools/wp
+
+            - name: Build
+              run: |
+                  export PATH=$PATH:${PWD}/tools
+                  npm run build
+
+            - name: Upload zip
+              uses: actions/upload-artifact@v4
+              with:
+                name: pinterest-for-woocommerce
+                path: ${{ github.workspace }}/pinterest-for-woocommerce.zip
+ 

--- a/.github/workflows/ci-cron-qit.yml
+++ b/.github/workflows/ci-cron-qit.yml
@@ -1,0 +1,62 @@
+name: QIT - Cron CI
+
+on:
+    schedule:
+        # Run at 04:00 on Tuesdays.
+        - cron: '0 4 * * 2'
+
+jobs:
+
+    setup:
+        name: Setup environments
+        uses: ./.github/workflows/setup-env.yml
+
+    build_project:
+        name: Package
+        needs: setup
+        uses: ./.github/workflows/build-upload-zip.yml
+
+    qit-tests:
+        name: QIT
+        needs: build_project
+        uses: ./.github/workflows/run-qit.yml
+        secrets: inherit
+        with:
+          extension: 'pinterest-for-woocommerce'
+          artifact: 'pinterest-for-woocommerce'
+          wp-version: 'nightly'
+          wc-version: 'nightly'
+          test-activation: true
+          test-security: true
+          test-phpcompatibility: true
+          test-validation: true
+          test-phpstan: false # TODO: Enable this once the PHPStan tests are fixed
+          test-woo-api: true
+          test-woo-e2e: true
+          test-malware: true
+
+    handle-success:
+        if: ${{ success() }}
+        needs: qit-tests
+        name: Handle success
+        runs-on: ubuntu-latest
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+            - uses: act10ns/slack@v2
+              with:
+                  status: success
+                  message: "Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed."
+
+    handle-error:
+      if: ${{ failure() }}
+      needs: qit-tests
+      name: Handle failure
+      runs-on: ubuntu-latest
+      env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      steps:
+          - uses: act10ns/slack@v2
+            with:
+                status: failure
+                message: "Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed. You can find the results in the artifacts section."

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -1,0 +1,78 @@
+name: QIT - Merge to Trunk CI
+
+on:
+  pull_request:
+    branches:
+      - trunk
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+    setup:
+        if: github.event.pull_request.merged == true
+        name: Setup environments
+        uses: ./.github/workflows/setup-env.yml
+
+    build_project:
+        needs: setup
+        name: Package
+        uses: ./.github/workflows/build-upload-zip.yml
+
+    qit-tests:
+        if: github.event.pull_request.merged == true
+        name: QIT tests
+        needs: build_project
+        uses: ./.github/workflows/run-qit.yml
+        secrets: inherit
+        with:
+          extension: 'pinterest-for-woocommerce'
+          artifact: 'pinterest-for-woocommerce'
+          test-activation: true
+          test-security: true
+          test-phpcompatibility: true
+          test-validation: true
+          test-phpstan: false # TODO: Enable this once the PHPStan tests are fixed
+
+    handle-success:
+        if: ${{ success() }}
+        needs: qit-tests
+        name: Handle success
+        runs-on: ubuntu-latest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+          - uses: act10ns/slack@v2
+            with:
+                status: success
+                message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> passed."
+
+    handle-cancelled:
+        if: ${{ cancelled() }}
+        needs: qit-tests
+        name: Handle cancellation
+        runs-on: ubuntu-latest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+          - uses: act10ns/slack@v2
+            with:
+                status: cancelled
+                message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> cancelled."
+
+    handle-error:
+        if: ${{ failure() }}
+        needs: qit-tests
+        name: Handle failure
+        runs-on: ubuntu-latest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+          - uses: act10ns/slack@v2
+            with:
+                status: failure
+                message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> failed."
+

--- a/.github/workflows/manual-ci.yml
+++ b/.github/workflows/manual-ci.yml
@@ -1,0 +1,151 @@
+name: QIT - Test Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      wp-version:
+        description: 'WordPress Version to be tested: `latest` or a specific version number.'
+        type: string
+        default: 'latest'
+      wc-version:
+        description: 'WooCommerce Version to be tested: `latest`, `nightly` or a specific version number.'
+        type: string
+        default: 'latest'
+      php-version:
+        description: |
+          PHP version. Default is `8.4`.
+        type: string
+        default: '8.4'
+      extension-tests:
+        description: 'Extension Tests'
+        type: choice
+        default: 'All'
+        options:
+          - 'E2E Tests'
+          - 'Unit Tests'
+          - 'All'
+          - 'None'
+      qit-tests:
+        description: 'QIT Tests'
+        type: choice
+        options:
+          - 'WooCommerce Pre-Release Tests (includes Activation, WooCommerce E2E and API tests)'
+          - 'Code Quality Checks (includes Security, Validation, Malware, PHPStan, and PHP Compatibility tests)'
+          - 'Activation'
+          - 'Security'
+          - 'Validation'
+          - 'Malware'
+          - 'PHPStan'
+          - 'PHP Compatibility'
+          - 'WooCommerce E2E and API tests'
+          - 'Plugin Checks (for dotOrg metadata)'
+          - 'None'
+      qit-wait:
+        description: 'Wait for QIT? Requires additional time for the QIT tests to complete within GHA.'
+        type: boolean
+        default: true
+      options:
+        description: 'QIT Additional options for `qit` command, like `--optional_features=hpos`.'
+        type: string
+        default: ''
+
+run-name: Tests with WP-${{ inputs.wp-version }} - WC-${{ inputs.wc-version }} - PHP ${{ inputs.php-version }} - Tests ${{ inputs.extension-tests }} - QIT ${{ inputs.qit-tests }}
+
+jobs:
+
+  setup:
+    name: Setup environments
+    uses: ./.github/workflows/setup-env.yml
+
+  php-tests:
+    if: contains(inputs.extension-tests, 'All') || contains(inputs.extension-tests, 'Unit')
+    name: PHP
+    needs: setup
+    uses: ./.github/workflows/run-unit-tests.yml
+    with:
+      wp_version: '[ "${{ inputs.wp-version }}" ]'
+      wc_version: '[ "${{ inputs.wc-version }}" ]'
+    secrets: inherit
+
+  build_project:
+    name: Package
+    needs: setup
+    uses: ./.github/workflows/build-upload-zip.yml
+
+  qit-tests:
+    name: QIT
+    needs: build_project
+    uses: ./.github/workflows/run-qit.yml
+    with:
+      extension: 'pinterest-for-woocommerce'
+      artifact: 'pinterest-for-woocommerce'
+      wp-version: ${{ inputs.wp-version == 'latest' && 'stable' || inputs.wp-version }}
+      wc-version: ${{ inputs.wc-version == 'latest' && 'stable' || contains( inputs.wc-version, 'rc' ) && 'rc' || inputs.wc-version }}
+      php-version: ${{ inputs.php-version }}
+      test-activation: ${{ contains(inputs.qit-tests, 'Activation') && true || false }}
+      test-security: ${{ contains(inputs.qit-tests, 'Security') && true || false }}
+      test-phpcompatibility: ${{ contains(inputs.qit-tests, 'Compatibility') && true || false }}
+      test-phpstan: ${{ contains(inputs.qit-tests, 'PHPStan') && true || false }}
+      test-woo-api: ${{ contains(inputs.qit-tests, 'API') && true || false }}
+      test-woo-e2e: ${{ contains(inputs.qit-tests, 'WooCommerce E2E') && true || false }}
+      test-malware: ${{ contains(inputs.qit-tests, 'Malware') && true || false }}
+      test-validation: ${{ contains(inputs.qit-tests, 'Validation') && true || false }}
+      test-plugin-check: ${{ contains(inputs.qit-tests, 'dotOrg') && true || false }}
+      options: ${{ inputs.options }}
+      wait: ${{ inputs.qit-wait }}
+    secrets: inherit
+
+  e2e-tests:
+    if: contains(inputs.extension-tests, 'All') || contains(inputs.extension-tests, 'E2E')
+    name: E2E tests
+    needs: build_project
+    uses: ./.github/workflows/run-e2e.yml
+    with:
+      wp_version: '[ "${{ inputs.wp-version }}" ]'
+      wc_version: '[ "${{ inputs.wc-version }}" ]'
+      php_version: '[ "${{ inputs.php-version }}" ]'
+      test_mode: '[ "legacy", "blocks" ]'
+    secrets: inherit
+
+  handle-success:
+    if: |
+      always() &&
+      (needs.qit-tests.result == 'success' || needs.qit-tests.result == 'skipped') &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
+      (needs.php-tests.result == 'success' || needs.php-tests.result == 'skipped')
+    needs: [qit-tests, e2e-tests, php-tests]
+    name: Handle success
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: act10ns/slack@v2
+        with:
+          status: success
+          message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed."
+
+  handle-cancelled:
+    if: cancelled()
+    needs: [qit-tests, e2e-tests, php-tests]
+    name: Handle cancellation
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: act10ns/slack@v2
+        with:
+          status: cancelled
+          message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> cancelled."
+
+  handle-error:
+    if: failure()
+    needs: [qit-tests, e2e-tests, php-tests]
+    name: Handle failure
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - uses: act10ns/slack@v2
+        with:
+          status: failure
+          message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed."

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -1,0 +1,50 @@
+name: Run E2E Tests
+
+on:
+  workflow_call:
+    inputs:
+      wp_version:
+        required: true
+        type: string
+      wc_version:
+        required: true
+        type: string
+      php_version:
+        required: true
+        type: string
+      test_mode:
+        required: true
+        type: string
+
+jobs:
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup node version and npm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+      # - name: Setup WordPress environment
+      #   run: wp-env start
+
+      - name: Run E2E tests
+        run: |
+          echo "E2E tests are not ready yet for this repository."
+          echo "This is a placeholder message. E2E test implementation is pending."
+          exit 0
+
+      # - name: Cleanup
+      #   run: wp-env stop 

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -1,0 +1,348 @@
+name: Run QIT
+description: Runs QIT tests for the extension.
+
+on:
+  workflow_call:
+    inputs:
+      extension:
+        required: true
+        type: string
+      artifact:
+        type: string
+        required: true
+      wp-version:
+        type: string
+        default: 'stable'
+      wc-version:
+        type: string
+        default: 'stable'
+      php-version:
+        type: string
+        default: '8.4'
+      # Customize which QIT test types to run.
+      test-activation:
+        type: string
+        default: 'false'
+      test-security:
+        type: string
+        default: 'false'
+      test-phpcompatibility:
+        type: string
+        default: 'false'
+      test-phpstan:
+        type: string
+        default: 'false'
+      test-woo-api:
+        type: string
+        default: 'false'
+      test-woo-e2e:
+        type: string
+        default: 'false'
+      test-e2e:
+        type: string
+        default: 'false'
+      test-additional-plugins:
+        type: string
+        default: ''
+      test-malware:
+        type: string
+        default: 'false'
+      test-plugin-check:
+        type: string
+        default: 'false'
+      test-validation:
+        type: string
+        default: 'false'
+      options:
+        type: string
+        default: ''
+      # End of QIT tests.
+      wait:
+        type: boolean
+        default: true
+
+env:
+  NO_COLOR: 1
+  QIT_DISABLE_ONBOARDING: yes
+  EXTENSION_SLUG: ${{ inputs.extension }}
+  WP_VERSION: ${{ inputs.wp-version && inputs.wp-version || 'stable' }}
+  WC_VERSION: ${{ inputs.wc-version && inputs.wc-version || 'stable' }}
+  PHP_VERSION: ${{ inputs.php-version && inputs.php-version || '8.4' }}
+  ADDITIONAL_PLUGINS: ${{ inputs.test-additional-plugins && format( '--additional_plugins={0}', inputs.test-additional-plugins ) || '' }}
+  WAIT_FLAG: ${{ inputs.wait && '--wait' || '' }}
+  EXTRA_OPTIONS: ${{ inputs.options }}
+
+jobs:
+
+  qit-tests:
+
+        name: Run QIT Tests
+        runs-on: ubuntu-latest
+        steps:
+
+          - name: Install QIT via composer
+            shell: bash
+            run: composer require woocommerce/qit-cli
+
+          - name: Add Partner and Prepare Environment
+            shell: bash
+            run: |
+
+              # Add Partner.
+              ./vendor/bin/qit partner:add \
+                --user='${{ secrets.QIT_PARTNER_USER }}' \
+                --qit_token='${{ secrets.QIT_PARTNER_SECRET }}'
+
+              # Export ZIP file path to GITHUB_ENV.
+              echo "ZIP_FILE_PATH=${{ github.workspace }}/$EXTENSION_SLUG.zip" >> $GITHUB_ENV
+
+              # Create a directory to store QIT Results.
+              mkdir ${{ github.workspace }}/qit-results
+
+          - name: Download the zip
+            uses: actions/download-artifact@v4
+            with:
+                name: ${{ inputs.artifact }}
+                path: ${{ github.workspace }}
+
+          ##############################
+          # Activation Tests.
+          ##############################
+
+          - name: Activation test
+            id: run-activation-test
+            if: ${{ inputs.test-activation == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              echo "Running activation test for ${{ env.EXTENSION_SLUG }}"
+              ./vendor/bin/qit run:activation \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                --wp=${{ env.WP_VERSION }} \
+                --woo=${{ env.WC_VERSION }} \
+                --php_version=${{ env.PHP_VERSION }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-activation-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo activation results
+            if: ${{ inputs.test-activation == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-activation-results.txt
+              exit ${{ steps.run-activation-test.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # Security Tests.
+          ##############################
+
+          - name: Run security test
+            id: run-security-test
+            if: ${{ inputs.test-security == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:security \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-security-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo security results
+            if: ${{ inputs.test-security == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-security-results.txt
+              exit ${{ steps.run-security-test.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # PHP Compatibility Tests.
+          ##############################
+
+          - name: Run PHP compatibility test
+            id: run-php-compatibility-test
+            if: ${{ inputs.test-phpcompatibility == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:phpcompatibility \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-php-compatibility-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo PHP compatibility results
+            if: ${{ inputs.test-phpcompatibility == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-php-compatibility-results.txt
+              exit ${{ steps.run-php-compatibility-test.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # PHPStan Tests.
+          ##############################
+          - name: Run PHPStan Tests
+            id: run-phpstan-tests
+            if: ${{ inputs.test-phpstan == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:phpstan \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                --wordpress_version=${{ env.WP_VERSION == 'nightly' && 'rc' || env.WP_VERSION }}  \
+                --woocommerce_version=${{ env.WC_VERSION == 'nightly' && 'rc' || env.WC_VERSION }}  \
+                ${{ env.ADDITIONAL_PLUGINS }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-phpstan-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo PHPStan results
+            if: ${{ inputs.test-phpstan == 'true' }}
+            run: |
+
+              cat -v ${{ github.workspace }}/qit-results/qit-phpstan-results.txt
+              exit ${{ steps.run-phpstan-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # Malware Tests.
+          ##############################
+          - name: Run Malware Tests
+            id: run-malware-tests
+            if: ${{ inputs.test-malware == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:malware \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-malware-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo Malware results
+            if: ${{ inputs.test-malware == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-malware-results.txt
+              exit ${{ steps.run-malware-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # Plugin Check Tests (for dotOrg).
+          ##############################
+          - name: Run Plugin Check Tests
+            id: run-plugin-check-tests
+            if: ${{ inputs.test-plugin-check == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:plugin-check \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-plugin-check-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo Plugin Check results
+            if: ${{ inputs.test-plugin-check == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-plugin-check-results.txt
+              exit ${{ steps.run-plugin-check-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # Validation Tests.
+          ##############################
+          - name: Run Validation Tests
+            id: run-validation-tests
+            if: ${{ inputs.test-validation == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:validation \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                --php_version=${{ env.PHP_VERSION }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-validation-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo Validation results
+            if: ${{ inputs.test-validation == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-validation-results.txt
+              exit ${{ steps.run-validation-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # WC API Tests.
+          ##############################
+          - name: Run WC API Tests
+            id: run-woo-api-tests
+            if: ${{ inputs.test-woo-api == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:woo-api \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                --wordpress_version=${{ env.WP_VERSION == 'nightly' && 'rc' || env.WP_VERSION }} \
+                --woocommerce_version=${{ env.WC_VERSION == 'nightly' && 'rc' || env.WC_VERSION }} \
+                --php_version=${{ env.PHP_VERSION }} \
+                ${{ env.ADDITIONAL_PLUGINS }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-woo-api-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo WC API results
+            if: ${{ inputs.test-woo-api == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-woo-api-results.txt
+              exit ${{ steps.run-woo-api-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          ##############################
+          # WC E2E Tests.
+          ##############################
+          - name: Run WC E2E Tests
+            id: run-woo-e2e-tests
+            if: ${{ inputs.test-woo-e2e == 'true' }}
+            # Do not fail when the `qit` fails, so we can annotate the results.
+            shell: bash --noprofile --norc {0}
+            run: |
+              ./vendor/bin/qit run:woo-e2e \
+                ${{ env.EXTENSION_SLUG }} \
+                --zip=${{ env.ZIP_FILE_PATH }} \
+                --wordpress_version=${{ env.WP_VERSION == 'nightly' && 'rc' || env.WP_VERSION }} \
+                --woocommerce_version=${{ env.WC_VERSION == 'nightly' && 'rc' || env.WC_VERSION }} \
+                --php_version=${{ env.PHP_VERSION }} \
+                ${{ env.ADDITIONAL_PLUGINS }} \
+                ${{ env.WAIT_FLAG }} \
+                ${{ env.EXTRA_OPTIONS }} \
+                -n \
+                > ${{ github.workspace }}/qit-results/qit-woo-e2e-results.txt
+              echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          - name: Echo WC E2E results
+            if: ${{ inputs.test-woo-e2e == 'true' }}
+            run: |
+              cat -v ${{ github.workspace }}/qit-results/qit-woo-e2e-results.txt
+              exit ${{ steps.run-woo-e2e-tests.outputs.exitcode == 1 && 1 || 0 }}
+
+          - name: Upload results
+            if: always()
+            uses: actions/upload-artifact@v4
+            with:
+                name: qit-results
+                path: ${{ github.workspace }}/qit-results/

--- a/.github/workflows/setup-env.yml
+++ b/.github/workflows/setup-env.yml
@@ -1,0 +1,57 @@
+name: Setup NodeJS and Dependencies
+
+on: workflow_call
+
+jobs:
+  setup-node:
+    name: Setup NodeJS and Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Setup node version and npm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install Node Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --no-optional --ignore-scripts
+
+  setup-php:
+    name: Setup PHP and Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-ansi --no-interaction --optimize-autoloader

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+v14.16


### PR DESCRIPTION
This PR schedules QIT tests for Pinterest for WooCommerce for Tuesdays at 4AM.

Tests also run automatically when a PR is merged into trunk and can be triggered manually if needed.

Most of the code is adapted from pdqkbG-5bb-p2.

The implementation follows this image (except for PHPStan check that it is disabled - pcShBQ-322-p2):
![image](https://github.com/user-attachments/assets/d5673c97-d2c3-4175-a573-f26dda0277d9)