### PR TITLE
Fix: Move CAPI disable procedure from 1.4.18 to 1.4.19

### DIFF
--- a/src/PluginUpdate.php
+++ b/src/PluginUpdate.php
@@ -137,7 +137,7 @@ class PluginUpdate {
 			'1.4.10' => array(
 				'feed_deletion_notice_cleanup',
 			),
-			'1.4.18' => array(
+			'1.4.19' => array(
 				'disable_capi_for_all_merchants',
 			),
 		);


### PR DESCRIPTION
## Summary
- Moves the `disable_capi_for_all_merchants` update procedure from version 1.4.18 to 1.4.19
- Since 1.4.18 was already released without this procedure, it needs to run in the next release

## Test plan
- [x] Verify the update procedure is correctly set for 1.4.19
- [x] Test that the procedure runs correctly during plugin update to 1.4.19

🤖 Generated with [Claude Code](https://claude.ai/code)