### PR TITLE
Fix feed file cleanup on deactivation

### DIFF
--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -134,26 +134,26 @@ register_activation_hook(
 	}
 );
 
-// Register deactivation hook.
+/**
+ * Handle plugin deregistration.
+ */
+function pinterest_for_woocommerce_deregister() {
+	Automattic\WooCommerce\Pinterest\ProductSync::deregister();
+	Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
+	Automattic\WooCommerce\Pinterest\ProductFeedStatus::deregister();
+	Pinterest_For_Woocommerce::disconnect();
+}
+
+// Register deactivation hook for this plugin.
 register_deactivation_hook(
 	PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE,
-	function () {
-		Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
-		Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
-		Automattic\WooCommerce\Pinterest\FeedGenerator::deregister();
-		Pinterest_For_Woocommerce::disconnect();
-	}
+	'pinterest_for_woocommerce_deregister'
 );
 
 // Register deactivation hook for WooCommerce.
 if ( defined( 'WC_PLUGIN_FILE' ) ) {
 	register_deactivation_hook(
 		WC_PLUGIN_FILE,
-		function () {
-			Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
-			Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
-			Automattic\WooCommerce\Pinterest\FeedGenerator::deregister();
-			Pinterest_For_Woocommerce::disconnect();
-		}
+		'pinterest_for_woocommerce_deregister'
 	);
 }

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -140,6 +140,7 @@ register_deactivation_hook(
 	function () {
 		Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
 		Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
+		Automattic\WooCommerce\Pinterest\FeedGenerator::deregister();
 		Pinterest_For_Woocommerce::disconnect();
 	}
 );
@@ -151,6 +152,7 @@ if ( defined( 'WC_PLUGIN_FILE' ) ) {
 		function () {
 			Automattic\WooCommerce\Pinterest\ProductSync::cancel_jobs();
 			Automattic\WooCommerce\Pinterest\Heartbeat::cancel_jobs();
+			Automattic\WooCommerce\Pinterest\FeedGenerator::deregister();
 			Pinterest_For_Woocommerce::disconnect();
 		}
 	);

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -203,7 +203,7 @@ class ProductSync {
 	 *
 	 * @return void
 	 */
-	private static function deregister() {
+	public static function deregister() {
 		FeedGenerator::deregister();
 		LocalFeedConfigs::deregister();
 		FeedRegistration::deregister();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes PIN4WOO63.

[Smoke tests](https://github.com/woocommerce/pinterest-for-woocommerce/wiki/Smoke-Tests#50-products-catalog-page) say the feed file is deleted on deactivation, but it wasn't working. This adds feed file deletion when Pinterest or WooCommerce are deactivated.



### Detailed test instructions:

1. Connect to a Pinterest account (doesn't have to be approved).
2. Confirm feed file is generated: `/wp-content/pinterest-for-woocommerce-….xml`
3. Deactivate the Pinterest plugin.
4. Confirm feed file has been deleted.


### Additional details:
The random string appended to the feed file is changed when the plugin is activated, so feed files with that string are no longer updated.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Remove feed file on deactivation.
