### PR TITLE
Fix: Resolve console error in Pinterest Save button script

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -1,7 +1,5 @@
-/*global fetch*/
-
 /**
- * Disable the Save to Pinterest button if the Chrome extension is detected.
+ * Disable the Save to Pinterest button if the Pinterest browser extension is detected.
  */
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.addEventListener( 'load', function () {
@@ -13,13 +11,14 @@ window.addEventListener( 'load', function () {
 			} );
 	};
 
-	const isChromeExtensionDetected = () => {
-		fetch(
-			`chrome-extension://gpdjojdkbbmdfjfahjcgigfpmkopogic/html/save.html`
-		)
-			.then( () => disableSaveButton() )
-			.catch( () => false );
+	const checkForPinterestExtension = () => {
+		const pinterestElement = document.querySelector(
+			'[data-pinterest-extension]'
+		);
+		if ( pinterestElement ) {
+			disableSaveButton();
+		}
 	};
 
-	isChromeExtensionDetected();
+	checkForPinterestExtension();
 } );


### PR DESCRIPTION
## Summary
Fixes PIN4WOO-50: The Pinterest Save button JS script threw console errors due to unsupported fetch API usage.

## Changes
- Replaced fetch-based Chrome extension detection with DOM-based approach
- The previous code used `fetch()` with a `chrome-extension://` URL, which is not supported by the fetch API and threw console errors on every page load
- Now checks for the `[data-pinterest-extension]` attribute that the Pinterest browser extension injects into the DOM

## Testing
1. Install Pinterest for WooCommerce
2. Visit a product page on the frontend
3. Open browser console
4. Verify no console errors related to the Save button script
5. If the Pinterest browser extension is installed, verify the plugin's Save button is hidden (the extension provides its own)

## Linear Issue
https://linear.app/a8c/issue/PIN4WOO-50

## GitHub Issue
https://github.com/woocommerce/pinterest-for-woocommerce/issues/1117

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)

### Changelog entry

> Fix - Resolve console error in Pinterest Save button script.