### PR TITLE
[dev] Pin Github actions to immutable references of commits instead of tags

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # v0.4.0
         with:
           project-url: https://github.com/orgs/woocommerce/projects/117
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/build-upload-zip.yml
+++ b/.github/workflows/build-upload-zip.yml
@@ -9,17 +9,17 @@ jobs:
         steps:
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Setup node version
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
               with:
                   node-version-file: '.nvmrc'
                   cache: 'npm'
 
             - name: Restore node_modules
               id: cache-node-modules
-              uses: actions/cache@v4
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
               env:
                   cache-name: cache-node-modules
               with:
@@ -41,8 +41,8 @@ jobs:
                   npm run build:zip
 
             - name: Upload zip
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                 name: pinterest-for-woocommerce
                 path: ${{ github.workspace }}/pinterest-for-woocommerce.zip
- 
+

--- a/.github/workflows/ci-cron-qit.yml
+++ b/.github/workflows/ci-cron-qit.yml
@@ -43,7 +43,7 @@ jobs:
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
-            - uses: act10ns/slack@v2
+            - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
               with:
                   status: success
                   message: "Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed."
@@ -56,7 +56,7 @@ jobs:
       env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       steps:
-          - uses: act10ns/slack@v2
+          - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
             with:
                 status: failure
                 message: "Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed. You can find the results in the artifacts section."

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
-          - uses: act10ns/slack@v2
+          - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
             with:
                 status: success
                 message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> passed."
@@ -58,7 +58,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
-          - uses: act10ns/slack@v2
+          - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
             with:
                 status: cancelled
                 message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> cancelled."
@@ -71,7 +71,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
-          - uses: act10ns/slack@v2
+          - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
             with:
                 status: failure
                 message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> failed."

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
         uses: woocommerce/grow/prepare-node@actions-v1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
         uses: woocommerce/grow/prepare-node@actions-v1

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
         uses: woocommerce/grow/prepare-node@actions-v1

--- a/.github/workflows/manual-ci.yml
+++ b/.github/workflows/manual-ci.yml
@@ -120,7 +120,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
         with:
           status: success
           message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed."
@@ -133,7 +133,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
         with:
           status: cancelled
           message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> cancelled."
@@ -146,7 +146,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d #v2.1.0
         with:
           status: failure
           message: "Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed."

--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f # v41.0.1
         with:
           files: "**/*.php"
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create branch & PR
         uses: woocommerce/grow/prepare-extension-release@actions-v1

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -21,10 +21,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup node version and npm cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -47,4 +47,4 @@ jobs:
           exit 0
 
       # - name: Cleanup
-      #   run: wp-env stop 
+      #   run: wp-env stop

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -100,7 +100,7 @@ jobs:
               mkdir ${{ github.workspace }}/qit-results
 
           - name: Download the zip
-            uses: actions/download-artifact@v4
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
             with:
                 name: ${{ inputs.artifact }}
                 path: ${{ github.workspace }}
@@ -342,7 +342,7 @@ jobs:
 
           - name: Upload results
             if: always()
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
             with:
                 name: qit-results
                 path: ${{ github.workspace }}/qit-results/

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
         php: [7.4, 8.3]
         wp-version: [latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1

--- a/.github/workflows/setup-env.yml
+++ b/.github/workflows/setup-env.yml
@@ -7,11 +7,11 @@ jobs:
     name: Setup NodeJS and Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         env:
           cache-name: cache-node-modules
         with:
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup node version and npm cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@27853eb8b46dc01c33bf9fef67d98df2683c3be2 # v2.34.0
         with:
           php-version: '8.4'
           coverage: none
@@ -47,7 +47,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Contributes to [QAO-20](https://linear.app/a8c/issue/QAO-20/pin-version-of-tj-actionschanged-files-to-a-commit-sha), [QAO-23](https://linear.app/a8c/issue/QAO-23)
Pins the versions of Github actions to commit SHAs as immutable references.
