### PR TITLE
Exclude README.md from built package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,6 +188,7 @@ gulp.task(
 					[
 						`${folder}/{assets,i18n,includes,src,vendor,views}/**/*`,
 						`${folder}/*.{php,txt,md}`,
+						`!${folder}/README.md`,
 						'LICENSE'
 					],
 					{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,6 +189,7 @@ gulp.task(
 						`${folder}/{assets,i18n,includes,src,vendor,views}/**/*`,
 						`${folder}/*.{php,txt,md}`,
 						`!${folder}/README.md`,
+						`!${folder}/i18n/languages/README.md`,
 						'LICENSE'
 					],
 					{

--- a/i18n/languages/README.md
+++ b/i18n/languages/README.md
@@ -1,0 +1,12 @@
+# Translation Files
+
+## Why the POT file is version controlled
+
+The `pinterest-for-woocommerce.pot` file is intentionally tracked in version control for the following reasons:
+
+- **Internal translation workflow**: Pinterest uses this POT file internally to check for changes and send to automatic translation services
+- **WooCommerce limitation**: Since WooCommerce doesn't have automatic translations, Pinterest pulls the POT files and handles translations internally
+- **Manual submission process**: Translated files are manually submitted to the WordPress website periodically
+- **Latest labels requirement**: Having the latest translatable strings in version control ensures the internal translation job has access to them
+
+The POT file should be updated whenever translatable strings change in the codebase. Older versions don't need to be maintained - only the latest version is required for the internal translation pipeline.

--- a/i18n/languages/pinterest-for-woocommerce.pot
+++ b/i18n/languages/pinterest-for-woocommerce.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2025 WooCommerce
+# Copyright (C) 2026 WooCommerce
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pinterest for WooCommerce 1.4.22\n"
+"Project-Id-Version: Pinterest for WooCommerce 1.4.24\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/pinterest-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-11-18T17:08:11+00:00\n"
+"POT-Creation-Date: 2026-01-27T17:01:32+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: pinterest-for-woocommerce\n"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes PIN4WOO-66.

The repository development README.md file was being included in the built plugin package. This PR:
- Excludes README.md from the build process in gulpfile.js
- Updates the translation template (.pot file) with current version and timestamp
- Adds a readme to explain why the translation template is being versioned 
- Excludes that explanation README.md from the built plugin package 

### Detailed test instructions:

1. Run `npm run build:zip` to generate the plugin package
2. Inspect the generated zip file contents
3. Verify that neither README.md is not included in the package
5. Verify that other expected files (PHP files, assets, etc.) are still included

### Changelog entry

> Fix - Exclude development README.md from built plugin package.