### PR TITLE
Reenable WP Consent API for tracking initialization

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -329,6 +329,9 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 */
 		public static function init_tracking() {
 
+			// Init WP Consent API integration.
+			new Pinterest\WPConsentAPI();
+
 			/**
 			 * Filters whether to disable tracking.
 			 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #1107.

This re-enables the WP Consent API tracking integration initialization.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. See #1107 for setup:
    - Pinterest for WooCommerce connected to Pinterest with Conversions API enabled 
    - Marketing > Pinterest > Settings > Enabled Debug Logging checked
    - WP Consent API plugin installed and activated
    - Complianz plugin installed and activated, configured with a basic consent banner using the Wizard (should have found Pinterest, etc).
    ![image](https://github.com/user-attachments/assets/6d10e261-4a2b-4645-9e1d-1a533d6efd8d)
3. Visit the store in a different browser / incognito and "Accept" the consent banner.
4. Open the Pinterest conversions log (`wp-content/uploads/wc-logs/pinterest-for-woocommerce-conversion-2025-….log`). Can use WooCommerce > Status > Logs.
5. Browse around the shop (products, add to cart, checkout, etc).
6. Confirm that the Conversions API calls appear in the log.
    - E.g., `DEBUG Sending Pinterest Conversions API event PageVisit with a payload: …`
7. Erase all `cmplz_` cookies and refresh (or start a new browsing session). 
8. Click "Deny" in the consent banner.
9. Browser around the shop again.
10. Confirm that the Conversions API calls no longer appear in the log.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Reenable WP Consent API tracking integration.
