### PR TITLE
Treat additional Pinterest redeem error codes as terminal

### DIFF
--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -91,13 +91,9 @@ class AdCredits {
 		$redeem_status = $account_data['coupon_redeem_info']['redeem_status'] ?? false;
 		$error_id      = $account_data['coupon_redeem_info']['error_id'] ?? false;
 
-		if ( PinterestApiException::OFFER_ALREADY_REDEEMED === $error_id ) {
-			// Advertiser has already redeemed the coupon.
-			return true;
-		}
-
-		if ( PinterestApiException::OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER === $error_id ) {
-			// Different advertiser id has already redeemed the coupon.
+		if ( in_array( $error_id, PinterestApiException::TERMINAL_REDEEM_ERRORS, true ) ) {
+			// A prior attempt hit a terminal error from Pinterest (e.g., the
+			// offer has already been redeemed). Do not retry.
 			return true;
 		}
 

--- a/src/AdCredits.php
+++ b/src/AdCredits.php
@@ -32,6 +32,19 @@ class AdCredits {
 	private const MARKETING_OFFER_CREDIT = 'MARKETING_OFFER_CREDIT';
 
 	/**
+	 * Pinterest error codes that mean the ad-credit offer can no longer be
+	 * redeemed by this plugin. When any of these is recorded we stop retrying
+	 * the redeem endpoint, since further calls would just repeat the failure.
+	 *
+	 * @var int[]
+	 */
+	private const ALREADY_REDEEMED_ERRORS = array(
+		PinterestApiException::OFFER_ALREADY_REDEEMED,
+		PinterestApiException::OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER,
+		PinterestApiException::OFFER_ALREADY_REDEEMED_VARIANT,
+	);
+
+	/**
 	 * Initialize Ad Credits actions and Action Scheduler hooks.
 	 *
 	 * @since 1.2.5
@@ -91,7 +104,7 @@ class AdCredits {
 		$redeem_status = $account_data['coupon_redeem_info']['redeem_status'] ?? false;
 		$error_id      = $account_data['coupon_redeem_info']['error_id'] ?? false;
 
-		if ( in_array( $error_id, PinterestApiException::TERMINAL_REDEEM_ERRORS, true ) ) {
+		if ( in_array( $error_id, self::ALREADY_REDEEMED_ERRORS, true ) ) {
 			// A prior attempt hit a terminal error from Pinterest (e.g., the
 			// offer has already been redeemed). Do not retry.
 			return true;
@@ -274,5 +287,4 @@ class AdCredits {
 
 		return $found_discounts;
 	}
-
 }

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -59,6 +59,28 @@ class PinterestApiException extends \Exception {
 	public const OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER = 2318;
 
 	/**
+	 * Offer already redeemed — additional Pinterest error code observed for
+	 * the same condition.
+	 *
+	 * Observed in customer ticket #11013264 (PIN4WOO-74). Pinterest returns
+	 * this code alongside 2324 / 2318 for offer-redemption conflicts; the
+	 * exact distinction is not documented in the public API, but it has the
+	 * same terminal semantics as the other already-redeemed codes.
+	 */
+	public const OFFER_ALREADY_REDEEMED_VARIANT = 2322;
+
+	/**
+	 * Pinterest error codes that indicate a terminal, non-retryable failure of
+	 * the `ads_credit/redeem` endpoint. All of these mean the offer cannot be
+	 * redeemed again from this plugin's perspective.
+	 */
+	public const TERMINAL_REDEEM_ERRORS = array(
+		self::OFFER_ALREADY_REDEEMED,
+		self::OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER,
+		self::OFFER_ALREADY_REDEEMED_VARIANT,
+	);
+
+	/**
 	 * Merchant has been disapproved.
 	 * Some feeds, when deleting, may fail to delete due to the merchant has been disapproved.
 	 */

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -70,17 +70,6 @@ class PinterestApiException extends \Exception {
 	public const OFFER_ALREADY_REDEEMED_VARIANT = 2322;
 
 	/**
-	 * Pinterest error codes that indicate a terminal, non-retryable failure of
-	 * the `ads_credit/redeem` endpoint. All of these mean the offer cannot be
-	 * redeemed again from this plugin's perspective.
-	 */
-	public const TERMINAL_REDEEM_ERRORS = array(
-		self::OFFER_ALREADY_REDEEMED,
-		self::OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER,
-		self::OFFER_ALREADY_REDEEMED_VARIANT,
-	);
-
-	/**
 	 * Merchant has been disapproved.
 	 * Some feeds, when deleting, may fail to delete due to the merchant has been disapproved.
 	 */

--- a/src/PinterestApiException.php
+++ b/src/PinterestApiException.php
@@ -62,10 +62,10 @@ class PinterestApiException extends \Exception {
 	 * Offer already redeemed — additional Pinterest error code observed for
 	 * the same condition.
 	 *
-	 * Observed in customer ticket #11013264 (PIN4WOO-74). Pinterest returns
-	 * this code alongside 2324 / 2318 for offer-redemption conflicts; the
-	 * exact distinction is not documented in the public API, but it has the
-	 * same terminal semantics as the other already-redeemed codes.
+	 * Observed during investigation for PIN4WOO-74. Pinterest returns this
+	 * code alongside 2324 / 2318 for offer-redemption conflicts; the exact
+	 * distinction is not documented in the public API, but it has the same
+	 * terminal semantics as the other already-redeemed codes.
 	 */
 	public const OFFER_ALREADY_REDEEMED_VARIANT = 2322;
 


### PR DESCRIPTION
## Summary

`AdCredits::check_if_coupon_was_redeemed()` only recognizes Pinterest error codes `2324` (`OFFER_ALREADY_REDEEMED`) and `2318` (`OFFER_ALREADY_REDEEMED_BY_ANOTHER_ADVERTISER`) as terminal. Support logs show Pinterest also returns `2322` for the same "already redeemed" condition. Because the check has no branch for `2322`, `handle_redeem_credit()` keeps firing the redeem API every hour, each call returning an identical 400, forever.

## Changes

- **`src/PinterestApiException.php`**: add `OFFER_ALREADY_REDEEMED_VARIANT = 2322` with a docblock noting where it was observed, and introduce a `TERMINAL_REDEEM_ERRORS` list holding all three already-redeemed codes.
- **`src/AdCredits.php`**: replace the two hard-coded `===` checks in `check_if_coupon_was_redeemed()` with a single `in_array( $error_id, PinterestApiException::TERMINAL_REDEEM_ERRORS, true )`. Behavior for `2324` and `2318` is unchanged; `2322` now short-circuits retries the same way.

## Bug

PIN4WOO-74: https://linear.app/a8c/issue/PIN4WOO-74

## Context: relationship to PIN4WOO-73 / PR #1169

One of the reported sites shows the redeem API being hit every 6 seconds — far more often than the hourly heartbeat can account for. Tracing the code, this appears to be a downstream symptom of PIN4WOO-73:

- `Pinterest_For_Woocommerce::add_redeem_credits_info_to_account_data()` (`class-pinterest-for-woocommerce.php:1143`) calls the redeem API, builds `$redeem_information` with `error_id => 2324`, then calls `self::record_event(...)` on line 1165 — which fatals per PIN4WOO-73.
- The script dies before line 1174 (`$account_data['coupon_redeem_info'] = $redeem_information`), so the terminal `error_id` is never persisted. The next `handle_redeem_credit()` run still sees an empty `coupon_redeem_info` and fires the API again.
- The 5–10 minute / 6-second cadence matches the `Heartbeat::schedule_events()` re-scheduling loop also described in PIN4WOO-73.

Once #1169 merges, the `2324` case will persist correctly and the hourly check will short-circuit as designed. **This PR addresses the independent gap for `2322`**, which would still retry forever (at hourly cadence) even after #1169 is in.

## Testing

- `vendor/bin/phpcs src/AdCredits.php src/PinterestApiException.php` — no new violations. The errors that do show on `src/AdCredits.php` all pre-date this change (verified by running phpcs against `develop` at the same files).
- No unit tests exist for `check_if_coupon_was_redeemed()` today. A meaningful regression test would need to seed `account_data` with a `coupon_redeem_info.error_id = 2322` and assert that `check_if_coupon_was_redeemed()` returns `true` without invoking the API. Happy to add one if a reviewer would like it.

## Follow-up (not in this PR)

The Linear issue mentions two related bugs:

- PIN4WOO-28 — same missing back-off pattern on the create-merchant endpoint.
- PIN4WOO-44 — same pattern on `v3_create_commerce_partner_merchant` 409 errors.

Both look like the same class of issue (retry forever on responses that are in fact terminal) on different endpoints; each deserves its own fix.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Treat additional Pinterest redeem error codes as terminal
