### PR TITLE
Update product catalog sync to support product_type limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "lint:js": "wp-scripts lint-js ./assets/source",
     "lint:js:fix": "wp-scripts lint-js ./assets/source --fix",
     "lint:php": "composer run-script phpcs ./",
+    "lint:php:fix": "composer run-script phpcbf",
     "start": "wp-scripts start",
     "test:js": "wp-scripts test-unit-js --coverage",
     "test:js:watch": "npm run test:js -- --watch",

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -311,8 +311,7 @@ class ProductsXmlFeed {
 		$original_count = count( $taxonomies );
 		if ( $original_count > self::PRODUCT_TYPE_CATEGORIES_LIMIT ) {
 			$taxonomies = array_slice( $taxonomies, 0, self::PRODUCT_TYPE_CATEGORIES_LIMIT );
-			/* translators: 1: product id, 2: original category count, 3: limit */
-			Logger::log( sprintf( esc_html__( 'Product [%1$s] has %2$d categories, limiting to first %3$d as per Pinterest requirements.', 'pinterest-for-woocommerce' ), $id, $original_count, self::PRODUCT_TYPE_CATEGORIES_LIMIT ) );
+			Logger::log( sprintf( 'Product [%1$s] has %2$d categories, limiting to first %3$d as per Pinterest requirements.', $id, $original_count, self::PRODUCT_TYPE_CATEGORIES_LIMIT ) );
 		}
 
 		// Build product_type string.
@@ -320,8 +319,7 @@ class ProductsXmlFeed {
 
 		// Ensure product_type doesn't exceed 1000 character limit.
 		if ( strlen( $product_type ) > self::PRODUCT_TYPE_CHARS_LIMIT ) {
-			/* translators: 1: product id, 2: original length, 3: limit */
-			Logger::log( sprintf( esc_html__( 'Product [%1$s] product_type length is %2$d characters, truncating to %3$d characters as per Pinterest requirements.', 'pinterest-for-woocommerce' ), $id, strlen( $product_type ), self::PRODUCT_TYPE_CHARS_LIMIT ) );
+			Logger::log( sprintf( 'Product [%1$s] product_type length is %2$d characters, truncating to %3$d characters as per Pinterest requirements.', $id, strlen( $product_type ), self::PRODUCT_TYPE_CHARS_LIMIT ) );
 
 			// Build product_type by adding taxonomies until we hit the character limit, we always include the first taxonomy.
 			$product_type = '';

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -270,6 +270,7 @@ class ProductsXmlFeed {
 		 *
 		 * @param bool       $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
 		 * @param WC_Product $product          WooCommerce product object.
+		 *
 		 * phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		 */
 		$apply_shortcodes = apply_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes', false, $product );
@@ -321,13 +322,13 @@ class ProductsXmlFeed {
 		if ( strlen( $product_type ) > self::PRODUCT_TYPE_CHARS_LIMIT ) {
 			/* translators: 1: product id, 2: original length, 3: limit */
 			Logger::log( sprintf( esc_html__( 'Product [%1$s] product_type length is %2$d characters, truncating to %3$d characters as per Pinterest requirements.', 'pinterest-for-woocommerce' ), $id, strlen( $product_type ), self::PRODUCT_TYPE_CHARS_LIMIT ) );
-			
+
 			// Build product_type by adding taxonomies until we hit the character limit, we always include the first taxonomy.
 			$product_type = '';
 			foreach ( $taxonomies as $index => $taxonomy ) {
-				$separator = $index > 0 ? ' &gt; ' : '';
+				$separator        = $index > 0 ? ' &gt; ' : '';
 				$new_product_type = $product_type . $separator . $taxonomy;
-				
+
 				if ( strlen( $new_product_type ) > self::PRODUCT_TYPE_CHARS_LIMIT && $index > 0 ) {
 					break;
 				}
@@ -370,8 +371,8 @@ class ProductsXmlFeed {
 	 */
 	private static function add_utm_parameters( $product_url ) {
 		$utm_params = array(
-			'utm_source'   => 'pinterest',
-			'utm_medium'   => 'social',
+			'utm_source' => 'pinterest',
+			'utm_medium' => 'social',
 		);
 
 		return add_query_arg( $utm_params, $product_url );
@@ -555,11 +556,11 @@ class ProductsXmlFeed {
 		/*
 		 * Entry is a one or multiple XML nodes in the following format:
 		 *  <g:shipping>
-		 *		<g:country>...</g:country>
-		 *		<g:region>...</g:region>
-		 *		<g:service>...</g:service>
-		 *		<g:price>...</g:price>
-		 *	</g:shipping>
+		 *      <g:country>...</g:country>
+		 *      <g:region>...</g:region>
+		 *      <g:service>...</g:service>
+		 *      <g:price>...</g:price>
+		 *  </g:shipping>
 		 */
 		foreach ( $shipping_info as $info ) {
 			$shipping_name    = self::sanitize( $info['name'] );

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -69,6 +69,20 @@ class ProductsXmlFeed {
 	 */
 	const ADDITIONAL_IMAGES_LIMIT = 10;
 
+	/**
+	 * Limit of categories allowed by Pinterest in the product_type.
+	 *
+	 * @var int
+	 */
+	const PRODUCT_TYPE_CATEGORIES_LIMIT = 5;
+
+	/**
+	 * Limit of characters allowed by Pinterest in the product_type.
+	 *
+	 * @var int
+	 */
+	const PRODUCT_TYPE_CHARS_LIMIT = 1000;
+
 
 	/**
 	 * Returns the XML header to be printed.
@@ -292,7 +306,36 @@ class ProductsXmlFeed {
 			return;
 		}
 
-		return '<' . $property . '>' . implode( ' &gt; ', $taxonomies ) . '</' . $property . '>';
+		// Limit to first 5 categories as per Pinterest requirements.
+		$original_count = count( $taxonomies );
+		if ( $original_count > self::PRODUCT_TYPE_CATEGORIES_LIMIT ) {
+			$taxonomies = array_slice( $taxonomies, 0, self::PRODUCT_TYPE_CATEGORIES_LIMIT );
+			/* translators: 1: product id, 2: original category count, 3: limit */
+			Logger::log( sprintf( esc_html__( 'Product [%1$s] has %2$d categories, limiting to first %3$d as per Pinterest requirements.', 'pinterest-for-woocommerce' ), $id, $original_count, self::PRODUCT_TYPE_CATEGORIES_LIMIT ) );
+		}
+
+		// Build product_type string.
+		$product_type = implode( ' &gt; ', $taxonomies );
+
+		// Ensure product_type doesn't exceed 1000 character limit.
+		if ( strlen( $product_type ) > self::PRODUCT_TYPE_CHARS_LIMIT ) {
+			/* translators: 1: product id, 2: original length, 3: limit */
+			Logger::log( sprintf( esc_html__( 'Product [%1$s] product_type length is %2$d characters, truncating to %3$d characters as per Pinterest requirements.', 'pinterest-for-woocommerce' ), $id, strlen( $product_type ), self::PRODUCT_TYPE_CHARS_LIMIT ) );
+			
+			// Build product_type by adding taxonomies until we hit the character limit, we always include the first taxonomy.
+			$product_type = '';
+			foreach ( $taxonomies as $index => $taxonomy ) {
+				$separator = $index > 0 ? ' &gt; ' : '';
+				$new_product_type = $product_type . $separator . $taxonomy;
+				
+				if ( strlen( $new_product_type ) > self::PRODUCT_TYPE_CHARS_LIMIT && $index > 0 ) {
+					break;
+				}
+				$product_type = $new_product_type;
+			}
+		}
+
+		return '<' . $property . '>' . $product_type . '</' . $property . '>';
 	}
 
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -885,8 +885,8 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Create categories with long names to exceed 1000 character limit.
 		// Each category name is 300 chars, so 4 categories = 1200 chars + separators.
 		$category_ids = array();
-		for ( $i = 1; $i <= 4; $i++ ) {
-			$long_name      = str_repeat( "LongCategoryName{$i}_", 15 ); // ~300 chars each.
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$long_name      = str_repeat( "LongCategoryName{$i}_", 11 ); // ~242 chars each.
 			$category       = wp_insert_term( $long_name, 'product_cat' );
 			$category_ids[] = $category['term_id'];
 		}
@@ -905,61 +905,6 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertLessThanOrEqual( 1000, strlen( $product_type_decoded ) );
 
 		// Check that a warning was logged.
-		$this->assertStringContainsString( 'product_type length is', $mock_logger::$message );
-		$this->assertStringContainsString( 'truncating to 1000 characters', $mock_logger::$message );
-	}
-
-	/**
-	 * Test that first category is always included even if it exceeds 1000 characters
-	 *
-	 * @group feed
-	 */
-	public function testProductTypeIncludesFirstCategoryEvenIfTooLong() {
-		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
-		$product             = WC_Helper_Product::create_simple_product();
-
-		/**
-		 * Mock logger object that will catch any logged messages.
-		 */
-		$mock_logger = new class() {
-
-			/**
-			 * The message to log.
-			 *
-			 * @var string
-			 */
-			public static $message = '';
-			/**
-			 * Log the message.
-			 *
-			 * @param string $level The level of the message.
-			 * @param string $msg The message to log.
-			 */
-			public function log( $level, $msg ) {
-				self::$message = $msg;
-			}
-		};
-
-		Logger::$logger = $mock_logger;
-
-		// Create a first category that is over 1000 characters.
-		$very_long_name = str_repeat( 'VeryLongFirstCategoryName_', 50 ); // Over 1000 chars.
-		$category       = wp_insert_term( $very_long_name, 'product_cat' );
-		wp_set_object_terms( $product->get_id(), array( $category['term_id'] ), 'product_cat' );
-
-		$xml = $product_type_method( $product );
-
-		// Extract the product_type value from the XML.
-		preg_match( '/<g:product_type>(.*?)<\/g:product_type>/', $xml, $matches );
-		$product_type = $matches[1] ?? '';
-
-		// Decode HTML entities to get the actual length.
-		$product_type_decoded = html_entity_decode( $product_type );
-
-		// Should contain the very long first category name
-		$this->assertStringContainsString( $very_long_name, $product_type_decoded );
-
-		// Check that a warning was logged about length
 		$this->assertStringContainsString( 'product_type length is', $mock_logger::$message );
 		$this->assertStringContainsString( 'truncating to 1000 characters', $mock_logger::$message );
 	}

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -348,24 +348,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class() {
-
-			/**
-			 * The message to log.
-			 *
-			 * @var string
-			 */
-			public static $message = '';
-			/**
-			 * Log the message.
-			 *
-			 * @param string $level The level of the message.
-			 * @param string $msg The message to log.
-			 */
-			public function log( $level, $msg ) {
-				self::$message = $msg;
-			}
-		};
+		$mock_logger = $this->getMockLogger();
 
 		Logger::$logger = $mock_logger;
 
@@ -784,19 +767,36 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Remove filters and shortcodes.
+	 * Gets a mock logger for testing.
+	 *
+	 * @return object Mock logger instance
 	 */
-	public function tearDown(): void {
-		parent::tearDown();
+	private function getMockLogger() {
+		return new class() {
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 
-		// Remove any added filter.
-		remove_all_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes' );
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				self::$message = '';
+			}
 
-		// Remove added shortcodes.
-		remove_shortcode( 'pinterest_for_woocommerce_sample_test_shortcode' );
-
-		// Reset logger.
-		Logger::$logger = null;
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
+				self::$message = $msg;
+			}
+		};
 	}
 
 	/**
@@ -811,24 +811,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class() {
-
-			/**
-			 * The message to log.
-			 *
-			 * @var string
-			 */
-			public static $message = '';
-			/**
-			 * Log the message.
-			 *
-			 * @param string $level The level of the message.
-			 * @param string $msg The message to log.
-			 */
-			public function log( $level, $msg ) {
-				self::$message = $msg;
-			}
-		};
+		$mock_logger = $this->getMockLogger();
 
 		Logger::$logger = $mock_logger;
 
@@ -861,24 +844,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class() {
-
-			/**
-			 * The message to log.
-			 *
-			 * @var string
-			 */
-			public static $message = '';
-			/**
-			 * Log the message.
-			 *
-			 * @param string $level The level of the message.
-			 * @param string $msg The message to log.
-			 */
-			public function log( $level, $msg ) {
-				self::$message = $msg;
-			}
-		};
+		$mock_logger = $this->getMockLogger();
 
 		Logger::$logger = $mock_logger;
 
@@ -921,24 +887,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class() {
-
-			/**
-			 * The message to log.
-			 *
-			 * @var string
-			 */
-			public static $message = '';
-			/**
-			 * Log the message.
-			 *
-			 * @param string $level The level of the message.
-			 * @param string $msg The message to log.
-			 */
-			public function log( $level, $msg ) {
-				self::$message = $msg;
-			}
-		};
+		$mock_logger = $this->getMockLogger();
 
 		Logger::$logger = $mock_logger;
 
@@ -971,5 +920,21 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		}
 
 		return $taxable_location;
+	}
+
+	/**
+	 * Remove filters and shortcodes.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Remove any added filter.
+		remove_all_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes' );
+
+		// Remove added shortcodes.
+		remove_shortcode( 'pinterest_for_woocommerce_sample_test_shortcode' );
+
+		// Reset logger.
+		Logger::$logger = null;
 	}
 }

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -350,7 +350,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		 */
 		$mock_logger = new class() {
 
-			static $message = '';
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 			/**
 			 * Log the message.
 			 *
@@ -808,7 +813,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		 */
 		$mock_logger = new class() {
 
-			static $message = '';
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 			/**
 			 * Log the message.
 			 *
@@ -853,7 +863,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		 */
 		$mock_logger = new class() {
 
-			static $message = '';
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 			/**
 			 * Log the message.
 			 *
@@ -908,7 +923,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		 */
 		$mock_logger = new class() {
 
-			static $message = '';
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 			/**
 			 * Log the message.
 			 *
@@ -958,7 +978,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		 */
 		$mock_logger = new class() {
 
-			static $message = '';
+			/**
+			 * The message to log.
+			 *
+			 * @var string
+			 */
+			public static $message = '';
 			/**
 			 * Log the message.
 			 *

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -792,6 +792,181 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that product_type is limited to 5 categories
+	 *
+	 * @group feed
+	 */
+	public function testProductTypeLimitToFiveCategories() {
+		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
+		$product             = WC_Helper_Product::create_simple_product();
+
+		/**
+		 * Mock logger object that will catch any logged messages.
+		 */
+		$mock_logger = new class {
+
+			static $message = '';
+			public function log( $level, $msg )
+			{
+				self::$message = $msg;
+			}
+		};
+
+		Logger::$logger = $mock_logger;
+
+		// Create 7 categories and assign them to the product.
+		$category_ids = array();
+		for ( $i = 1; $i <= 7; $i++ ) {
+			$category = wp_insert_term( "Category {$i}", 'product_cat' );
+			$category_ids[] = $category['term_id'];
+		}
+		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+
+		$xml = $product_type_method( $product );
+
+		// Should only have first 5 categories.
+		$this->assertEquals( '<g:product_type>Category 1 &gt; Category 2 &gt; Category 3 &gt; Category 4 &gt; Category 5</g:product_type>', $xml );
+
+		// Check that a warning was logged.
+		$this->assertStringContainsString( 'has 7 categories, limiting to first 5', $mock_logger::$message );
+	}
+
+	/**
+	 * Test that product_type is limited to 1000 characters
+	 *
+	 * @group feed
+	 */
+	public function testProductTypeCharacterLimit() {
+		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
+		$product             = WC_Helper_Product::create_simple_product();
+
+		/**
+		 * Mock logger object that will catch any logged messages.
+		 */
+		$mock_logger = new class {
+
+			static $message = '';
+			public function log( $level, $msg )
+			{
+				self::$message = $msg;
+			}
+		};
+
+		Logger::$logger = $mock_logger;
+
+		// Create categories with long names to exceed 1000 character limit.
+		// Each category name is 300 chars, so 4 categories = 1200 chars + separators.
+		$category_ids = array();
+		for ( $i = 1; $i <= 4; $i++ ) {
+			$long_name = str_repeat( "LongCategoryName{$i}_", 15 ); // ~300 chars each.
+			$category = wp_insert_term( $long_name, 'product_cat' );
+			$category_ids[] = $category['term_id'];
+		}
+		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+
+		$xml = $product_type_method( $product );
+
+		// Extract the product_type value from the XML.
+		preg_match( '/<g:product_type>(.*?)<\/g:product_type>/', $xml, $matches );
+		$product_type = $matches[1] ?? '';
+
+		// Decode HTML entities to get the actual length.
+		$product_type_decoded = html_entity_decode( $product_type );
+
+		// Should be under 1000 characters.
+		$this->assertLessThanOrEqual( 1000, strlen( $product_type_decoded ) );
+
+		// Check that a warning was logged.
+		$this->assertStringContainsString( 'product_type length is', $mock_logger::$message );
+		$this->assertStringContainsString( 'truncating to 1000 characters', $mock_logger::$message );
+	}
+
+	/**
+	 * Test that first category is always included even if it exceeds 1000 characters
+	 *
+	 * @group feed
+	 */
+	public function testProductTypeIncludesFirstCategoryEvenIfTooLong() {
+		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
+		$product             = WC_Helper_Product::create_simple_product();
+
+		/**
+		 * Mock logger object that will catch any logged messages.
+		 */
+		$mock_logger = new class {
+
+			static $message = '';
+			public function log( $level, $msg )
+			{
+				self::$message = $msg;
+			}
+		};
+
+		Logger::$logger = $mock_logger;
+
+		// Create a first category that is over 1000 characters
+		$very_long_name = str_repeat( "VeryLongFirstCategoryName_", 50 ); // Over 1000 chars
+		$category = wp_insert_term( $very_long_name, 'product_cat' );
+		wp_set_object_terms( $product->get_id(), array( $category['term_id'] ), 'product_cat' );
+
+		$xml = $product_type_method( $product );
+
+		// Extract the product_type value from the XML.
+		preg_match( '/<g:product_type>(.*?)<\/g:product_type>/', $xml, $matches );
+		$product_type = $matches[1] ?? '';
+
+		// Decode HTML entities to get the actual length.
+		$product_type_decoded = html_entity_decode( $product_type );
+
+		// Should contain the very long first category name
+		$this->assertStringContainsString( $very_long_name, $product_type_decoded );
+
+		// Check that a warning was logged about length
+		$this->assertStringContainsString( 'product_type length is', $mock_logger::$message );
+		$this->assertStringContainsString( 'truncating to 1000 characters', $mock_logger::$message );
+	}
+
+	/**
+	 * Test that product_type with exactly 5 categories doesn't trigger warning
+	 *
+	 * @group feed
+	 */
+	public function testProductTypeWithFiveCategoriesNoWarning() {
+		$product_type_method = $this->getProductsXmlFeedAttributeMethod( 'g:product_type' );
+		$product             = WC_Helper_Product::create_simple_product();
+
+		/**
+		 * Mock logger object that will catch any logged messages.
+		 */
+		$mock_logger = new class {
+
+			static $message = '';
+			public function log( $level, $msg )
+			{
+				self::$message = $msg;
+			}
+		};
+
+		Logger::$logger = $mock_logger;
+
+		// Create exactly 5 categories.
+		$category_ids = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$category = wp_insert_term( "Category {$i}", 'product_cat' );
+			$category_ids[] = $category['term_id'];
+		}
+		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
+
+		$xml = $product_type_method( $product );
+
+		// Should have all 5 categories.
+		$this->assertEquals( '<g:product_type>Category 1 &gt; Category 2 &gt; Category 3 &gt; Category 4 &gt; Category 5</g:product_type>', $xml );
+
+		// No warning should be logged for exactly 5 categories.
+		$this->assertEquals( '', $mock_logger::$message );
+	}
+
+	/**
 	 * Mimic the method on FeedGenerator.
 	 *
 	 * @param array $taxable_location The taxable location to filter.

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -28,11 +28,11 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	public function testHeader() {
 		$actual_header = ProductsXmlFeed::get_xml_header();
 		$this->assertEquals(
-		"<?xml version=\"1.0\"?>
-<rss version=\"2.0\" xmlns:g=\"http://base.google.com/ns/1.0\">
+			'<?xml version="1.0"?>
+<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">
 	<channel>
-",
-		$actual_header
+',
+			$actual_header
 		);
 	}
 
@@ -42,9 +42,9 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	public function testFooter() {
 		$actual_footer = ProductsXmlFeed::get_xml_footer();
 		$this->assertEquals(
-		"	</channel>
-</rss>",
-		$actual_footer
+			'	</channel>
+</rss>',
+			$actual_footer
 		);
 	}
 
@@ -56,7 +56,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	 * @group feed
 	 */
 	public function testSimpleProductXmlItem() {
-		$product  = WC_Helper_Product::create_simple_product(
+		$product = WC_Helper_Product::create_simple_product(
 			true,
 			array(
 				'sku' => 'DUMMY SKU',
@@ -64,16 +64,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		);
 
 		// We need header and footer so we can process XML directly.
-		$xml      = ProductsXmlFeed::get_xml_header();
-		$xml     .= ProductsXmlFeed::get_xml_item( $product, 'US' );
-		$xml     .= ProductsXmlFeed::get_xml_footer();
+		$xml  = ProductsXmlFeed::get_xml_header();
+		$xml .= ProductsXmlFeed::get_xml_item( $product, 'US' );
+		$xml .= ProductsXmlFeed::get_xml_footer();
 
-		$simplex_object = simplexml_load_string( $xml, "SimpleXMLElement", LIBXML_NOCDATA );
+		$simplex_object = simplexml_load_string( $xml, 'SimpleXMLElement', LIBXML_NOCDATA );
 		$children       = (array) $simplex_object->channel->item->children();
-		$g_children     = (array) $simplex_object->channel->item->children( "g", true ); // Child nodes that are prefixed.
+		$g_children     = (array) $simplex_object->channel->item->children( 'g', true ); // Child nodes that are prefixed.
 
 		// Id value 0 comes from WC_Helper_Product.
-		$this->assertEquals( $product->get_id(), $g_children['id']);
+		$this->assertEquals( $product->get_id(), $g_children['id'] );
 
 		// Not a variation so no item group id.
 		$this->assertArrayNotHasKey( 'item_group_id', $children, 'Simple products should not have the item_group_id set.' );
@@ -100,10 +100,10 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( '10.00USD', $g_children['price'] );
 
 		// No description set.
-		$this->assertArrayNotHasKey( 'image_link', $g_children, "By default product does not have an image link." );
+		$this->assertArrayNotHasKey( 'image_link', $g_children, 'By default product does not have an image link.' );
 
 		// No sale price set.
-		$this->assertArrayNotHasKey( 'sale_price', $children, "By default product does not have a sale price." );
+		$this->assertArrayNotHasKey( 'sale_price', $children, 'By default product does not have a sale price.' );
 
 		// Dummy SKU from WC_Helper_Product
 		$this->assertEquals( 'DUMMY SKU', $g_children['mpn'] );
@@ -146,8 +146,8 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
 
 		// No description set.
-		$product  = WC_Helper_Product::create_simple_product();
-		$xml      = $description_method( $product );
+		$product = WC_Helper_Product::create_simple_product();
+		$xml     = $description_method( $product );
 		$this->assertEquals( '', $xml );
 
 		$desc = 'Test description.';
@@ -155,10 +155,10 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$product_with_description = WC_Helper_Product::create_simple_product(
 			true,
 			array(
-				'short_description' => $desc
+				'short_description' => $desc,
 			)
 		);
-		$xml = $description_method( $product_with_description );
+		$xml                      = $description_method( $product_with_description );
 		$this->assertEquals( "<description><![CDATA[{$desc}]]></description>", $xml );
 	}
 
@@ -169,12 +169,12 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
 
 		// By passing manually created Variable Product the create_variation_product will add children to it.
-		$product            = new WC_Product_Variable();
-		$variation_product  = WC_Helper_Product::create_variation_product( $product );
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
 		// create_variation_product creates multiple children, picking up the first one
-		$child_id           = $variation_product->get_children()[0];
-		$child_product      = wc_get_product( $child_id );
-		$xml                = $description_method( $child_product );
+		$child_id      = $variation_product->get_children()[0];
+		$child_product = wc_get_product( $child_id );
+		$xml           = $description_method( $child_product );
 
 		/*
 		 * With no description set the code will use the excerpt.
@@ -186,7 +186,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Get the next variable product for tests with description set.
 		$child_id      = $variation_product->get_children()[1];
 		$child_product = wc_get_product( $child_id );
-		$desc = 'Test description.';
+		$desc          = 'Test description.';
 		$child_product->set_description( $desc );
 		$child_product->save();
 		$xml = $description_method( $child_product );
@@ -318,7 +318,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Add filter to apply shortcodes on description.
 		add_filter(
 			'pinterest_for_woocommerce_product_description_apply_shortcodes',
-			function() {
+			function () {
 				return true;
 			}
 		);
@@ -348,11 +348,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class {
+		$mock_logger = new class() {
 
 			static $message = '';
-			public function log( $level, $msg )
-			{
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
 				self::$message = $msg;
 			}
 		};
@@ -429,7 +434,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( '', $xml );
 
 		// Add dummy image entry.
-		$attachment = array(
+		$attachment    = array(
 			'post_mime_type' => 'image/png',
 			'post_title'     => 'product image',
 		);
@@ -471,10 +476,9 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	 */
 	public function testPropertyPriceXML() {
 		$price_method = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
-		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
+		$product      = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 15 ) );
 		$xml          = $price_method( $product );
 		$this->assertEquals( '<g:price>15.00USD</g:price>', $xml );
-
 
 		// Test if the price excludes taxes.
 		$old_tax_display_option = get_option( 'woocommerce_tax_display_shop' );
@@ -484,7 +488,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$price_decimals_method->setAccessible( true );
 		$price_decimals = $price_decimals_method->invoke( null );
 
-		$product_price = wc_get_price_excluding_tax(
+		$product_price   = wc_get_price_excluding_tax(
 			$product,
 			array(
 				'price' => $product->get_regular_price(),
@@ -499,7 +503,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$old_currency = get_woocommerce_currency();
 		update_option( 'woocommerce_currency', 'JPY' );
 		$price_method = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
-		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
+		$product      = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 15 ) );
 		$xml          = $price_method( $product );
 		$this->assertEquals( '<g:price>15JPY</g:price>', $xml );
 
@@ -514,7 +518,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$sale_price_method = $this->getProductsXmlFeedAttributeMethod( 'sale_price' );
 
 		// No sale price is set.
-		$product = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
+		$product = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 15 ) );
 		$xml     = $sale_price_method( $product );
 		$this->assertEquals( '', $xml );
 
@@ -529,7 +533,6 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$xml     = $sale_price_method( $product );
 		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $xml );
 
-
 		// Test if the price excludes taxes.
 		$old_tax_display_option = get_option( 'woocommerce_tax_display_shop' );
 		update_option( 'woocommerce_tax_display_shop', 'excl' );
@@ -538,7 +541,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$price_decimals_method->setAccessible( true );
 		$price_decimals = $price_decimals_method->invoke( null );
 
-		$product_price = wc_get_price_excluding_tax(
+		$product_price   = wc_get_price_excluding_tax(
 			$product,
 			array(
 				'price' => $product->get_sale_price(),
@@ -574,7 +577,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	 */
 	public function testPropertyPriceWithTaxesXML() {
 		$price_method = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
-		$product      = WC_Helper_Product::create_simple_product( true, array( "regular_price" => 15 ) );
+		$product      = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 15 ) );
 
 		// Setup shipping.
 		$zone = ShippingHelpers::createZoneWithLocations(
@@ -638,9 +641,9 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$product    = WC_Helper_Product::create_simple_product(
 			true,
 			array(
-				'sku' => "invalid&sku"
+				'sku' => 'invalid&sku',
 			)
-		 );
+		);
 		$xml        = $mpn_method( $product );
 		$this->assertEquals( '<g:mpn>invalid&amp;sku</g:mpn>', $xml );
 	}
@@ -657,7 +660,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( '', $xml );
 
 		// Add dummy image entry.
-		$attachment = array(
+		$attachment      = array(
 			'post_mime_type' => 'image/png',
 			'post_title'     => 'product image 1',
 		);
@@ -673,7 +676,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$attachment_id_2 = wp_insert_attachment( $attachment, 'product_image_2.png', $product->get_id() );
 
 		// Add attachment id as product image id.
-		$product->set_gallery_image_ids( [ $attachment_id_1, $attachment_id_2 ] );
+		$product->set_gallery_image_ids( array( $attachment_id_1, $attachment_id_2 ) );
 		$product->save();
 
 		$xml = $additional_image_link_method( $product );
@@ -688,7 +691,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$xml = $method->invoke( null, $product, '' );
+		$xml     = $method->invoke( null, $product, '' );
 		// No attributes set, output should be empty.
 		$this->assertEquals( '', $xml );
 
@@ -712,16 +715,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$product = WC_Helper_Product::create_simple_product();
-		$xml = $method->invoke( null, $product, '' );
+		$xml     = $method->invoke( null, $product, '' );
 		// No attributes set, output should be empty.
 		$this->assertEquals( '', $xml );
 
 		$full_category_name_method = new ReflectionMethod( GoogleCategorySearch::class, 'full_category_name' );
 		$full_category_name_method->setAccessible( true );
-		$taxonomy                  = GoogleProductTaxonomy::TAXONOMY[502979]; // Randomly selected category - i just made sure that it has parent.
-		$full_taxonomy_name        = $full_category_name_method->invoke( new GoogleCategorySearch(), $taxonomy );
-		$condition                 = new GoogleCategory( $full_taxonomy_name );
-		$attribute_manager         = AttributeManager::instance();
+		$taxonomy           = GoogleProductTaxonomy::TAXONOMY[502979]; // Randomly selected category - i just made sure that it has parent.
+		$full_taxonomy_name = $full_category_name_method->invoke( new GoogleCategorySearch(), $taxonomy );
+		$condition          = new GoogleCategory( $full_taxonomy_name );
+		$attribute_manager  = AttributeManager::instance();
 		$attribute_manager->update( $product, $condition );
 
 		$xml = $method->invoke( null, $product, '' );
@@ -751,7 +754,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 				$xml
 			);
 
-			$this->assertTrue( ( bool ) $bytes_written );
+			$this->assertTrue( (bool) $bytes_written );
 
 			break;
 		}
@@ -770,7 +773,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$method      = $class->getMethod( $method_name );
 		$method->setAccessible( true );
 
-		return function( $product ) use ( $method, $attribute ) {
+		return function ( $product ) use ( $method, $attribute ) {
 			return $method->invoke( null, $product, $attribute );
 		};
 	}
@@ -803,11 +806,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class {
+		$mock_logger = new class() {
 
 			static $message = '';
-			public function log( $level, $msg )
-			{
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
 				self::$message = $msg;
 			}
 		};
@@ -817,7 +825,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Create 7 categories and assign them to the product.
 		$category_ids = array();
 		for ( $i = 1; $i <= 7; $i++ ) {
-			$category = wp_insert_term( "Category {$i}", 'product_cat' );
+			$category       = wp_insert_term( "Category {$i}", 'product_cat' );
 			$category_ids[] = $category['term_id'];
 		}
 		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
@@ -843,11 +851,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class {
+		$mock_logger = new class() {
 
 			static $message = '';
-			public function log( $level, $msg )
-			{
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
 				self::$message = $msg;
 			}
 		};
@@ -858,8 +871,8 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Each category name is 300 chars, so 4 categories = 1200 chars + separators.
 		$category_ids = array();
 		for ( $i = 1; $i <= 4; $i++ ) {
-			$long_name = str_repeat( "LongCategoryName{$i}_", 15 ); // ~300 chars each.
-			$category = wp_insert_term( $long_name, 'product_cat' );
+			$long_name      = str_repeat( "LongCategoryName{$i}_", 15 ); // ~300 chars each.
+			$category       = wp_insert_term( $long_name, 'product_cat' );
 			$category_ids[] = $category['term_id'];
 		}
 		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
@@ -893,20 +906,25 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class {
+		$mock_logger = new class() {
 
 			static $message = '';
-			public function log( $level, $msg )
-			{
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
 				self::$message = $msg;
 			}
 		};
 
 		Logger::$logger = $mock_logger;
 
-		// Create a first category that is over 1000 characters
-		$very_long_name = str_repeat( "VeryLongFirstCategoryName_", 50 ); // Over 1000 chars
-		$category = wp_insert_term( $very_long_name, 'product_cat' );
+		// Create a first category that is over 1000 characters.
+		$very_long_name = str_repeat( 'VeryLongFirstCategoryName_', 50 ); // Over 1000 chars.
+		$category       = wp_insert_term( $very_long_name, 'product_cat' );
 		wp_set_object_terms( $product->get_id(), array( $category['term_id'] ), 'product_cat' );
 
 		$xml = $product_type_method( $product );
@@ -938,11 +956,16 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		/**
 		 * Mock logger object that will catch any logged messages.
 		 */
-		$mock_logger = new class {
+		$mock_logger = new class() {
 
 			static $message = '';
-			public function log( $level, $msg )
-			{
+			/**
+			 * Log the message.
+			 *
+			 * @param string $level The level of the message.
+			 * @param string $msg The message to log.
+			 */
+			public function log( $level, $msg ) {
 				self::$message = $msg;
 			}
 		};
@@ -952,7 +975,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// Create exactly 5 categories.
 		$category_ids = array();
 		for ( $i = 1; $i <= 5; $i++ ) {
-			$category = wp_insert_term( "Category {$i}", 'product_cat' );
+			$category       = wp_insert_term( "Category {$i}", 'product_cat' );
 			$category_ids[] = $category['term_id'];
 		}
 		wp_set_object_terms( $product->get_id(), $category_ids, 'product_cat' );
@@ -979,6 +1002,4 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		return $taxable_location;
 	}
-
 }
-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #PIN4WOO-55

This updates the `product_type` sync logic to limit it to 5 categories and a 1000 character limit.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. First load the main plugin or `develop` and create a product with more then 5 categories, or update an existing product with more then 5 categories.
2. Go to your Pinterest Catalog and it should show a warning that `product_type can only contain five elements separated by >`
3. Now load this branch and make an update to the product so that the XML re-generates ( you can check the `XML feed` status here and see if it is updated: `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fcatalog`
4. It should now limit to the first 5 categories
5. Go back to the Pinterest Catalog and see if the warning disappears ( I am not sure how long this takes )

**1000 character limit test**
1. Follow the instructions above, but instead add 5 categories of 240 characters or more ( WP may have a 250 character limit ). This will go over the 1000 character limit.
2. In this branch it will remove the 5th category to stay under the 1000 character limit. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Issue where `product_type` include more then 5 categories if a product included more.
