### PR TITLE
Add core WooCommerce product_brand to Pinterest feed as g:brand

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -84,6 +84,13 @@ class ProductsXmlFeed {
 	 */
 	const PRODUCT_TYPE_CHARS_LIMIT = 1000;
 
+	/**
+	 * Limit of characters allowed by Pinterest in the brand.
+	 *
+	 * @var int
+	 */
+	const BRAND_CHARS_LIMIT = 100;
+
 
 	/**
 	 * Returns the XML header to be printed.
@@ -525,6 +532,12 @@ class ProductsXmlFeed {
 
 		if ( empty( $brand ) ) {
 			return '';
+		}
+
+		// Ensure brand doesn't exceed Pinterest's character limit.
+		if ( strlen( $brand ) > self::BRAND_CHARS_LIMIT ) {
+			Logger::log( sprintf( 'Product [%1$s] brand length is %2$d characters, truncating to %3$d characters as per Pinterest requirements.', $id, strlen( $brand ), self::BRAND_CHARS_LIMIT ) );
+			$brand = substr( $brand, 0, self::BRAND_CHARS_LIMIT );
 		}
 
 		return '<' . $property . '>' . self::sanitize( $brand ) . '</' . $property . '>';

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -43,6 +43,7 @@ class ProductsXmlFeed {
 		'g:price',
 		'sale_price',
 		'g:mpn',
+		'g:brand',
 		'g:tax',
 		'g:shipping',
 		'g:additional_image_link',
@@ -496,6 +497,38 @@ class ProductsXmlFeed {
 		return '<' . $property . '>' . self::sanitize( $product->get_sku() ) . '</' . $property . '>';
 	}
 
+
+	/**
+	 * Returns the brand of the product from the core WooCommerce product_brand taxonomy.
+	 *
+	 * @param WC_Product $product The product.
+	 * @param string     $property The name of the property.
+	 *
+	 * @return string
+	 */
+	private static function get_property_g_brand( $product, $property ) {
+		$id    = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
+		$terms = wc_get_object_terms( $id, 'product_brand' );
+
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			return '';
+		}
+
+		/**
+		 * Filters the brand value included in the Pinterest feed.
+		 *
+		 * @since 1.4.27
+		 * @param string     $brand   The brand name.
+		 * @param WC_Product $product The product.
+		 */
+		$brand = apply_filters( 'pinterest_for_woocommerce_product_brand', $terms[0]->name, $product );
+
+		if ( empty( $brand ) ) {
+			return '';
+		}
+
+		return '<' . $property . '>' . self::sanitize( $brand ) . '</' . $property . '>';
+	}
 
 	/**
 	 * Returns the gallery images for the product.

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -975,6 +975,86 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the brand value can be overridden and suppressed via the
+	 * pinterest_for_woocommerce_product_brand filter.
+	 *
+	 * @group feed
+	 */
+	public function testPropertyBrandFilterXML() {
+		$brand_method = $this->getProductsXmlFeedAttributeMethod( 'g:brand' );
+		$product      = WC_Helper_Product::create_simple_product();
+
+		$term = wp_insert_term( 'Reebok', 'product_brand' );
+		wp_set_object_terms( $product->get_id(), $term['term_id'], 'product_brand' );
+
+		// Override the brand value.
+		add_filter(
+			'pinterest_for_woocommerce_product_brand',
+			static function () {
+				return 'Custom Brand';
+			}
+		);
+		$this->assertEquals( '<g:brand>Custom Brand</g:brand>', $brand_method( $product ) );
+		remove_all_filters( 'pinterest_for_woocommerce_product_brand' );
+
+		// Suppress the brand value.
+		add_filter( 'pinterest_for_woocommerce_product_brand', '__return_empty_string' );
+		$this->assertEquals( '', $brand_method( $product ) );
+		remove_all_filters( 'pinterest_for_woocommerce_product_brand' );
+	}
+
+	/**
+	 * Test that a brand longer than the allowed limit is truncated and logged.
+	 *
+	 * @group feed
+	 */
+	public function testPropertyBrandCharacterLimitXML() {
+		$brand_method = $this->getProductsXmlFeedAttributeMethod( 'g:brand' );
+		$product      = WC_Helper_Product::create_simple_product();
+
+		$mock_logger = $this->getMockLogger();
+
+		Logger::$logger = $mock_logger;
+
+		// Debug logging is gated behind this setting; enable it so the log is captured.
+		Pinterest_For_Woocommerce()::save_setting( 'enable_debug_logging', true );
+
+		// Brand name longer than the 100 character limit.
+		$long_brand = str_repeat( 'A', 150 );
+		$term       = wp_insert_term( $long_brand, 'product_brand' );
+		wp_set_object_terms( $product->get_id(), $term['term_id'], 'product_brand' );
+
+		$xml = $brand_method( $product );
+
+		// Extract the brand value from the XML.
+		preg_match( '/<g:brand>(.*?)<\/g:brand>/', $xml, $matches );
+		$brand = $matches[1] ?? '';
+
+		// Should be truncated to 100 characters.
+		$this->assertEquals( 100, strlen( $brand ) );
+
+		// Check that a warning was logged.
+		$this->assertStringContainsString( 'brand length is', $mock_logger::$message );
+		$this->assertStringContainsString( 'truncating to 100 characters', $mock_logger::$message );
+	}
+
+	/**
+	 * Test that the brand is included in the full feed item output, covering the
+	 * feed-structure entry and the get_xml_item() code path.
+	 *
+	 * @group feed
+	 */
+	public function testBrandInFeedItemXML() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$term = wp_insert_term( 'Puma', 'product_brand' );
+		wp_set_object_terms( $product->get_id(), $term['term_id'], 'product_brand' );
+
+		$xml = ProductsXmlFeed::get_xml_item( $product, 'US' );
+		$this->assertStringContainsString( '<g:brand>Puma</g:brand>', $xml );
+	}
+
+	/**
 	 * Mimic the method on FeedGenerator.
 	 *
 	 * @param array $taxable_location The taxable location to filter.
@@ -996,6 +1076,7 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		// Remove any added filter.
 		remove_all_filters( 'pinterest_for_woocommerce_product_description_apply_shortcodes' );
+		remove_all_filters( 'pinterest_for_woocommerce_product_brand' );
 
 		// Remove added shortcodes.
 		remove_shortcode( 'pinterest_for_woocommerce_sample_test_shortcode' );

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -939,6 +939,42 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @group feed
+	 */
+	public function testPropertyBrandXML() {
+		$brand_method = $this->getProductsXmlFeedAttributeMethod( 'g:brand' );
+		$product      = WC_Helper_Product::create_simple_product();
+
+		// No brand set.
+		$xml = $brand_method( $product );
+		$this->assertEquals( '', $xml );
+
+		// Assign a brand via the product_brand taxonomy.
+		$term = wp_insert_term( 'Nike', 'product_brand' );
+		wp_set_object_terms( $product->get_id(), $term['term_id'], 'product_brand' );
+
+		$xml = $brand_method( $product );
+		$this->assertEquals( '<g:brand>Nike</g:brand>', $xml );
+	}
+
+	/**
+	 * @group feed
+	 */
+	public function testPropertyBrandVariationUsesParentXML() {
+		$brand_method      = $this->getProductsXmlFeedAttributeMethod( 'g:brand' );
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+		$child_product     = wc_get_product( $variation_product->get_children()[0] );
+
+		// Assign brand to the parent product.
+		$term = wp_insert_term( 'Adidas', 'product_brand' );
+		wp_set_object_terms( $variation_product->get_id(), $term['term_id'], 'product_brand' );
+
+		$xml = $brand_method( $child_product );
+		$this->assertEquals( '<g:brand>Adidas</g:brand>', $xml );
+	}
+
+	/**
 	 * Mimic the method on FeedGenerator.
 	 *
 	 * @param array $taxable_location The taxable location to filter.


### PR DESCRIPTION
## Summary

- Adds `g:brand` field to the Pinterest XML product feed, sourced from the core WooCommerce `product_brand` taxonomy (WooCommerce Brands)
- Variations inherit brand from their parent product, consistent with how `g:product_type` handles categories
- A `pinterest_for_woocommerce_product_brand` filter allows overriding the brand value per product

Closes PIN4WOO-68

## Test plan

- [ ] Add a brand via **Products → Brands** and assign it to a product
- [ ] Trigger a feed sync and inspect the XML — confirm `<g:brand>BrandName</g:brand>` appears for that product
- [ ] Confirm products with no brand assigned have no `<g:brand>` element in the feed
- [ ] Confirm a product variation inherits the brand from its parent
- [ ] Run `vendor/bin/phpunit --testsuite unit --filter testPropertyBrand` — should show 2 passing tests

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>Add - WooCommerce product_brand to Pinterest feed as `g:brand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

