### PR TITLE
Fix feed generator robustness at scale

### DIFF
--- a/src/Exception/FeedCircuitBreakerException.php
+++ b/src/Exception/FeedCircuitBreakerException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Feed circuit breaker exception.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Exception
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Pinterest\Exception;
+
+use Exception;
+
+/**
+ * Thrown when the feed generator circuit breaker trips (batch_number exceeds
+ * the configured max batches per cycle limit).
+ */
+class FeedCircuitBreakerException extends Exception implements PinterestException {}

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -173,17 +173,6 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
-		self::log(
-			sprintf(
-				// Translators: Action Scheduler hook name.
-				__(
-					'Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it.',
-					'pinterest-for-woocommerce'
-				),
-				$hook
-			)
-		);
-
 		// Check if an action with the same hook and args is already scheduled to prevent duplicate retries.
 		// Important: Check this BEFORE throttling to avoid unnecessary batch size adjustments.
 		if ( as_has_scheduled_action( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
@@ -199,6 +188,17 @@ class FeedGenerator extends AbstractChainedJob {
 			);
 			return;
 		}
+
+		self::log(
+			sprintf(
+				// Translators: Action Scheduler hook name.
+				__(
+					'Feed Generator `%s` Action timed out due to an unexpected shutdown. Rescheduling it.',
+					'pinterest-for-woocommerce'
+				),
+				$hook
+			)
+		);
 
 		// Decrease the number of products to retry.
 		$attempt = ( Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) ?? 1 ) + 1;

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -15,7 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Utilities\BatchQueryOffset;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\AbstractChainedJob;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
+use Automattic\WooCommerce\Pinterest\Exception\FeedCircuitBreakerException;
 use Automattic\WooCommerce\Pinterest\Exception\FeedFileOperationsException;
+use Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 use ActionScheduler;
 use Exception;
@@ -368,7 +370,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @return array Items ids.
 	 *
