### PR TITLE
Enable Conversions API in OAuth flow and settings UI

### DIFF
--- a/assets/source/setup-guide/app/steps/SetupPins.js
+++ b/assets/source/setup-guide/app/steps/SetupPins.js
@@ -120,6 +120,38 @@ const SetupPins = ( {} ) => {
 									/>
 									<CheckboxControl
 										label={ __(
+											'Conversions API',
+											'pinterest-for-woocommerce'
+										) }
+										help={
+											<HelpTooltip
+												text={ __(
+													'Enable server-side tracking for more reliable conversion data.',
+													'pinterest-for-woocommerce'
+												) }
+											/>
+										}
+										checked={
+											appSettings.track_conversions_capi
+										}
+										className={ classnames(
+											'woocommerce-setup-guide__checkbox-group',
+											{
+												'pinterest-for-woocommerce-settings-checkbox-disabled':
+													! appSettings.track_conversions,
+											}
+										) }
+										disabled={
+											! appSettings.track_conversions
+										}
+										onChange={ () =>
+											handleOptionChange(
+												'track_conversions_capi'
+											)
+										}
+									/>
+									<CheckboxControl
+										label={ __(
 											'Enhanced Match support',
 											'pinterest-for-woocommerce'
 										) }

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -153,7 +153,7 @@ class Auth extends VendorAPI {
 	 */
 	private function apply_oauth_flow_features( array $features ): void {
 		Pinterest_For_Woocommerce()::save_setting( 'track_conversions', $features['tags'] ?? false );
-		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', false );
+		Pinterest_For_Woocommerce()::save_setting( 'track_conversions_capi', $features['CAPI'] ?? false );
 		Pinterest_For_Woocommerce()::save_setting( 'product_sync_enabled', $features['catalog'] ?? false );
 	}
 


### PR DESCRIPTION
## Summary
- Updates OAuth flow to set track_conversions_capi from features['CAPI']
- Adds a Conversions API checkbox to the settings UI 
- Ensures CAPI can be toggled while respecting the track_conversions parent setting

## Screenshots
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/fad964e9-0796-4291-a883-66f611ee6280" />

## Test plan
1. Reset plugin settings and reconnect to Pinterest
2. During OAuth flow, verify CAPI setting is properly stored
3. Check that the Conversions API checkbox appears in settings and functions correctly
4. Verify CAPI is only enabled when Track Conversions is also enabled

🤖 Generated with [Claude Code](https://claude.ai/code)