### PR TITLE
Disable CAPI for all merchants in update process

### DIFF
--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -137,7 +137,7 @@ class PluginUpdate {
 			'1.4.10' => array(
 				'feed_deletion_notice_cleanup',
 			),
-			'1.4.17' => array(
+			'1.4.18' => array(
 				'disable_capi_for_all_merchants',
 			),
 		);

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -413,13 +413,13 @@ class PluginUpdate {
 	}
 
 	/**
-	 * Disable CAPI for all merchants
-	 * 
-	 * @since 1.4.17
+	 * Disable CAPI for all merchants.
+	 *
+	 * @since x.x.x
 	 * @return void
 	 */
 	protected function disable_capi_for_all_merchants(): void {
-		// Set track_conversions_capi to false for all merchants
+		// Set track_conversions_capi to false for all merchants.
 		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -137,6 +137,9 @@ class PluginUpdate {
 			'1.4.10' => array(
 				'feed_deletion_notice_cleanup',
 			),
+			'1.4.17' => array(
+				'disable_capi_for_all_merchants',
+			),
 		);
 	}
 
@@ -407,5 +410,21 @@ class PluginUpdate {
 		} catch ( NotesUnavailableException $e ) {
 			return;
 		}
+	}
+
+	/**
+	 * Disable CAPI for all merchants
+	 * 
+	 * @since 1.4.17
+	 * @return void
+	 */
+	protected function disable_capi_for_all_merchants(): void {
+		// Set track_conversions_capi to false for all merchants
+		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
+		
+		Logger::log(
+			'Disabled Conversions API for all merchants as part of the update to 1.4.17',
+			'info'
+		);
 	}
 }

--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -421,10 +421,5 @@ class PluginUpdate {
 	protected function disable_capi_for_all_merchants(): void {
 		// Set track_conversions_capi to false for all merchants
 		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
-		
-		Logger::log(
-			'Disabled Conversions API for all merchants as part of the update to 1.4.17',
-			'info'
-		);
 	}
 }


### PR DESCRIPTION
Closes PIN4WOO-51

## Summary
- Adds an update procedure in version 1.4.18 that disables the Conversions API (CAPI) for all merchants
- Ensures merchants that already had CAPI enabled will have it disabled after update
- Implements the fix requested by PR #1111 which disabled CAPI only for new merchants

## Test plan
1. Install a previous version of the plugin
2. Enable CAPI tracking
3. Upgrade to the version with this change
4. Verify CAPI tracking has been disabled

🤖 Generated with [Claude Code](https://claude.ai/code)