-	 * @throws Exception On error. The failure will be logged by Action Scheduler and the job chain will stop.
+	 * @throws FeedCircuitBreakerException When the batch limit is exceeded, stopping the job chain.
 	 */
 	protected function get_items_for_batch( int $batch_number, array $args ): array {
 		/**
@@ -388,7 +390,7 @@ class FeedGenerator extends AbstractChainedJob {
 				$max_batches,
 				'pinterest_for_woocommerce_max_feed_batches_per_cycle'
 			);
-			throw new Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new FeedCircuitBreakerException( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		global $wpdb;
@@ -578,6 +580,11 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return void
 	 */
 	private function handle_error( Throwable $th, string $hook_name = '' ) {
+		if ( $th instanceof FeedCircuitBreakerException ) {
+			$recommended = $this->calculate_recommended_batch_limit( $this->count_published_products() );
+			FeedCircuitBreakerNote::add_note( $recommended );
+		}
+
 		ProductFeedStatus::set(
 			array(
 				'status'        => 'error',

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -43,6 +43,12 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	const MAX_RETRIES_PER_BATCH = 2;
 
+	/**
+	 * The max number of batches to process in a single generation cycle.
+	 * Circuit breaker to prevent runaway scheduling and database bloat.
+	 */
+	const MAX_BATCHES_PER_CYCLE = 1000;
+
 	public const DEFAULT_PRODUCT_BATCH_SIZE = 100;
 
 	/**
@@ -66,6 +72,14 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @var array $buffers Array of feed buffers.
 	 */
 	private $buffers = array();
+
+	/**
+	 * Pending last batch ID to be committed after successful processing.
+	 * Prevents cursor advancement before batch processing completes.
+	 *
+	 * @var int|null $pending_last_batch_id
+	 */
+	private $pending_last_batch_id = null;
 
 	/**
 	 * FeedGenerator initialization.
@@ -188,6 +202,21 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 
+		// Check if an action with the same hook and args is already scheduled to prevent duplicate retries.
+		if ( as_has_scheduled_action( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+			self::log(
+				sprintf(
+					// Translators: Action Scheduler hook name.
+					__(
+						'Feed Generator `%s` Action retry already scheduled. Skipping duplicate.',
+						'pinterest-for-woocommerce'
+					),
+					$hook
+				)
+			);
+			return;
+		}
+
 		// Register retry attempt.
 		$this->action_scheduler->schedule_immediate( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 	}
@@ -267,6 +296,9 @@ class FeedGenerator extends AbstractChainedJob {
 				)
 			);
 			$this->feed_file_operations->prepare_temporary_files();
+
+			// Reset circuit breaker batch counter.
+			Pinterest_For_Woocommerce::save_data( 'feed_batch_count', 0 );
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th, $this->get_action_full_name( self::CHAIN_START ) );
 			throw $th;
@@ -288,9 +320,15 @@ class FeedGenerator extends AbstractChainedJob {
 
 		/*
 		 * Action has finished successfully.
+		 *   - Commit the cursor position (only after successful processing).
 		 *   - Reset number of products per batch.
 		 *   - Reset action retries counter.
 		 */
+		if ( null !== $this->pending_last_batch_id ) {
+			$this->set_last_batch_id( $this->pending_last_batch_id );
+			$this->pending_last_batch_id = null;
+		}
+
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_size' );
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_attempt' );
 	}
@@ -321,6 +359,9 @@ class FeedGenerator extends AbstractChainedJob {
 		}
 		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
 
+		// Clean up circuit breaker counter.
+		Pinterest_For_Woocommerce::remove_data( 'feed_batch_count' );
+
 		// Check if feed is dirty and reschedule in necessary.
 		if ( $this->feed_is_dirty() ) {
 			$this->mark_feed_clean();
@@ -342,6 +383,26 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Exception On error. The failure will be logged by Action Scheduler and the job chain will stop.
 	 */
 	protected function get_items_for_batch( int $batch_number, array $args ): array {
+		// Circuit breaker: Check if max batches per cycle has been reached.
+		$batch_count = Pinterest_For_Woocommerce::get_data( 'feed_batch_count' ) ?? 0;
+		if ( $batch_count >= self::MAX_BATCHES_PER_CYCLE ) {
+			self::log(
+				sprintf(
+					// Translators: Maximum number of batches allowed.
+					__(
+						'Feed Generator circuit breaker triggered. Maximum batch limit of %d reached. Completing generation.',
+						'pinterest-for-woocommerce'
+					),
+					self::MAX_BATCHES_PER_CYCLE
+				),
+				\WC_Log_Levels::WARNING
+			);
+			return array();
+		}
+
+		// Increment batch counter.
+		Pinterest_For_Woocommerce::save_data( 'feed_batch_count', $batch_count + 1 );
+
 		global $wpdb;
 
 		$variable_type_like = $wpdb->esc_like( 'variable' ) . '%';
@@ -375,8 +436,10 @@ class FeedGenerator extends AbstractChainedJob {
 		);
 
 		$product_ids = array_map( 'intval', $product_ids );
-		// We save the last product's id from the current batch to start from it next time when fetching the next batch.
-		$this->set_last_batch_id( $product_ids[ count( $product_ids ) - 1 ] ?? 0 );
+		// Store the last product ID temporarily. It will be committed to persistent storage
+		// only after the batch is successfully processed (in handle_batch_action).
+		// This prevents timeouts from causing cursor advancement before processing completes.
+		$this->pending_last_batch_id = $product_ids[ count( $product_ids ) - 1 ] ?? 0;
 		return $product_ids;
 	}
 
@@ -450,7 +513,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		// Do not sync out of stock products which do not support backorders if woocommerce_hide_out_of_stock_items is set.
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$products_query_args['stock_status'] = [ 'instock', 'onbackorder' ];
+			$products_query_args['stock_status'] = array( 'instock', 'onbackorder' );
 		}
 
 		return wc_get_products( $products_query_args );
@@ -512,6 +575,8 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Handle feed generation error by updating status and scheduling retry.
+	 *
 	 * @param Throwable $th - An exception that was thrown.
 	 * @param string    $hook_name - The name of the hook that was being executed when the exception was thrown.
 	 *
@@ -770,20 +835,20 @@ class FeedGenerator extends AbstractChainedJob {
 		 * Threshold of failed actions.
 		 * phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		 */
-		$threshold   = apply_filters( 'pinterest_for_woocommerce_action_failure_threshold', 3 );
+		$threshold = apply_filters( 'pinterest_for_woocommerce_action_failure_threshold', 3 );
 		/**
 		 * Time period of failed actions.
 		 * phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		 */
-		$time_period = apply_filters( 'pinterest_for_woocommerce_action_failure_time_period', 30 * MINUTE_IN_SECONDS );
+		$time_period    = apply_filters( 'pinterest_for_woocommerce_action_failure_time_period', 30 * MINUTE_IN_SECONDS );
 		$failed_actions = $this->action_scheduler->search(
-			[
+			array(
 				'hook'         => $hook,
 				'args'         => $args,
 				'status'       => ActionSchedulerInterface::STATUS_FAILED,
 				'date'         => gmdate( 'U' ) - $time_period,
 				'date_compare' => '>',
-			],
+			),
 			'ids'
 		);
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -712,6 +712,10 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Formula: ceil(total / DEFAULT_PRODUCT_BATCH_SIZE) * 1.25 headroom, rounded up
 	 * to the nearest 500.
 	 *
+	 * Uses DEFAULT_PRODUCT_BATCH_SIZE (not the current runtime batch size) so the
+	 * recommendation remains stable across retry cycles where the batch size is
+	 * temporarily halved due to timeouts.
+	 *
 	 * @param int $total_products Total published product count.
 	 * @return int
 	 */

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -584,6 +584,26 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Whether the given throwable is, or wraps, a FeedCircuitBreakerException.
+	 *
+	 * Action Scheduler's queue runner catches the original Throwable and re-throws a
+	 * generic Exception, keeping the original only as the previous exception. The
+	 * exception delivered to the failed-execution handler is therefore not the
+	 * FeedCircuitBreakerException itself, so we walk the previous chain to detect it.
+	 *
+	 * @param Throwable $th The thrown exception.
+	 * @return bool
+	 */
+	private function is_circuit_breaker_exception( Throwable $th ): bool {
+		for ( $current = $th; null !== $current; $current = $current->getPrevious() ) {
+			if ( $current instanceof FeedCircuitBreakerException ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Handle feed generation error by updating status and scheduling retry.
 	 *
 	 * @param Throwable $th - An exception that was thrown.
@@ -602,7 +622,7 @@ class FeedGenerator extends AbstractChainedJob {
 		);
 		ProductFeedStatus::mark_feed_file_generation_as_failed();
 
-		if ( $th instanceof FeedCircuitBreakerException ) {
+		if ( $this->is_circuit_breaker_exception( $th ) ) {
 			// Use a live product count rather than the batch-run status cache — the batch
 			// may have been interrupted mid-update, so the cached count could be stale.
 			$total_products = $this->count_published_products();

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -581,6 +581,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	private function handle_error( Throwable $th, string $hook_name = '' ) {
 		if ( $th instanceof FeedCircuitBreakerException ) {
+			// Use a live product count rather than the batch-run status cache — the batch
+			// may have been interrupted mid-update, so the cached count could be stale.
 			$recommended = $this->calculate_recommended_batch_limit( $this->count_published_products() );
 			FeedCircuitBreakerNote::add_note( $recommended );
 		}

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -175,9 +175,23 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
-		// Check if an action with the same hook and args is already scheduled to prevent duplicate retries.
-		// Important: Check this BEFORE throttling to avoid unnecessary batch size adjustments.
-		if ( as_has_scheduled_action( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+		// Check if a PENDING retry already exists to prevent duplicate retries.
+		// We query STATUS_PENDING only — the timing out action itself is STATUS_RUNNING
+		// at the point this handler fires (AS marks it in-progress before invoking the
+		// callback), so as_has_scheduled_action() would incorrectly match it and block
+		// the very first reschedule.  A genuine duplicate is a *pending* retry scheduled
+		// by an earlier invocation of this handler.
+		$pending_retries = $this->action_scheduler->search(
+			array(
+				'hook'     => $hook,
+				'args'     => $args,
+				'per_page' => 1,
+				'status'   => ActionSchedulerInterface::STATUS_PENDING,
+			),
+			'ids',
+			PINTEREST_FOR_WOOCOMMERCE_PREFIX
+		);
+		if ( ! empty( $pending_retries ) ) {
 			self::log(
 				sprintf(
 					// Translators: Action Scheduler hook name.

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -297,9 +297,6 @@ class FeedGenerator extends AbstractChainedJob {
 				)
 			);
 			$this->feed_file_operations->prepare_temporary_files();
-
-			// Reset circuit breaker batch counter.
-			Pinterest_For_Woocommerce::save_data( 'feed_batch_count', 0 );
 		} catch ( Throwable $th ) {
 			$this->handle_error( $th, $this->get_action_full_name( self::CHAIN_START ) );
 			throw $th;
@@ -322,17 +319,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		parent::handle_batch_action( $batch_number, $args );
 
-		/*
-		 * Action has finished successfully.
-		 *   - Commit the cursor position (only after successful processing).
-		 *   - Reset number of products per batch.
-		 *   - Reset action retries counter.
-		 */
-		if ( null !== $this->pending_last_batch_id ) {
-			$this->set_last_batch_id( $this->pending_last_batch_id );
-			$this->pending_last_batch_id = null;
-		}
-
+		// Reset number of products per batch and action retries counter on success.
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_size' );
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_attempt' );
 	}
@@ -363,9 +350,6 @@ class FeedGenerator extends AbstractChainedJob {
 		}
 		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
 
-		// Clean up circuit breaker counter.
-		Pinterest_For_Woocommerce::remove_data( 'feed_batch_count' );
-
 		// Check if feed is dirty and reschedule in necessary.
 		if ( $this->feed_is_dirty() ) {
 			$this->mark_feed_clean();
@@ -387,25 +371,25 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Exception On error. The failure will be logged by Action Scheduler and the job chain will stop.
 	 */
 	protected function get_items_for_batch( int $batch_number, array $args ): array {
-		// Circuit breaker: Check if max batches per cycle has been reached.
-		$batch_count = Pinterest_For_Woocommerce::get_data( 'feed_batch_count' ) ?? 0;
-		if ( $batch_count >= self::MAX_BATCHES_PER_CYCLE ) {
-			self::log(
-				sprintf(
-					// Translators: Maximum number of batches allowed.
-					__(
-						'Feed Generator circuit breaker triggered. Maximum batch limit of %d reached. Completing generation.',
-						'pinterest-for-woocommerce'
-					),
-					self::MAX_BATCHES_PER_CYCLE
-				),
-				\WC_Log_Levels::WARNING
-			);
-			return array();
-		}
+		/**
+		 * Maximum number of batches allowed per generation cycle.
+		 * phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		 */
+		$max_batches = (int) apply_filters( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', self::MAX_BATCHES_PER_CYCLE );
 
-		// Increment batch counter.
-		Pinterest_For_Woocommerce::save_data( 'feed_batch_count', $batch_count + 1 );
+		// Circuit breaker: abort with an error so the truncated feed is never silently published.
+		if ( $batch_number > $max_batches ) {
+			$message = sprintf(
+				// Translators: 1: batch limit, 2: filter name.
+				__(
+					'Feed generation truncated: maximum batch limit of %1$d reached. Use the `%2$s` filter to increase the limit.',
+					'pinterest-for-woocommerce'
+				),
+				$max_batches,
+				'pinterest_for_woocommerce_max_feed_batches_per_cycle'
+			);
+			throw new Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
 
 		global $wpdb;
 
@@ -439,10 +423,7 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 
-		$product_ids = array_map( 'intval', $product_ids );
-		// Store the last product ID temporarily. It will be committed to persistent storage
-		// only after the batch is successfully processed (in handle_batch_action).
-		// This prevents timeouts from causing cursor advancement before processing completes.
+		$product_ids                 = array_map( 'intval', $product_ids );
 		$this->pending_last_batch_id = $product_ids[ count( $product_ids ) - 1 ] ?? 0;
 		return $product_ids;
 	}
@@ -477,6 +458,14 @@ class FeedGenerator extends AbstractChainedJob {
 
 		// May throw write to file exception.
 		$this->feed_file_operations->write_buffers_to_temp_files( $this->buffers );
+
+		// Commit cursor immediately after the successful write to minimise the duplicate-append
+		// window: if a timeout lands after write_buffers_to_temp_files() but before the commit the
+		// retry would re-fetch the same IDs and append them a second time.
+		if ( null !== $this->pending_last_batch_id ) {
+			$this->set_last_batch_id( $this->pending_last_batch_id );
+			$this->pending_last_batch_id = null;
+		}
 
 		$count = ProductFeedStatus::get()['product_count'] ?? 0;
 		ProductFeedStatus::set(
@@ -691,6 +680,45 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function set_last_batch_id( int $id ): void {
 		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', $id );
+	}
+
+	/**
+	 * Count all published products and published product variations.
+	 *
+	 * Uses the same product/variation filter as get_items_for_batch() so the
+	 * result accurately reflects what the feed would include.
+	 *
+	 * @return int
+	 */
+	private function count_published_products(): int {
+		global $wpdb;
+
+		return (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			"SELECT COUNT( post.ID )
+			FROM {$wpdb->posts} AS post
+			LEFT JOIN {$wpdb->posts} AS parent ON post.post_parent = parent.ID
+			WHERE
+				(
+					( post.post_type = 'product_variation' AND parent.post_status = 'publish' )
+				OR
+					( post.post_type = 'product' AND post.post_status = 'publish' )
+				)" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+	}
+
+	/**
+	 * Calculate the recommended max-batches-per-cycle filter value for the given product count.
+	 *
+	 * Formula: ceil(total / DEFAULT_PRODUCT_BATCH_SIZE) * 1.25 headroom, rounded up
+	 * to the nearest 500.
+	 *
+	 * @param int $total_products Total published product count.
+	 * @return int
+	 */
+	protected function calculate_recommended_batch_limit( int $total_products ): int {
+		$needed   = (int) ceil( $total_products / self::DEFAULT_PRODUCT_BATCH_SIZE );
+		$buffered = (int) ceil( $needed * 1.25 );
+		return (int) ( ceil( $buffered / 500 ) * 500 );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -580,13 +580,6 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return void
 	 */
 	private function handle_error( Throwable $th, string $hook_name = '' ) {
-		if ( $th instanceof FeedCircuitBreakerException ) {
-			// Use a live product count rather than the batch-run status cache — the batch
-			// may have been interrupted mid-update, so the cached count could be stale.
-			$recommended = $this->calculate_recommended_batch_limit( $this->count_published_products() );
-			FeedCircuitBreakerNote::add_note( $recommended );
-		}
-
 		ProductFeedStatus::set(
 			array(
 				'status'        => 'error',
@@ -594,6 +587,13 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 		ProductFeedStatus::mark_feed_file_generation_as_failed();
+
+		if ( $th instanceof FeedCircuitBreakerException ) {
+			// Use a live product count rather than the batch-run status cache — the batch
+			// may have been interrupted mid-update, so the cached count could be stale.
+			$recommended = $this->calculate_recommended_batch_limit( $this->count_published_products() );
+			FeedCircuitBreakerNote::add_note( $recommended );
+		}
 
 		self::log(
 			sprintf(
@@ -731,7 +731,7 @@ class FeedGenerator extends AbstractChainedJob {
 	protected function calculate_recommended_batch_limit( int $total_products ): int {
 		$needed   = (int) ceil( $total_products / self::DEFAULT_PRODUCT_BATCH_SIZE );
 		$buffered = (int) ceil( $needed * 1.25 );
-		return (int) ( ceil( $buffered / 500 ) * 500 );
+		return max( 500, (int) ( ceil( $buffered / 500 ) * 500 ) );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -694,24 +694,38 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Count all published products and published product variations.
 	 *
-	 * Uses the same product/variation filter as get_items_for_batch() so the
-	 * result accurately reflects what the feed would include.
+	 * Mirrors the same WHERE clause as get_items_for_batch() — including the EXISTS
+	 * subquery that restricts variations to variable-type parents — so the result
+	 * accurately reflects what the feed would include.
 	 *
 	 * @return int
 	 */
 	private function count_published_products(): int {
 		global $wpdb;
 
+		$variable_type_like = $wpdb->esc_like( 'variable' ) . '%';
+
 		return (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			"SELECT COUNT( post.ID )
-			FROM {$wpdb->posts} AS post
-			LEFT JOIN {$wpdb->posts} AS parent ON post.post_parent = parent.ID
-			WHERE
-				(
-					( post.post_type = 'product_variation' AND parent.post_status = 'publish' )
-				OR
-					( post.post_type = 'product' AND post.post_status = 'publish' )
-				)" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->prepare(
+				"SELECT COUNT( post.ID )
+				FROM {$wpdb->posts} AS post
+				LEFT JOIN {$wpdb->posts} AS parent ON post.post_parent = parent.ID
+				WHERE
+					(
+						( post.post_type = 'product_variation' AND parent.post_status = 'publish'
+							AND EXISTS (
+								SELECT 1
+								FROM {$wpdb->term_relationships} tr
+								INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+								INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+								WHERE tr.object_id = parent.ID AND tt.taxonomy = 'product_type' AND t.slug LIKE %s
+							)
+						)
+					OR
+						( post.post_type = 'product' AND post.post_status = 'publish' )
+					)",
+				$variable_type_like
+			)
 		);
 	}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -678,7 +678,7 @@ class FeedGenerator extends AbstractChainedJob {
 			Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
 		}
 		// Get last fetched ID to start from the next item after it.
-		return Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		return (int) Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -605,8 +605,41 @@ class FeedGenerator extends AbstractChainedJob {
 		if ( $th instanceof FeedCircuitBreakerException ) {
 			// Use a live product count rather than the batch-run status cache — the batch
 			// may have been interrupted mid-update, so the cached count could be stale.
-			$recommended = $this->calculate_recommended_batch_limit( $this->count_published_products() );
+			$total_products = $this->count_published_products();
+			/**
+			 * Maximum number of batches allowed per generation cycle.
+			 * phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			 */
+			$max_batches = (int) apply_filters( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', self::MAX_BATCHES_PER_CYCLE );
+			$recommended = null === $total_products ? 0 : $this->calculate_recommended_batch_limit( $total_products );
+
+			// Never advise a value at or below the limit that just tripped. That would
+			// happen if the count query failed ( null ) or returned a stale/low value,
+			// leaving the merchant with a recommendation that cannot resolve the problem.
+			if ( $recommended <= $max_batches ) {
+				$recommended = (int) ( ceil( ( $max_batches * 2 ) / 500 ) * 500 );
+			}
+
 			FeedCircuitBreakerNote::add_note( $recommended );
+
+			// Do not reschedule a full regeneration here. An over-limit catalog would
+			// re-process every cycle and trip the breaker again — the exact runaway the
+			// breaker exists to prevent. The admin note prompts the merchant to raise the
+			// limit; the daily generator recurrence resumes the sync once they do.
+			self::log(
+				sprintf(
+					// Translators: 1: Action Scheduler hook name, 2: Error message about why action has failed to execute.
+					__(
+						'Feed Generator `%1$s` Action stopped: `%2$s`. No automatic retry scheduled; raise the batch limit filter to resume.',
+						'pinterest-for-woocommerce'
+					),
+					$hook_name,
+					$th->getMessage()
+				),
+				\WC_Log_Levels::ERROR
+			);
+
+			return;
 		}
 
 		self::log(
@@ -712,14 +745,14 @@ class FeedGenerator extends AbstractChainedJob {
 	 * subquery that restricts variations to variable-type parents — so the result
 	 * accurately reflects what the feed would include.
 	 *
-	 * @return int
+	 * @return int|null Published product count, or null if the count query failed.
 	 */
-	private function count_published_products(): int {
+	private function count_published_products(): ?int {
 		global $wpdb;
 
 		$variable_type_like = $wpdb->esc_like( 'variable' ) . '%';
 
-		return (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT COUNT( post.ID )
 				FROM {$wpdb->posts} AS post
@@ -741,6 +774,19 @@ class FeedGenerator extends AbstractChainedJob {
 				$variable_type_like
 			)
 		);
+
+		// A failed query (lock timeout, killed subquery, etc.) returns null. Surface it
+		// rather than letting an (int) cast coerce it to 0, which would feed a misleading
+		// recommendation into the admin note.
+		if ( null === $count ) {
+			self::log(
+				__( 'Failed to count published products for the feed circuit breaker recommendation.', 'pinterest-for-woocommerce' ),
+				\WC_Log_Levels::WARNING
+			);
+			return null;
+		}
+
+		return (int) $count;
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -184,6 +184,22 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 
+		// Check if an action with the same hook and args is already scheduled to prevent duplicate retries.
+		// Important: Check this BEFORE throttling to avoid unnecessary batch size adjustments.
+		if ( as_has_scheduled_action( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
+			self::log(
+				sprintf(
+					// Translators: Action Scheduler hook name.
+					__(
+						'Feed Generator `%s` Action retry already scheduled. Skipping duplicate.',
+						'pinterest-for-woocommerce'
+					),
+					$hook
+				)
+			);
+			return;
+		}
+
 		// Decrease the number of products to retry.
 		$attempt = ( Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) ?? 1 ) + 1;
 		$limit   = (int) ceil( $this->get_batch_size() / $attempt );
@@ -201,21 +217,6 @@ class FeedGenerator extends AbstractChainedJob {
 				$limit
 			)
 		);
-
-		// Check if an action with the same hook and args is already scheduled to prevent duplicate retries.
-		if ( as_has_scheduled_action( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX ) ) {
-			self::log(
-				sprintf(
-					// Translators: Action Scheduler hook name.
-					__(
-						'Feed Generator `%s` Action retry already scheduled. Skipping duplicate.',
-						'pinterest-for-woocommerce'
-					),
-					$hook
-				)
-			);
-			return;
-		}
 
 		// Register retry attempt.
 		$this->action_scheduler->schedule_immediate( $hook, $args, PINTEREST_FOR_WOOCOMMERCE_PREFIX );
@@ -316,6 +317,9 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to issue possible when creating an empty feed temp file and populating the header.
 	 */
 	public function handle_batch_action( int $batch_number, array $args ) {
+		// Reset pending cursor to prevent stale values from previous failed batches.
+		$this->pending_last_batch_id = null;
+
 		parent::handle_batch_action( $batch_number, $args );
 
 		/*

--- a/src/Notes/FeedCircuitBreakerNote.php
+++ b/src/Notes/FeedCircuitBreakerNote.php
@@ -41,7 +41,7 @@ class FeedCircuitBreakerNote {
 		$content = sprintf(
 			// translators: %d: recommended batch limit value for the filter.
 			__(
-				'Your catalog is too large to fully sync with Pinterest. Some products may not appear on Pinterest. Ask a developer to increase the batch limit to %d — see the plugin documentation for instructions.',
+				'Your catalog is too large to fully sync with Pinterest. Some products may not appear on Pinterest yet. Please refer to plugin documentation at https://woocommerce.com/document/pinterest-for-woocommerce/ to increase the batch limit to %d to sync all products.',
 				'pinterest-for-woocommerce'
 			),
 			$recommended_limit

--- a/src/Notes/FeedCircuitBreakerNote.php
+++ b/src/Notes/FeedCircuitBreakerNote.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WooCommerce Admin: Pinterest Feed Circuit Breaker Triggered.
+ *
+ * Adds a note to inform the user that feed generation was truncated because
+ * the maximum batch limit was reached, and provides guidance on how to fix it.
+ *
+ * @package Automattic\WooCommerce\Pinterest\Notes
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Feed Circuit Breaker admin note.
+ */
+class FeedCircuitBreakerNote {
+
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 *
+	 * @var string
+	 */
+	const NOTE_NAME = 'pinterest-for-woocommerce-feed-circuit-breaker';
+
+	/**
+	 * Build the note object.
+	 *
+	 * @param int $recommended_limit Recommended value for the max batches filter.
+	 * @return Note
+	 */
+	public static function get_note( int $recommended_limit ): Note {
+		$filter_snippet = sprintf(
+			"add_filter( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', function() { return %d; } );",
+			$recommended_limit
+		);
+
+		$content = sprintf(
+			// translators: 1: recommended batch limit; 2: filter code snippet.
+			__(
+				'Your store has more products than Pinterest for WooCommerce processed in the last feed generation cycle. Some products may not appear on Pinterest.<br/><br/>To fix this, a developer can increase the batch limit. Based on your current product count, a value of <strong>%1$d</strong> is recommended. Add this to your theme\'s <code>functions.php</code>:<br/><br/><code>%2$s</code>',
+				'pinterest-for-woocommerce'
+			),
+			$recommended_limit,
+			esc_html( $filter_snippet )
+		);
+
+		$note = new Note();
+		$note->set_title( __( 'Pinterest catalog feed incomplete — product limit reached', 'pinterest-for-woocommerce' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array( 'role' => 'administrator' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_WARNING );
+		$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'pinterest-for-woocommerce' );
+		$note->add_action(
+			'go-to-catalog-sync',
+			__( 'Go to Catalog Sync', 'pinterest-for-woocommerce' ),
+			admin_url( 'admin.php?page=wc-admin&path=/pinterest/catalog' )
+		);
+		$note->add_action(
+			'dismiss',
+			__( 'Dismiss', 'pinterest-for-woocommerce' )
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Delete any existing note and save a fresh one.
+	 *
+	 * Called on every circuit breaker trip so the note reappears even if the
+	 * merchant previously dismissed it.
+	 *
+	 * @param int $recommended_limit Recommended value for the max batches filter.
+	 * @return void
+	 */
+	public static function add_note( int $recommended_limit ): void {
+		try {
+			Notes::delete_notes_with_name( self::NOTE_NAME );
+			$note = self::get_note( $recommended_limit );
+			$note->save();
+		} catch ( NotesUnavailableException $e ) {
+			return;
+		}
+	}
+}

--- a/src/Notes/FeedCircuitBreakerNote.php
+++ b/src/Notes/FeedCircuitBreakerNote.php
@@ -38,19 +38,13 @@ class FeedCircuitBreakerNote {
 	 * @return Note
 	 */
 	public static function get_note( int $recommended_limit ): Note {
-		$filter_snippet = sprintf(
-			"add_filter( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', function() { return %d; } );",
-			$recommended_limit
-		);
-
 		$content = sprintf(
-			// translators: 1: recommended batch limit; 2: filter code snippet.
+			// translators: %d: recommended batch limit value for the filter.
 			__(
-				'Your store has more products than Pinterest for WooCommerce processed in the last feed generation cycle. Some products may not appear on Pinterest.<br/><br/>To fix this, a developer can increase the batch limit. Based on your current product count, a value of <strong>%1$d</strong> is recommended. Add this to your theme\'s <code>functions.php</code>:<br/><br/><code>%2$s</code>',
+				'Your catalog is too large to fully sync with Pinterest. Some products may not appear on Pinterest. Ask a developer to increase the batch limit to %d — see the plugin documentation for instructions.',
 				'pinterest-for-woocommerce'
 			),
-			$recommended_limit,
-			esc_html( $filter_snippet )
+			$recommended_limit
 		);
 
 		$note = new Note();

--- a/src/Notes/FeedCircuitBreakerNote.php
+++ b/src/Notes/FeedCircuitBreakerNote.php
@@ -77,8 +77,9 @@ class FeedCircuitBreakerNote {
 	/**
 	 * Delete any existing note and save a fresh one.
 	 *
-	 * Called on every circuit breaker trip so the note reappears even if the
-	 * merchant previously dismissed it.
+	 * Unlike other notes that use NoteTraits::possibly_add_note() (which no-ops
+	 * if the note already exists), this always deletes and re-saves so the note
+	 * reappears even if the merchant previously dismissed it.
 	 *
 	 * @param int $recommended_limit Recommended value for the max batches filter.
 	 * @return void

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -83,9 +83,9 @@ class TestActionSchedulerProxy implements ActionSchedulerInterface {
 	/**
 	 * Get the next scheduled action timestamp.
 	 *
-	 * @param string      $hook  Action hook.
-	 * @param mixed       $args  Action arguments.
-	 * @param string      $group Action group.
+	 * @param string $hook  Action hook.
+	 * @param mixed  $args  Action arguments.
+	 * @param string $group Action group.
 	 * @return int|bool
 	 */
 	public function next_scheduled_action( $hook, $args = null, string $group = '' ) {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -137,7 +137,8 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			'pinterest-for-woocommerce'
 		);
 
-		$this->action_scheduler->expects( $this->exactly( 2 ) )
+		// The first call should reschedule (no duplicate exists yet).
+		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
 			->with(
 				'pinterest/jobs/generate_feed/chain_batch',
@@ -156,10 +157,55 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 		$this->assertEquals( 2, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
 
+		// Second call should be skipped due to deduplication (action already scheduled).
 		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
 
-		$this->assertEquals( 17, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
-		$this->assertEquals( 3, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
+		// Batch size and attempt should remain the same since rescheduling was skipped.
+		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
+		$this->assertEquals( 2, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
+	}
+
+	/**
+	 * Tests that deduplication prevents rescheduling when action is already scheduled.
+	 *
+	 * @return void
+	 */
+	public function test_handle_unexpected_shutdown_skips_rescheduling_if_action_already_scheduled() {
+		$action_id = as_schedule_single_action(
+			gmdate( 'U' ) - 1,
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 1, array() ),
+			'pinterest-for-woocommerce'
+		);
+
+		// First call schedules the action.
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				'pinterest/jobs/generate_feed/chain_batch',
+				array( 1, array() ),
+				'pinterest-for-woocommerce'
+			);
+		$this->action_scheduler->method( 'search' )
+			->willReturn( array() );
+
+		$error = array(
+			'type'    => E_ERROR,
+			'message' => 'Maximum execution time',
+		);
+
+		// First timeout: should reschedule.
+		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
+
+		// Verify batch size was decreased.
+		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
+
+		// Second timeout with same action: should skip due to deduplication.
+		// The action is already scheduled from the first call.
+		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
+
+		// Batch size should not change further since rescheduling was skipped.
+		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 	}
 
 	/**
@@ -221,10 +267,10 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->feed_generator->handle_failed_execution( $action_id, new Exception( 'Some error msg.' ), '' );
 
 		$pending_actions = as_get_scheduled_actions(
-			[
+			array(
 				'hook'   => 'pinterest/jobs/generate_feed/chain_batch_foo',
 				'status' => 'pending',
-			]
+			)
 		);
 
 		$this->assertCount( 0, $pending_actions );
@@ -244,7 +290,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// Add a callback to throw an exception when the action is processed.
 		$callback = function () {
-			throw new Exception('Action `pinterest/jobs/generate_feed/chain_batch` failed to complete.' );
+			throw new Exception( 'Action `pinterest/jobs/generate_feed/chain_batch` failed to complete.' );
 		};
 		add_action( 'pinterest/jobs/generate_feed/chain_batch', $callback, 10, 2 );
 
@@ -280,7 +326,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->assertCount( 1, $future_actions );
 		/** @var ActionScheduler_Action $action */
-		$action = current( $future_actions );
+		$action         = current( $future_actions );
 		$delay_in_hours = (int) ceil( ( $action->get_schedule()->get_date()->getTimestamp() - time() ) / 3600 );
 		$this->assertEquals( 1, $delay_in_hours );
 	}
@@ -341,7 +387,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		try {
 			$this->feed_generator->handle_start_action( array() );
 		} catch ( Exception $e ) {
-			$feed_generation_status        = ProductFeedStatus::get()[ 'status' ];
+			$feed_generation_status        = ProductFeedStatus::get()['status'];
 			$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 			$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
@@ -369,7 +415,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function test_feed_generator_end_sets_product_count_into_persistent_state_property() {
 		ProductFeedStatus::set(
 			array(
-				'product_count'                                              => 13,
+				'product_count' => 13,
 				ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT => 1,
 			)
 		);
@@ -398,7 +444,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		try {
 			$this->feed_generator->handle_end_action( array() );
 		} catch ( Exception $e ) {
-			$feed_generation_status        = ProductFeedStatus::get()[ 'status' ];
+			$feed_generation_status        = ProductFeedStatus::get()['status'];
 			$feed_generation_wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 			$feed_generation_product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
@@ -418,7 +464,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_start_action( array() );
 
-		$status        = ProductFeedStatus::get()[ 'status' ];
+		$status        = ProductFeedStatus::get()['status'];
 		$wall_time     = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_WALL_TIME ];
 		$product_count = ProductFeedStatus::get()[ ProductFeedStatus::PROP_FEED_GENERATION_RECENT_PRODUCT_COUNT ];
 
@@ -439,7 +485,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_batch_action( 1, array() );
 
-		$this->assertEquals( 0, (int) \Pinterest_For_Woocommerce::get_data( 'feed_generation_retries' ));
+		$this->assertEquals( 0, (int) \Pinterest_For_Woocommerce::get_data( 'feed_generation_retries' ) );
 	}
 
 	public function test_handle_batch_action_queues_next_batch_when_there_are_items_to_process() {
@@ -456,7 +502,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_batch_action( 1, array() );
 
-		$this->assertEquals( 0, (int) \Pinterest_For_Woocommerce::get_data( 'feed_generation_retries' ));
+		$this->assertEquals( 0, (int) \Pinterest_For_Woocommerce::get_data( 'feed_generation_retries' ) );
 	}
 
 	/**
@@ -468,26 +514,26 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
 		$product_a = \WC_Helper_Product::create_simple_product(
 			true,
-			[
+			array(
 				'name' => 'In stock product',
-			]
+			)
 		);
 		$product_b = \WC_Helper_Product::create_simple_product(
 			true,
-			[
+			array(
 				'name'         => 'Product on backorder',
 				'stock_status' => 'onbackorder',
-			]
+			)
 		);
 		$product_c = \WC_Helper_Product::create_simple_product(
 			true,
-			[
+			array(
 				'name'         => 'Out of stock product',
 				'stock_status' => 'outofstock',
-			]
+			)
 		);
 
-		$ids = [ $product_a->get_id(), $product_b->get_id(), $product_c->get_id() ];
+		$ids = array( $product_a->get_id(), $product_b->get_id(), $product_c->get_id() );
 
 		$products = $this->feed_generator->get_feed_products( $ids );
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -16,6 +16,23 @@ use ReflectionMethod;
 use WC_Helper_Product;
 use WC_Product_Variable;
 
+/**
+ * Test helper class that wraps real Action Scheduler functions.
+ */
+class TestActionSchedulerProxy implements ActionSchedulerInterface {
+	public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
+		return as_schedule_single_action( time(), $hook, $args, $group );
+	}
+
+	public function search( array $args = array(), string $return_format = OBJECT ): array {
+		return array();
+	}
+
+	public function cancel( int $action_id ): void {}
+
+	public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
+}
+
 class FeedGeneratorTest extends \WP_UnitTestCase {
 
 	/** @var ActionSchedulerInterface */
@@ -130,9 +147,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_handle_unexpected_shutdown_does_throttle_product_number_when_rescheduling_the_action() {
-		// Use real FeedGenerator without mocks for this integration test.
+		// Use real FeedGenerator that schedules actual actions.
 		$real_feed_generator = new FeedGenerator(
-			$this->createMock( ActionSchedulerInterface::class ),
+			new TestActionSchedulerProxy(),
 			$this->feed_file_operations,
 			$this->local_feed_configs
 		);
@@ -147,22 +164,6 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$error = array(
 			'type'    => E_ERROR,
 			'message' => 'Maximum execution time',
-		);
-
-		// Mock search to return empty array (no failure threshold met).
-		$real_feed_generator = new FeedGenerator(
-			new class() implements ActionSchedulerInterface {
-				public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
-					return as_schedule_single_action( time(), $hook, $args, $group );
-				}
-				public function search( array $args = array(), string $return_format = OBJECT ): array {
-					return array();
-				}
-				public function cancel( int $action_id ): void {}
-				public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
-			},
-			$this->feed_file_operations,
-			$this->local_feed_configs
 		);
 
 		// First call: should reschedule and throttle.
@@ -186,16 +187,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function test_handle_unexpected_shutdown_skips_rescheduling_if_action_already_scheduled() {
 		// Use real FeedGenerator that actually schedules actions.
 		$real_feed_generator = new FeedGenerator(
-			new class() implements ActionSchedulerInterface {
-				public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
-					return as_schedule_single_action( time(), $hook, $args, $group );
-				}
-				public function search( array $args = array(), string $return_format = OBJECT ): array {
-					return array();
-				}
-				public function cancel( int $action_id ): void {}
-				public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
-			},
+			new TestActionSchedulerProxy(),
 			$this->feed_file_operations,
 			$this->local_feed_configs
 		);

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -543,6 +543,52 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests circuit breaker stops batch processing after reaching MAX_BATCHES_PER_CYCLE.
+	 *
+	 * @return void
+	 */
+	public function test_circuit_breaker_stops_processing_at_max_batches() {
+		// Set batch counter to just below the limit.
+		Pinterest_For_Woocommerce::save_data( 'feed_batch_count', FeedGenerator::MAX_BATCHES_PER_CYCLE - 1 );
+
+		// This should process normally (last allowed batch).
+		$items = $this->feed_generator->get_items_for_batch( 1, array() );
+		$this->assertIsArray( $items );
+
+		// Next call should return empty array due to circuit breaker.
+		$items = $this->feed_generator->get_items_for_batch( 2, array() );
+		$this->assertEmpty( $items, 'Circuit breaker should return empty array after max batches reached' );
+	}
+
+	/**
+	 * Tests that cursor is only advanced after successful batch processing.
+	 *
+	 * @return void
+	 */
+	public function test_cursor_deferred_until_successful_batch_completion() {
+		// Create a product to fetch.
+		WC_Helper_Product::create_simple_product();
+
+		// Set initial cursor.
+		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+
+		// Fetch items - this should store pending cursor but not commit it yet.
+		$items = $this->feed_generator->get_items_for_batch( 1, array() );
+		$this->assertNotEmpty( $items );
+
+		// Cursor should still be at initial value (not advanced yet).
+		$cursor_before = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$this->assertEquals( 0, $cursor_before, 'Cursor should not advance before handle_batch_action completes' );
+
+		// Complete batch processing.
+		$this->feed_generator->handle_batch_action( 1, array() );
+
+		// Now cursor should be advanced.
+		$cursor_after = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$this->assertGreaterThan( $cursor_before, $cursor_after, 'Cursor should advance after successful batch completion' );
+	}
+
+	/**
 	 * Tests get feed products method returns products in stock including products on backorder.
 	 *
 	 * @return void

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -20,16 +20,45 @@ use WC_Product_Variable;
  * Test helper class that wraps real Action Scheduler functions.
  */
 class TestActionSchedulerProxy implements ActionSchedulerInterface {
+	/**
+	 * Schedule an action to run immediately.
+	 *
+	 * @param string $hook  Action hook.
+	 * @param mixed  $args  Action arguments.
+	 * @param string $group Action group.
+	 * @return int Action ID.
+	 */
 	public function schedule_immediate( string $hook, $args = array(), string $group = '' ) {
 		return as_schedule_single_action( time(), $hook, $args, $group );
 	}
 
+	/**
+	 * Search for scheduled actions.
+	 *
+	 * @param mixed  $args          Search arguments.
+	 * @param string $return_format Return format.
+	 * @return array Empty array for testing.
+	 */
 	public function search( $args = array(), $return_format = OBJECT ) {
 		return array();
 	}
 
+	/**
+	 * Cancel an action.
+	 *
+	 * @param mixed $action_id Action ID.
+	 * @return void
+	 */
 	public function cancel( $action_id ) {}
 
+	/**
+	 * Cancel all actions matching criteria.
+	 *
+	 * @param string $hook  Action hook.
+	 * @param mixed  $args  Action arguments.
+	 * @param string $group Action group.
+	 * @return void
+	 */
 	public function cancel_all( string $hook, $args = array(), string $group = '' ) {}
 }
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -157,6 +157,15 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 		$this->assertEquals( 2, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
 
+		// Schedule a duplicate action to simulate what the first call would have done.
+		// This allows the deduplication logic to find it on the second call.
+		as_schedule_single_action(
+			time(),
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 1, array() ),
+			'pinterest-for-woocommerce'
+		);
+
 		// Second call should be skipped due to deduplication (action already scheduled).
 		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
 
@@ -199,6 +208,15 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// Verify batch size was decreased.
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
+
+		// Schedule a duplicate action to simulate what the first call would have done.
+		// This allows the deduplication logic to find it on the second call.
+		as_schedule_single_action(
+			time(),
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 1, array() ),
+			'pinterest-for-woocommerce'
+		);
 
 		// Second timeout with same action: should skip due to deduplication.
 		// The action is already scheduled from the first call.

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -246,6 +246,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			array( 1, array() ),
 			'pinterest-for-woocommerce'
 		);
+		// Cancel the pending action so as_has_scheduled_action() returns false on the first call,
+		// mirroring production where the action is in-progress (not pending) at shutdown time.
+		as_unschedule_action( 'pinterest/jobs/generate_feed/chain_batch', array( 1, array() ), 'pinterest-for-woocommerce' );
 
 		$error = array(
 			'type'    => E_ERROR,
@@ -284,6 +287,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			array( 1, array() ),
 			'pinterest-for-woocommerce'
 		);
+		// Cancel the pending action so as_has_scheduled_action() returns false on the first call,
+		// mirroring production where the action is in-progress (not pending) at shutdown time.
+		as_unschedule_action( 'pinterest/jobs/generate_feed/chain_batch', array( 1, array() ), 'pinterest-for-woocommerce' );
 
 		$error = array(
 			'type'    => E_ERROR,

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -20,17 +20,17 @@ use WC_Product_Variable;
  * Test helper class that wraps real Action Scheduler functions.
  */
 class TestActionSchedulerProxy implements ActionSchedulerInterface {
-	public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
+	public function schedule_immediate( string $hook, $args = array(), string $group = '' ) {
 		return as_schedule_single_action( time(), $hook, $args, $group );
 	}
 
-	public function search( array $args = array(), string $return_format = OBJECT ): array {
+	public function search( $args = array(), $return_format = OBJECT ) {
 		return array();
 	}
 
-	public function cancel( int $action_id ): void {}
+	public function cancel( $action_id ) {}
 
-	public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
+	public function cancel_all( string $hook, $args = array(), string $group = '' ) {}
 }
 
 class FeedGeneratorTest extends \WP_UnitTestCase {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -6,6 +6,7 @@ use ActionScheduler_Action;
 use ActionScheduler_QueueRunner;
 use ActionScheduler;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
+use Automattic\WooCommerce\Pinterest\Exception\FeedCircuitBreakerException;
 use Automattic\WooCommerce\Pinterest\FeedFileOperations;
 use Automattic\WooCommerce\Pinterest\FeedGenerator;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
@@ -573,16 +574,13 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_circuit_breaker_stops_processing_at_max_batches() {
-		// Set batch counter to just below the limit.
-		Pinterest_For_Woocommerce::save_data( 'feed_batch_count', FeedGenerator::MAX_BATCHES_PER_CYCLE - 1 );
-
-		// This should process normally (last allowed batch).
-		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
+		// The last allowed batch (batch_number = MAX_BATCHES_PER_CYCLE) should process normally.
+		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( FeedGenerator::MAX_BATCHES_PER_CYCLE, array() ) );
 		$this->assertIsArray( $items );
 
-		// Next call should return empty array due to circuit breaker.
-		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 2, array() ) );
-		$this->assertEmpty( $items, 'Circuit breaker should return empty array after max batches reached' );
+		// The next batch exceeds the limit and must throw so the feed is never silently truncated.
+		$this->expectException( Exception::class );
+		$this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( FeedGenerator::MAX_BATCHES_PER_CYCLE + 1, array() ) );
 	}
 
 	/**
@@ -764,5 +762,15 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		foreach ( $variation_ids as $variation_id ) {
 			$this->assertNotContains( $variation_id, $batch_ids );
 		}
+	}
+
+	/**
+	 * Verifies FeedCircuitBreakerException is throwable and is-a Exception.
+	 *
+	 * @return void
+	 */
+	public function test_feed_circuit_breaker_exception_is_an_exception() {
+		$this->expectException( FeedCircuitBreakerException::class );
+		throw new FeedCircuitBreakerException( 'limit reached' );
 	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -131,6 +131,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		as_unschedule_all_actions( 'pinterest/jobs/generate_feed/chain_batch', null, 'pinterest-for-woocommerce' );
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', null, 'pinterest-for-woocommerce' );
 		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		parent::tearDown();
 	}
@@ -614,13 +615,43 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_circuit_breaker_stops_processing_at_max_batches() {
-		// The last allowed batch (batch_number = MAX_BATCHES_PER_CYCLE) should process normally.
+		$product = WC_Helper_Product::create_simple_product();
+		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+		// Large batch size so the single product falls inside the boundary batch's query.
+		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', 10000 );
+
+		// The last allowed batch ( batch_number === MAX_BATCHES_PER_CYCLE ) must process
+		// normally and actually return the product — not a vacuous empty array.
 		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( FeedGenerator::MAX_BATCHES_PER_CYCLE, array() ) );
-		$this->assertIsArray( $items );
+		$this->assertContains( $product->get_id(), $items, 'Last allowed batch must still fetch products.' );
 
 		// The next batch exceeds the limit and must throw so the feed is never silently truncated.
 		$this->expectException( FeedCircuitBreakerException::class );
 		$this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( FeedGenerator::MAX_BATCHES_PER_CYCLE + 1, array() ) );
+	}
+
+	/**
+	 * Tests the circuit breaker honours a custom limit set via the filter.
+	 *
+	 * @return void
+	 */
+	public function test_circuit_breaker_respects_custom_filter_limit() {
+		$filter = static function () {
+			return 1;
+		};
+		add_filter( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', $filter );
+
+		try {
+			// Batch 1 is within the custom limit and must not throw.
+			$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
+			$this->assertIsArray( $items );
+
+			// Batch 2 exceeds the custom limit of 1 and must throw.
+			$this->expectException( FeedCircuitBreakerException::class );
+			$this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 2, array() ) );
+		} finally {
+			remove_filter( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', $filter );
+		}
 	}
 
 	/**
@@ -885,5 +916,77 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		$this->assertCount( 0, $note_ids, 'No inbox note should be created for non-circuit-breaker errors' );
+	}
+
+	/**
+	 * The circuit breaker must NOT reschedule a full regeneration — that would re-process
+	 * the over-limit catalog every cycle and trip the breaker again indefinitely.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_with_circuit_breaker_exception_does_not_schedule_retry() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+
+		$this->invoke_protected(
+			$this->feed_generator,
+			'handle_error',
+			array( new FeedCircuitBreakerException( 'limit reached' ), 'chain_batch' )
+		);
+
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'   => 'pinterest-for-woocommerce-start-feed-generation',
+				'status' => 'pending',
+				'group'  => 'pinterest-for-woocommerce',
+			)
+		);
+		$this->assertCount( 0, $pending, 'Circuit breaker must not schedule a full regeneration retry.' );
+	}
+
+	/**
+	 * A transient (non-circuit-breaker) error must still schedule a full regeneration retry.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_with_generic_exception_schedules_retry() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+
+		$this->invoke_protected(
+			$this->feed_generator,
+			'handle_error',
+			array( new \Exception( 'transient error' ), 'chain_batch' )
+		);
+
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'   => 'pinterest-for-woocommerce-start-feed-generation',
+				'status' => 'pending',
+				'group'  => 'pinterest-for-woocommerce',
+			)
+		);
+		$this->assertNotEmpty( $pending, 'Transient errors must schedule a full regeneration retry.' );
+	}
+
+	/**
+	 * When the product count is unavailable or low, the recommended limit must still
+	 * exceed the limit that just tripped — otherwise the note advises a useless value.
+	 *
+	 * @return void
+	 */
+	public function test_circuit_breaker_recommendation_exceeds_tripped_limit() {
+		// Empty product table => count is 0 => the raw formula yields 500, which is below
+		// the default tripped limit of 1000. The floor guard must bump it above 1000.
+		$this->invoke_protected(
+			$this->feed_generator,
+			'handle_error',
+			array( new FeedCircuitBreakerException( 'limit reached' ), 'chain_batch' )
+		);
+
+		$note = Notes::get_note(
+			current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) )
+		);
+
+		// Default MAX_BATCHES_PER_CYCLE is 1000; the floor guard bumps the recommendation to 2000.
+		$this->assertStringContainsString( '2000', $note->get_content() );
 	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -36,15 +36,17 @@ class TestActionSchedulerProxy implements ActionSchedulerInterface {
 	}
 
 	/**
-	 * Search for scheduled actions.
+	 * Search for scheduled actions — delegates to real Action Scheduler so status
+	 * filters (e.g. STATUS_PENDING) behave exactly as they would in production.
 	 *
-	 * @param mixed  $args          Search arguments.
-	 * @param string $return_format Return format.
+	 * @param mixed  $args          Search arguments (see as_get_scheduled_actions()).
+	 * @param string $return_format Return format: OBJECT, ARRAY_A, or 'ids'.
 	 * @param string $group         Action group.
-	 * @return array Empty array for testing.
+	 * @return array
 	 */
 	public function search( $args = array(), $return_format = OBJECT, string $group = '' ) {
-		return array();
+		$args['group'] = $group;
+		return as_get_scheduled_actions( $args, $return_format );
 	}
 
 	/**
@@ -246,9 +248,11 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			array( 1, array() ),
 			'pinterest-for-woocommerce'
 		);
-		// Cancel the pending action so as_has_scheduled_action() returns false on the first call,
-		// mirroring production where the action is in-progress (not pending) at shutdown time.
-		as_unschedule_action( 'pinterest/jobs/generate_feed/chain_batch', array( 1, array() ), 'pinterest-for-woocommerce' );
+		// Simulate Action Scheduler picking up the action: mark it in-progress exactly
+		// as AS does via process_action() → log_execution() before invoking our callback.
+		// This mirrors real timeout conditions and ensures the dedup guard (STATUS_PENDING
+		// only) allows the first reschedule even while the original action is running.
+		\ActionScheduler_Store::instance()->log_execution( $action_id );
 
 		$error = array(
 			'type'    => E_ERROR,
@@ -287,9 +291,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			array( 1, array() ),
 			'pinterest-for-woocommerce'
 		);
-		// Cancel the pending action so as_has_scheduled_action() returns false on the first call,
-		// mirroring production where the action is in-progress (not pending) at shutdown time.
-		as_unschedule_action( 'pinterest/jobs/generate_feed/chain_batch', array( 1, array() ), 'pinterest-for-woocommerce' );
+		// Simulate Action Scheduler picking up the action: mark it in-progress exactly
+		// as AS does via process_action() → log_execution() before invoking our callback.
+		\ActionScheduler_Store::instance()->log_execution( $action_id );
 
 		$error = array(
 			'type'    => E_ERROR,

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -159,8 +159,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// Schedule a duplicate action to simulate what the first call would have done.
 		// This allows the deduplication logic to find it on the second call.
+		// Schedule it in the future to keep it in "pending" status.
 		as_schedule_single_action(
-			time(),
+			time() + 10,
 			'pinterest/jobs/generate_feed/chain_batch',
 			array( 1, array() ),
 			'pinterest-for-woocommerce'
@@ -211,8 +212,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// Schedule a duplicate action to simulate what the first call would have done.
 		// This allows the deduplication logic to find it on the second call.
+		// Schedule it in the future to keep it in "pending" status.
 		as_schedule_single_action(
-			time(),
+			time() + 10,
 			'pinterest/jobs/generate_feed/chain_batch',
 			array( 1, array() ),
 			'pinterest-for-woocommerce'

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -820,6 +820,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function provide_product_count_to_recommended_limit(): array {
 		return array(
+			'0 products'    => array( 0, 500 ),
 			'50k products'  => array( 50000, 1000 ),
 			'120k products' => array( 120000, 1500 ),
 			'200k products' => array( 200000, 2500 ),

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -130,6 +130,13 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_handle_unexpected_shutdown_does_throttle_product_number_when_rescheduling_the_action() {
+		// Use real FeedGenerator without mocks for this integration test.
+		$real_feed_generator = new FeedGenerator(
+			$this->createMock( ActionSchedulerInterface::class ),
+			$this->feed_file_operations,
+			$this->local_feed_configs
+		);
+
 		$action_id = as_schedule_single_action(
 			gmdate( 'U' ) - 1,
 			'pinterest/jobs/generate_feed/chain_batch',
@@ -137,38 +144,34 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			'pinterest-for-woocommerce'
 		);
 
-		// The first call should reschedule (no duplicate exists yet).
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with(
-				'pinterest/jobs/generate_feed/chain_batch',
-				array( 1, array() ),
-				'pinterest-for-woocommerce'
-			);
-		$this->action_scheduler->method( 'search' )
-			->willReturn( array() );
-
 		$error = array(
 			'type'    => E_ERROR,
 			'message' => 'Maximum execution time',
 		);
-		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
 
+		// Mock search to return empty array (no failure threshold met).
+		$real_feed_generator = new FeedGenerator(
+			new class() implements ActionSchedulerInterface {
+				public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
+					return as_schedule_single_action( time(), $hook, $args, $group );
+				}
+				public function search( array $args = array(), string $return_format = OBJECT ): array {
+					return array();
+				}
+				public function cancel( int $action_id ): void {}
+				public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
+			},
+			$this->feed_file_operations,
+			$this->local_feed_configs
+		);
+
+		// First call: should reschedule and throttle.
+		$real_feed_generator->handle_unexpected_shutdown( $action_id, $error );
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 		$this->assertEquals( 2, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
 
-		// Schedule a duplicate action to simulate what the first call would have done.
-		// This allows the deduplication logic to find it on the second call.
-		// Schedule it in the future to keep it in "pending" status.
-		as_schedule_single_action(
-			time() + 10,
-			'pinterest/jobs/generate_feed/chain_batch',
-			array( 1, array() ),
-			'pinterest-for-woocommerce'
-		);
-
-		// Second call should be skipped due to deduplication (action already scheduled).
-		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
+		// Second call: should be skipped due to deduplication (action already scheduled from first call).
+		$real_feed_generator->handle_unexpected_shutdown( $action_id, $error );
 
 		// Batch size and attempt should remain the same since rescheduling was skipped.
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
@@ -181,6 +184,22 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_handle_unexpected_shutdown_skips_rescheduling_if_action_already_scheduled() {
+		// Use real FeedGenerator that actually schedules actions.
+		$real_feed_generator = new FeedGenerator(
+			new class() implements ActionSchedulerInterface {
+				public function schedule_immediate( string $hook, array $args = array(), string $group = '' ): int {
+					return as_schedule_single_action( time(), $hook, $args, $group );
+				}
+				public function search( array $args = array(), string $return_format = OBJECT ): array {
+					return array();
+				}
+				public function cancel( int $action_id ): void {}
+				public function cancel_all( string $hook, array $args = array(), string $group = '' ): void {}
+			},
+			$this->feed_file_operations,
+			$this->local_feed_configs
+		);
+
 		$action_id = as_schedule_single_action(
 			gmdate( 'U' ) - 1,
 			'pinterest/jobs/generate_feed/chain_batch',
@@ -188,43 +207,19 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			'pinterest-for-woocommerce'
 		);
 
-		// First call schedules the action.
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with(
-				'pinterest/jobs/generate_feed/chain_batch',
-				array( 1, array() ),
-				'pinterest-for-woocommerce'
-			);
-		$this->action_scheduler->method( 'search' )
-			->willReturn( array() );
-
 		$error = array(
 			'type'    => E_ERROR,
 			'message' => 'Maximum execution time',
 		);
 
-		// First timeout: should reschedule.
-		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
-
-		// Verify batch size was decreased.
+		// First timeout: should reschedule and decrease batch size.
+		$real_feed_generator->handle_unexpected_shutdown( $action_id, $error );
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 
-		// Schedule a duplicate action to simulate what the first call would have done.
-		// This allows the deduplication logic to find it on the second call.
-		// Schedule it in the future to keep it in "pending" status.
-		as_schedule_single_action(
-			time() + 10,
-			'pinterest/jobs/generate_feed/chain_batch',
-			array( 1, array() ),
-			'pinterest-for-woocommerce'
-		);
+		// Second timeout: deduplication should prevent rescheduling since action already exists.
+		$real_feed_generator->handle_unexpected_shutdown( $action_id, $error );
 
-		// Second timeout with same action: should skip due to deduplication.
-		// The action is already scheduled from the first call.
-		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
-
-		// Batch size should not change further since rescheduling was skipped.
+		// Batch size should remain unchanged since deduplication skipped the second reschedule.
 		$this->assertEquals( 50, \Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 	}
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -989,4 +989,31 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		// Default MAX_BATCHES_PER_CYCLE is 1000; the floor guard bumps the recommendation to 2000.
 		$this->assertStringContainsString( '2000', $note->get_content() );
 	}
+
+	/**
+	 * Action Scheduler's queue runner catches the original Throwable and re-throws a generic
+	 * Exception, exposing the original only via getPrevious(). handle_error must still detect
+	 * the circuit breaker through the exception chain — to add the note and skip the retry.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_detects_circuit_breaker_wrapped_by_action_scheduler() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+
+		// Mirror ActionScheduler_Abstract_QueueRunner: throw new Exception( msg, code, $original ).
+		$wrapped = new \Exception( 'limit reached', 0, new FeedCircuitBreakerException( 'limit reached' ) );
+		$this->invoke_protected( $this->feed_generator, 'handle_error', array( $wrapped, 'chain_batch' ) );
+
+		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		$this->assertNotEmpty( $note_ids, 'Note must be created even when the breaker exception is wrapped by Action Scheduler.' );
+
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'   => 'pinterest-for-woocommerce-start-feed-generation',
+				'status' => 'pending',
+				'group'  => 'pinterest-for-woocommerce',
+			)
+		);
+		$this->assertCount( 0, $pending, 'A wrapped circuit breaker exception must not schedule a full regeneration retry.' );
+	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -92,6 +92,31 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up Action Scheduler entries after each test to prevent cross-test interference
+	 * when the deduplication guard checks for pending scheduled actions.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		as_unschedule_all_actions( 'pinterest/jobs/generate_feed/chain_batch', null, 'pinterest-for-woocommerce' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper to invoke a protected method on FeedGenerator via reflection.
+	 *
+	 * @param FeedGenerator $generator    The FeedGenerator instance.
+	 * @param string        $method_name  Name of the protected method.
+	 * @param array         $args         Arguments to pass to the method.
+	 * @return mixed Return value of the method.
+	 */
+	private function invoke_protected( FeedGenerator $generator, string $method_name, array $args = array() ) {
+		$reflection = new \ReflectionMethod( FeedGenerator::class, $method_name );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $generator, $args );
+	}
+
+	/**
 	 * Tests feed generator registers the action scheduler failed execution hook.
 	 *
 	 * @return void
@@ -552,11 +577,11 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		Pinterest_For_Woocommerce::save_data( 'feed_batch_count', FeedGenerator::MAX_BATCHES_PER_CYCLE - 1 );
 
 		// This should process normally (last allowed batch).
-		$items = $this->feed_generator->get_items_for_batch( 1, array() );
+		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
 		$this->assertIsArray( $items );
 
 		// Next call should return empty array due to circuit breaker.
-		$items = $this->feed_generator->get_items_for_batch( 2, array() );
+		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 2, array() ) );
 		$this->assertEmpty( $items, 'Circuit breaker should return empty array after max batches reached' );
 	}
 
@@ -573,7 +598,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
 
 		// Fetch items - this should store pending cursor but not commit it yet.
-		$items = $this->feed_generator->get_items_for_batch( 1, array() );
+		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
 		$this->assertNotEmpty( $items );
 
 		// Cursor should still be at initial value (not advanced yet).

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -846,6 +846,6 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->invoke_protected( $this->feed_generator, 'handle_error', array( $exception, 'chain_batch' ) );
 
 		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
-		$this->assertEmpty( $note_ids, 'No inbox note should be created for non-circuit-breaker errors' );
+		$this->assertCount( 0, $note_ids, 'No inbox note should be created for non-circuit-breaker errors' );
 	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -50,10 +50,12 @@ class TestActionSchedulerProxy implements ActionSchedulerInterface {
 	/**
 	 * Cancel an action.
 	 *
-	 * @param mixed $action_id Action ID.
+	 * @param string $hook  Action hook.
+	 * @param mixed  $args  Action arguments.
+	 * @param string $group Action group.
 	 * @return void
 	 */
-	public function cancel( $action_id ) {}
+	public function cancel( string $hook, $args = array(), string $group = '' ) {}
 
 	/**
 	 * Cancel all actions matching criteria.

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -773,4 +773,49 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->expectException( FeedCircuitBreakerException::class );
 		throw new FeedCircuitBreakerException( 'limit reached' );
 	}
+
+	/**
+	 * @return void
+	 */
+	public function test_count_published_products_counts_only_published() {
+		$before = $this->invoke_protected( $this->feed_generator, 'count_published_products', array() );
+
+		// Published product — should be counted.
+		WC_Helper_Product::create_simple_product();
+
+		// Draft product — should NOT be counted.
+		$draft = WC_Helper_Product::create_simple_product();
+		wp_update_post( array( 'ID' => $draft->get_id(), 'post_status' => 'draft' ) );
+
+		$after = $this->invoke_protected( $this->feed_generator, 'count_published_products', array() );
+
+		$this->assertEquals( $before + 1, $after, 'Only published products should be counted' );
+	}
+
+	/**
+	 * @dataProvider provide_product_count_to_recommended_limit
+	 * @param int $total    Total product count.
+	 * @param int $expected Expected recommended limit.
+	 * @return void
+	 */
+	public function test_calculate_recommended_batch_limit( int $total, int $expected ) {
+		$result = $this->invoke_protected(
+			$this->feed_generator,
+			'calculate_recommended_batch_limit',
+			array( $total )
+		);
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @return array<string, array{int, int}>
+	 */
+	public function provide_product_count_to_recommended_limit(): array {
+		return array(
+			'50k products'  => array( 50000,  1000 ),
+			'120k products' => array( 120000, 1500 ),
+			'200k products' => array( 200000, 2500 ),
+			'500k products' => array( 500000, 6500 ),
+		);
+	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -785,7 +785,12 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// Draft product — should NOT be counted.
 		$draft = WC_Helper_Product::create_simple_product();
-		wp_update_post( array( 'ID' => $draft->get_id(), 'post_status' => 'draft' ) );
+		wp_update_post(
+			array(
+				'ID'          => $draft->get_id(),
+				'post_status' => 'draft',
+			)
+		);
 
 		$after = $this->invoke_protected( $this->feed_generator, 'count_published_products', array() );
 
@@ -812,7 +817,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function provide_product_count_to_recommended_limit(): array {
 		return array(
-			'50k products'  => array( 50000,  1000 ),
+			'50k products'  => array( 50000, 1000 ),
 			'120k products' => array( 120000, 1500 ),
 			'200k products' => array( 200000, 2500 ),
 			'500k products' => array( 500000, 6500 ),

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -6,8 +6,10 @@ use ActionScheduler_Action;
 use ActionScheduler_QueueRunner;
 use ActionScheduler;
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionSchedulerInterface;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Pinterest\Exception\FeedCircuitBreakerException;
 use Automattic\WooCommerce\Pinterest\FeedFileOperations;
+use Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote;
 use Automattic\WooCommerce\Pinterest\FeedGenerator;
 use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
 use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
@@ -100,6 +102,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		as_unschedule_all_actions( 'pinterest/jobs/generate_feed/chain_batch', null, 'pinterest-for-woocommerce' );
+		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		parent::tearDown();
 	}
 
@@ -579,7 +582,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertIsArray( $items );
 
 		// The next batch exceeds the limit and must throw so the feed is never silently truncated.
-		$this->expectException( Exception::class );
+		$this->expectException( FeedCircuitBreakerException::class );
 		$this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( FeedGenerator::MAX_BATCHES_PER_CYCLE + 1, array() ) );
 	}
 
@@ -822,5 +825,27 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			'200k products' => array( 200000, 2500 ),
 			'500k products' => array( 500000, 6500 ),
 		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_handle_error_with_circuit_breaker_exception_creates_inbox_note() {
+		$exception = new FeedCircuitBreakerException( 'limit reached' );
+		$this->invoke_protected( $this->feed_generator, 'handle_error', array( $exception, 'chain_batch' ) );
+
+		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		$this->assertNotEmpty( $note_ids, 'Inbox note should be created when the circuit breaker trips' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_handle_error_with_generic_exception_does_not_create_inbox_note() {
+		$exception = new \Exception( 'some other error' );
+		$this->invoke_protected( $this->feed_generator, 'handle_error', array( $exception, 'chain_batch' ) );
+
+		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		$this->assertEmpty( $note_ids, 'No inbox note should be created for non-circuit-breaker errors' );
 	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -37,9 +37,10 @@ class TestActionSchedulerProxy implements ActionSchedulerInterface {
 	 *
 	 * @param mixed  $args          Search arguments.
 	 * @param string $return_format Return format.
+	 * @param string $group         Action group.
 	 * @return array Empty array for testing.
 	 */
-	public function search( $args = array(), $return_format = OBJECT ) {
+	public function search( $args = array(), $return_format = OBJECT, string $group = '' ) {
 		return array();
 	}
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -66,6 +66,31 @@ class TestActionSchedulerProxy implements ActionSchedulerInterface {
 	 * @return void
 	 */
 	public function cancel_all( string $hook, $args = array(), string $group = '' ) {}
+
+	/**
+	 * Schedule a single action at a given timestamp.
+	 *
+	 * @param mixed  $timestamp Unix timestamp.
+	 * @param string $hook      Action hook.
+	 * @param mixed  $args      Action arguments.
+	 * @param string $group     Action group.
+	 * @return int Action ID.
+	 */
+	public function schedule_single( $timestamp, $hook, $args = array(), string $group = '' ) {
+		return as_schedule_single_action( $timestamp, $hook, $args, $group );
+	}
+
+	/**
+	 * Get the next scheduled action timestamp.
+	 *
+	 * @param string      $hook  Action hook.
+	 * @param mixed       $args  Action arguments.
+	 * @param string      $group Action group.
+	 * @return int|bool
+	 */
+	public function next_scheduled_action( $hook, $args = null, string $group = '' ) {
+		return as_next_scheduled_action( $hook, $args, $group );
+	}
 }
 
 class FeedGeneratorTest extends \WP_UnitTestCase {

--- a/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
+++ b/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit\Notes;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote;
+
+class FeedCircuitBreakerNoteTest extends \WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+	}
+
+	public function tearDown(): void {
+		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_add_note_creates_note_when_none_exists() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+
+		$note_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		$this->assertCount( 1, $note_ids );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_add_note_replaces_existing_unactioned_note() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+		$first_id = current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) );
+
+		FeedCircuitBreakerNote::add_note( 3000 );
+		$second_ids = Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+
+		$this->assertCount( 1, $second_ids, 'Only one note should exist after two add_note calls' );
+		$this->assertNotEquals( $first_id, current( $second_ids ), 'Should be a new note, not the original' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_add_note_replaces_dismissed_note() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+
+		$data_store = Notes::load_data_store();
+		$note       = Notes::get_note( current( $data_store->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) ) );
+		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note->save();
+
+		FeedCircuitBreakerNote::add_note( 3000 );
+
+		$note_ids   = $data_store->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
+		$fresh_note = Notes::get_note( current( $note_ids ) );
+		$this->assertCount( 1, $note_ids );
+		$this->assertEquals( Note::E_WC_ADMIN_NOTE_UNACTIONED, $fresh_note->get_status() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_note_has_warning_type_and_correct_title() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+
+		$note = Notes::get_note(
+			current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) )
+		);
+
+		$this->assertEquals( Note::E_WC_ADMIN_NOTE_WARNING, $note->get_type() );
+		$this->assertStringContainsString( 'Pinterest catalog feed incomplete', $note->get_title() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_note_body_contains_recommended_limit() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+
+		$note = Notes::get_note(
+			current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) )
+		);
+
+		$this->assertStringContainsString( '2500', $note->get_content() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_note_has_catalog_sync_and_dismiss_actions() {
+		FeedCircuitBreakerNote::add_note( 2500 );
+
+		$note        = Notes::get_note(
+			current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) )
+		);
+		$action_names = array_map( fn( $a ) => $a->name, $note->get_actions() );
+
+		$this->assertContains( 'go-to-catalog-sync', $action_names );
+		$this->assertContains( 'dismiss', $action_names );
+	}
+}

--- a/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
+++ b/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
@@ -6,13 +6,22 @@ use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote;
 
+/**
+ * FeedCircuitBreakerNoteTest class.
+ */
 class FeedCircuitBreakerNoteTest extends \WP_UnitTestCase {
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function tearDown(): void {
 		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		parent::tearDown();
@@ -94,7 +103,7 @@ class FeedCircuitBreakerNoteTest extends \WP_UnitTestCase {
 	public function test_note_has_catalog_sync_and_dismiss_actions() {
 		FeedCircuitBreakerNote::add_note( 2500 );
 
-		$note        = Notes::get_note(
+		$note         = Notes::get_note(
 			current( Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) )
 		);
 		$action_names = array_map( fn( $a ) => $a->name, $note->get_actions() );


### PR DESCRIPTION
## Summary

Fixes three critical issues in the feed generator that cause runaway scheduling and database bloat at scale, as reported in customer feedback.

### Changes

1. **Fix cursor advancement before processing**
   - Modified `get_items_for_batch()` to store the last batch ID in a pending property
   - Cursor is only committed to persistent storage after successful batch processing in `handle_batch_action()`
   - Prevents timeouts from causing cursor advancement before batch processing completes
   - Ensures retries re-process the correct batch instead of skipping to the next one

2. **Add deduplication for timeout retries**
   - Added `as_has_scheduled_action()` check in `handle_unexpected_shutdown()` before rescheduling
   - Prevents overlapping retries that fetch different work than originally intended
   - Eliminates fan-out of duplicate batches when timeouts occur

3. **Add circuit breaker to prevent runaway scheduling**
   - Added `MAX_BATCHES_PER_CYCLE` constant (1000 batches)
   - Track batch count during generation cycle
   - Abort with warning if maximum batch limit is reached
   - Prevents excessive Action Scheduler entries and database bloat

## Problem

As reported in [WordPress.org support thread](https://wordpress.org/support/topic/do-not-use-badly-designed-plugin/), the feed generation job was not robust at scale:
- Cursor (`feed_last_queued_item_id`) advanced in `get_items_for_batch()` before batch processing
- `handle_unexpected_shutdown()` blindly rescheduled timed-out batches without deduplication
- Timeout + cursor advancement = retries fetch wrong batch, creating overlapping work
- No circuit breaker to limit total batches, allowing runaway scheduling
- Result: massive Action Scheduler bloat, database timeouts, feed generation failures

## Testing

- ✅ Code passes `vendor/bin/phpcs` (WooCommerce coding standards)
- ✅ All phpcs violations resolved
- Manual testing recommended on stores with large catalogs (10k+ products)

## Related Issues

- Fixes: [PIN4WOO-70](https://linear.app/a8c/issue/PIN4WOO-70)
- Related: [ACTSCH-92](https://linear.app/a8c/issue/ACTSCH-92) (Action Scheduler logs bloat)
- Similar fix pattern used in: [AUTOM8-213](https://linear.app/a8c/issue/AUTOM8-213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Feed generator robustness at scale