### PR TITLE
Restore class_exists guard on record_event

### DIFF
--- a/src/Utilities/Tracks.php
+++ b/src/Utilities/Tracks.php
@@ -24,6 +24,10 @@ trait Tracks {
 	 * @param array  $properties Array of properties to include with the event.
 	 */
 	private static function record_event( string $name, array $properties = array() ): void {
-		WC_Tracks::record_event( $name, $properties );
+		if ( class_exists( '\WC_Tracks' ) ) {
+			\WC_Tracks::record_event( $name, $properties );
+		} elseif ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event( $name, $properties );
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Commit `832a1013` (PR #1159, "Remove WC 6.x compatibility code") removed the guarded implementation of `Utilities\Tracks::record_event()` and replaced it with a bare call to `WC_Tracks::record_event(...)`. That introduced two defects:

1. **Missing leading backslash.** `Tracks.php` declares `namespace Automattic\WooCommerce\Pinterest\Utilities`, so the unqualified `WC_Tracks` resolves to `Automattic\WooCommerce\Pinterest\Utilities\WC_Tracks` — a class that doesn't exist.
2. **Missing `class_exists` guard.** `\WC_Tracks` is only loaded in WooCommerce admin contexts. Action Scheduler processes heartbeat actions via cron, REST and CLI, where `\WC_Tracks` isn't available.

As a result, every Action Scheduler heartbeat action that reaches `record_event()` fatals with:

```
Fatal error: Uncaught Error: Class "Automattic\WooCommerce\Pinterest\Utilities\WC_Tracks" not found
```

## Fix

Restore the guarded behavior that existed prior to `832a1013`, with an explicit global-namespace reference:

```php
if ( class_exists( '\WC_Tracks' ) ) {
    \WC_Tracks::record_event( $name, $properties );
} elseif ( function_exists( 'wc_admin_record_tracks_event' ) ) {
    wc_admin_record_tracks_event( $name, $properties );
}
```

Behavior:
- In WC admin contexts, records via `\WC_Tracks::record_event()` directly.
- In cron / REST / CLI contexts, falls back to `wc_admin_record_tracks_event()` if present.
- Otherwise silently no-ops, matching the pre-`832a1013` fallback behavior.

## Bug

PIN4WOO-73: https://linear.app/a8c/issue/PIN4WOO-73

## Testing

- `vendor/bin/phpcs src/Utilities/Tracks.php` passes.
- No existing unit tests cover the `Tracks` trait; meaningful coverage would require mocking the global `\WC_Tracks` class, which is out of scope for this restoration. Happy to add one if a reviewer wants.
- Manual verification: in a non-admin context (cron/REST/CLI), `record_event()` previously fataled; with this change it no-ops gracefully. In admin contexts, the event is recorded via `\WC_Tracks` as intended.

## Follow-up (not in this PR)

The reporter also flagged a re-scheduling amplification in `Heartbeat::schedule_events()`: because `as_has_scheduled_action()` doesn't see failed actions, every page load re-creates the recurring schedule, producing clusters of failures far more frequent than the intended hourly cadence. Once this fatal stops, the hourly recurrence works as designed, but the re-scheduling loop is worth a separate look.



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Restore class_exists guard on record_event