### PR TITLE
Add `wp_json_encode` tags for safe JS injection

### DIFF
--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -153,7 +153,7 @@ class Tag extends Tracker {
 	 * @return string A generated event call.
 	 */
 	private static function get_event_code( string $event_name, array $data ) {
-		$data_string = empty( $data ) ? null : wp_json_encode( $data );
+		$data_string = empty( $data ) ? null : wp_json_encode( $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 		return sprintf(
 			'pintrk( \'track\', \'%s\' %s);',
 			$event_name,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #PIN4WOO-57

Updates use of `wp_json_encode` to add the necessary tags to avoid parsing errors. See https://sirre.al/2025/08/06/safe-json-in-script-tags-how-not-to-break-a-site/ for more info.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install Pinterest Pixel Helper.
2. Connect your site to Pinterest, don't forget to allow conversion tag
3. Open your site in a new tab. Accept the consent, then refresh ( confirm the Pinterest Events are firing with the correct data).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Update use of `wp_json_encode` to avoid potential browser parsing issues.
