### PR TITLE
v1.4.23 Trunk -> Develop

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.4.23 - 2025-11-24 =
+* Fix - Remove feed file on deactivation.
+* Tweak - WC 10.4 compatibility.
+* Tweak - WP 6.9 compatibility.
+
 = 1.4.22 - 2025-10-28 =
 * Fix - Issue where `product_type` include more then 5 categories if a product included more.
 * Tweak - Update use of `wp_json_encode` to avoid potential browser parsing issues.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.22
+ * Version:           1.4.23
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -23,11 +23,11 @@
  * Requires Plugins:  woocommerce
  *
  * Requires at least: 5.6
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 10.3
+ * WC tested up to: 10.4
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.22' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.23' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: automattic, pinterest, woocommerce
 Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.3
-Stable tag: 1.4.22
+Stable tag: 1.4.23
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.23 - 2025-11-24 =
+* Fix - Remove feed file on deactivation.
+* Tweak - WC 10.4 compatibility.
+* Tweak - WP 6.9 compatibility.
+
 = 1.4.22 - 2025-10-28 =
 * Fix - Issue where `product_type` include more then 5 categories if a product included more.
 * Tweak - Update use of `wp_json_encode` to avoid potential browser parsing issues.


### PR DESCRIPTION
Merge version bumps for [v1.4.23](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.23) from `trunk` into `develop`.