### PR TITLE
Add basic wp-env config and ingore wp-env override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 coverage
 phplint.cache
 .phpunit.result.cache
+.wp-env.override.json
 
 # Ignore assets except source files
 assets/*

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,11 @@
+{
+	"core": "https://wordpress.org/wordpress-latest.zip",
+	"phpVersion": "7.4",
+	"plugins": [ "." ],
+	"config": {
+		"JETPACK_AUTOLOAD_DEV": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"ALTERNATE_WP_CRON": true
+	}
+}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"core": "https://wordpress.org/wordpress-latest.zip",
 	"phpVersion": "7.4",
-	"plugins": [ "." ],
+	"plugins": ["https://downloads.wordpress.org/plugin/woocommerce.zip", "."],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,
 		"WP_DEBUG_LOG": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds simple `wp-env` config and adds the override config to `.gitignore`

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install wp-env: `npm -g i @wordpress/env`
2. Run `wp-env start`
3. Make sure PInterest and WooCommerce are loaded in the `wp-env` environment.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add `wp-env` config.
