### PR TITLE
Release/1.4.24 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
 = 1.4.24 - 2026-01-27 =
-* Fix - Remove feed file on deactivation.
-* Tweak - WC 10.4 compatibility.
-* Tweak - WP 6.9 compatibility.
+* Tweak - PHP 8.5 compatibiliy.
+* Tweak - WC 10.5 compatibility.
 
 = 1.4.22 - 2025-10-28 =
 * Fix - Issue where `product_type` include more then 5 categories if a product included more.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Pinterest for WooCommerce Changelog ***
 
-= 1.4.23 - 2025-11-24 =
+= 1.4.24 - 2026-01-27 =
 * Fix - Remove feed file on deactivation.
 * Tweak - WC 10.4 compatibility.
 * Tweak - WP 6.9 compatibility.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.23
+ * Version:           1.4.24
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 6.3
- * WC tested up to: 10.4
+ * WC tested up to: 10.5
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.23' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.24' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.24 - 2026-01-27 =
+* Tweak - PHP 8.5 compatibiliy.
+* Tweak - WC 10.5 compatibility.
+
 = 1.4.23 - 2025-11-24 =
 * Fix - Remove feed file on deactivation.
 * Tweak - WC 10.4 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.3
-Stable tag: 1.4.23
+Stable tag: 1.4.24
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR merges the changes from [release v1.4.24](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.24) back into `develop`.