### PR TITLE
Update minimum WooCommerce version to 7.0

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		const PLUGIN_REQUIREMENTS = array(
 			'php_version'      => '7.4',
 			'wp_version'       => '5.6',
-			'wc_version'       => '5.3',
+			'wc_version'       => '7.0',
 			'action_scheduler' => '3.3.0',
 		);
 

--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -1392,7 +1392,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 		 * @since 1.2.11
 		 */
 		public function add_onboarding_task() {
-			if ( class_exists( TaskLists::class ) ) { // compatibility-code "< WC 5.9". This is added for backward compatibility.
+			if ( class_exists( TaskLists::class ) ) {
 				TaskLists::add_task(
 					'extended',
 					new Onboarding(

--- a/includes/admin/class-pinterest-for-woocommerce-admin.php
+++ b/includes/admin/class-pinterest-for-woocommerce-admin.php
@@ -9,7 +9,6 @@
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
@@ -244,24 +243,13 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 				Features::is_enabled( 'navigation' );
 		}
 
-		/**
-		 * Compatibility layer for is_admin_page function.
-		 * Needed since WC 6.5.
-		 */
-		private function is_admin_page(): bool {
-			if ( method_exists( PageController::class, 'is_admin_page' ) ) {
-				return PageController::is_admin_page();
-			} else {
-				return class_exists( Loader::class ) && Loader::is_admin_page();
-			}
-		}
 
 		/**
 		 * Load the scripts needed for the setup guide / settings page.
 		 */
 		public function load_setup_guide_scripts() {
 
-			if ( ! $this->is_admin_page() ) {
+			if ( ! PageController::is_admin_page() ) {
 				return;
 			}
 
@@ -325,7 +313,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		public function register_task_list_item( $registered_tasks_list_items ) {
 
 			if (
-				! $this->is_admin_page() ||
+				! PageController::is_admin_page() ||
 				! Compat::should_show_tasks()
 			) {
 				return $registered_tasks_list_items;
@@ -348,7 +336,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce_Admin' ) ) :
 		 * @return void
 		 */
 		public function load_settings() {
-			if ( ! $this->is_admin_page() || ! class_exists( AssetDataRegistry::class ) ) {
+			if ( ! PageController::is_admin_page() || ! class_exists( AssetDataRegistry::class ) ) {
 				return;
 			}
 

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -26,7 +26,7 @@
  * Tested up to: 6.9
  * Requires PHP: 7.4
  *
- * WC requires at least: 6.3
+ * WC requires at least: 7.0
  * WC tested up to: 10.5
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 * Add - API method to get commerce integration.
 * Add - Commerce Integration `partner_metadata` weekly sync.
 * Add - Failed Create Commerce Integration API call retries procedure.
-* Add - Weakly heartbeat action.
+* Add - Weekly heartbeat action.
 * Update - Make `integration_data` optional for the extension.
 
 = 1.4.10 - 2024-09-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 = 1.4.21 - 2025-06-16 =
 * Update WP Consent API to affect all tracking with improved architecture.
-* [dev] Pin Github actions to immutable references of commits instead of tags.
+* [dev] Pin GitHub actions to immutable references of commits instead of tags.
 
 = 1.4.20 - 2025-06-03 =
 * Tweak - Reenable WP Consent API tracking integration.

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ Pinterest is a visual discovery engine people use to find inspiration for their 
 
 * WordPress 5.6 or greater
 * WooCommerce 7.0 or greater
-* PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
+* PHP version 7.4 or greater
 * MySQL version 5.6 or greater
 
 Visit the [WooCommerce server requirements documentation](https://woocommerce.com/document/server-requirements/) for a detailed list of server requirements.

--- a/readme.txt
+++ b/readme.txt
@@ -92,7 +92,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 == Changelog ==
 
 = 1.4.24 - 2026-01-27 =
-* Tweak - PHP 8.5 compatibiliy.
+* Tweak - PHP 8.5 compatibility.
 * Tweak - WC 10.5 compatibility.
 
 = 1.4.23 - 2025-11-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ Pinterest is a visual discovery engine people use to find inspiration for their 
 = Minimum Requirements =
 
 * WordPress 5.6 or greater
-* WooCommerce 5.3 or greater
+* WooCommerce 7.0 or greater
 * PHP version 7.3 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pinterest, woocommerce
 Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 6.9
-Requires PHP: 7.3
+Requires PHP: 7.4
 Stable tag: 1.4.24
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/src/Admin/Tasks/Onboarding.php
+++ b/src/Admin/Tasks/Onboarding.php
@@ -75,18 +75,4 @@ class Onboarding extends Task {
 	public function is_complete() {
 		return Pinterest_For_Woocommerce()::is_setup_complete();
 	}
-
-	/**
-	 * Parent ID. This method is abstract in WooCommerce 6.1.x, 6.2.x and 6.3.x. This implementation is for backward compatibility for these versions.
-	 * compatibility-code "WC 6.1.x, WC 6.2.x, WC 6.3.x"
-	 *
-	 * @return string
-	 */
-	public function get_parent_id() {
-		if ( is_callable( parent::class . '::get_parent_id' ) ) {
-			return parent::get_parent_id();
-		}
-
-		return 'extended'; // The parent task list id.
-	}
 }

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -11,7 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 /**
@@ -26,10 +25,6 @@ class Compat {
 	 * @return bool
 	 */
 	public static function should_show_tasks(): bool {
-		if ( version_compare( WC_VERSION, '5.9', '<' ) ) {
-			return Onboarding::should_show_tasks();
-		}
-
 		$setup_list    = TaskLists::get_list( 'setup' );
 		$extended_list = TaskLists::get_list( 'extended' );
 

--- a/src/Utilities/Tracks.php
+++ b/src/Utilities/Tracks.php
@@ -24,11 +24,6 @@ trait Tracks {
 	 * @param array  $properties Array of properties to include with the event.
 	 */
 	private static function record_event( string $name, array $properties = array() ): void {
-		if ( class_exists( WC_Tracks::class ) ) {
-			WC_Tracks::record_event( $name, $properties );
-		} elseif ( function_exists( 'wc_admin_record_tracks_event' ) ) {
-			wc_admin_record_tracks_event( $name, $properties );
-		}
+		WC_Tracks::record_event( $name, $properties );
 	}
-
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the minimum required WooCommerce version from 5.3/6.3 to 7.0 and removes all compatibility code for versions below 7.0.

The readme previously indicated the minimum should be L-2 (current minus 2 major versions), which would be WooCommerce 8.x or 9.x given the current 10.5 release. However, this PR takes a conservative approach by bumping to 7.0 to remove old deprecated code while maintaining broader compatibility.


### Screenshots:

N/A


### Detailed test instructions:

1. Install WooCommerce 7.0+ on a test site
2. Install and activate the Pinterest for WooCommerce plugin from this branch
3. Complete the Pinterest connection and setup process
4. Verify all admin pages render correctly (Pinterest settings, catalog, connection pages)
5. Verify product sync functionality works
6. Check that task list integrations appear correctly in WooCommerce admin
7. Confirm no PHP notices or warnings related to deprecated WooCommerce methods


### Additional details:

This change removes compatibility shims for WooCommerce versions below 7.0:
- Removed `is_admin_page()` compatibility method that checked for both `PageController::is_admin_page()` and deprecated `Loader::is_admin_page()`
- Removed WooCommerce < 5.9 version check in `Compat::should_show_tasks()`
- Removed compatibility comments referencing WC < 5.9

### Changelog entry

> Update - Minimum required WooCommerce version bumped to 7.0