### PR TITLE
Fix checkout tracking payload data

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -193,7 +193,7 @@ class Tracking {
 				$order_item->get_name(),
 				wc_get_product_category_list( $product->get_id() ),
 				'brand',
-				$order_item->get_total() / max( 1, $order_item->get_quantity() ),
+				$order->get_item_total( $order_item, true, true ),
 				get_woocommerce_currency(),
 				$order_item->get_quantity()
 			);

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -193,7 +193,7 @@ class Tracking {
 				$order_item->get_name(),
 				wc_get_product_category_list( $product->get_id() ),
 				'brand',
-				$order->get_item_total( $order_item, true, true ),
+				$order->get_item_total( $order_item, false, true ),
 				get_woocommerce_currency(),
 				$order_item->get_quantity()
 			);

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -193,7 +193,7 @@ class Tracking {
 				$order_item->get_name(),
 				wc_get_product_category_list( $product->get_id() ),
 				'brand',
-				wc_get_price_to_display( $product ),
+				$order_item->get_total() / max( 1, $order_item->get_quantity() ),
 				get_woocommerce_currency(),
 				$order_item->get_quantity()
 			);

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -123,9 +123,7 @@ class Conversions extends Tracker {
 
 		$email = self::maybe_get_hashed_customer_email();
 		if ( false !== $email ) {
-			$data['user_data'] = array(
-				'em' => array( $email ),
-			);
+			$data['user_data']['em'] = array( $email );
 		}
 
 		return $data;

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -13,6 +13,7 @@ class ConversionsTest extends WP_UnitTestCase {
 		parent::tearDown();
 
 		remove_all_filters( 'pre_http_request' );
+		wp_set_current_user( 0 );
 	}
 
 	public function test_conversions_track_page_visit_event() {
@@ -86,6 +87,32 @@ class ConversionsTest extends WP_UnitTestCase {
 		$user        = new User( 'Some IP address.', 'Some user agent string.' );
 		$conversions = new Conversions( $user );
 		$conversions->track_event( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+	}
+
+	/**
+	 * Tests that hashed email is merged into default user data.
+	 */
+	public function test_default_data_keeps_ip_user_agent_with_logged_in_email() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'customer@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$user        = new User( 'Some IP address.', 'Some user agent string.' );
+		$conversions = new Conversions( $user );
+
+		$data = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+
+		$this->assertEquals(
+			array(
+				'client_ip_address' => 'Some IP address.',
+				'client_user_agent' => 'Some user agent string.',
+				'em'                => array( hash( 'sha256', 'customer@example.com' ) ),
+			),
+			$data['user_data']
+		);
 	}
 
 	public function test_get_checkout_data() {

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -3,7 +3,7 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
-use Automattic\WooCommerce\Pinterest\Tracking\Data;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\Checkout;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\None;
 use Automattic\WooCommerce\Pinterest\Tracking\Tag;
 use Automattic\WooCommerce\Pinterest\Tracking\Tracker;
@@ -82,7 +82,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = new Tracking();
 
-		$pinterest_tag_tracker = $this->createMock( Tag::class );
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
 		$pinterest_capi_tracker = $this->createMock( Conversions::class );
 
 		$tracking->add_tracker( $pinterest_tag_tracker );
@@ -104,7 +104,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = new Tracking();
 
-		$pinterest_tag_tracker = $this->createMock( Tag::class );
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
 		$pinterest_capi_tracker = $this->createMock( Conversions::class );
 
 		$tracking->add_tracker( $pinterest_tag_tracker );
@@ -123,7 +123,8 @@ class TrackingTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that checkout tracking uses the paid order line unit price.
+	 * Tests that checkout tracking uses the paid order line unit price when a
+	 * 100% discount drops the line total to zero.
 	 */
 	public function test_checkout_uses_paid_order_item_unit_price() {
 		$product = WC_Helper_Product::create_simple_product(
@@ -144,24 +145,72 @@ class TrackingTest extends \WP_UnitTestCase {
 		$order->set_total( 0 );
 		$order->save();
 
-		$tracker = $this->createMock( Tracker::class );
+		$captured = null;
+		$tracker  = $this->createMock( Tracker::class );
 		$tracker->expects( $this->once() )
 			->method( 'track_event' )
 			->with(
 				Tracking::EVENT_CHECKOUT,
 				$this->callback(
-					function ( Data\Checkout $checkout ) {
-						$items = $checkout->get_items();
-
-						return 1 === count( $items )
-							&& 0 === (int) $items[0]->get_price()
-							&& 2 === (int) $items[0]->get_quantity()
-							&& 0 === (int) ( $items[0]->get_price() * $items[0]->get_quantity() );
+					function ( Checkout $checkout ) use ( &$captured ) {
+						$captured = $checkout;
+						return true;
 					}
 				)
 			);
 
 		$tracking = new Tracking( array( $tracker ) );
 		$tracking->handle_checkout( $order->get_id() );
+
+		$items = $captured->get_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( 2, $items[0]->get_quantity() );
+		$this->assertEqualsWithDelta( 0.0, (float) $items[0]->get_price(), 0.0001 );
+	}
+
+	/**
+	 * Tests that checkout tracking divides the paid line total by quantity
+	 * for partial discounts, rather than re-reading the catalog price.
+	 */
+	public function test_checkout_uses_partially_discounted_per_unit_price() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 20,
+				'price'         => 20,
+			)
+		);
+
+		$order = wc_create_order();
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_subtotal( 40 );
+		$item->set_total( 20 );
+		$order->add_item( $item );
+		$order->set_total( 20 );
+		$order->save();
+
+		$captured = null;
+		$tracker  = $this->createMock( Tracker::class );
+		$tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with(
+				Tracking::EVENT_CHECKOUT,
+				$this->callback(
+					function ( Checkout $checkout ) use ( &$captured ) {
+						$captured = $checkout;
+						return true;
+					}
+				)
+			);
+
+		$tracking = new Tracking( array( $tracker ) );
+		$tracking->handle_checkout( $order->get_id() );
+
+		$items = $captured->get_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( 2, $items[0]->get_quantity() );
+		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
 	}
 }

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -3,9 +3,12 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
+use Automattic\WooCommerce\Pinterest\Tracking\Data;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\None;
 use Automattic\WooCommerce\Pinterest\Tracking\Tag;
+use Automattic\WooCommerce\Pinterest\Tracking\Tracker;
 use Pinterest_For_Woocommerce;
+use WC_Helper_Product;
 
 class TrackingTest extends \WP_UnitTestCase {
 
@@ -117,5 +120,48 @@ class TrackingTest extends \WP_UnitTestCase {
 			->with( 'test', $data );
 
 		$tracking->track_event( 'test', $data );
+	}
+
+	/**
+	 * Tests that checkout tracking uses the paid order line unit price.
+	 */
+	public function test_checkout_uses_paid_order_item_unit_price() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 20,
+				'price'         => 20,
+			)
+		);
+
+		$order = wc_create_order();
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_subtotal( 40 );
+		$item->set_total( 0 );
+		$order->add_item( $item );
+		$order->set_total( 0 );
+		$order->save();
+
+		$tracker = $this->createMock( Tracker::class );
+		$tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with(
+				Tracking::EVENT_CHECKOUT,
+				$this->callback(
+					function ( Data\Checkout $checkout ) {
+						$items = $checkout->get_items();
+
+						return 1 === count( $items )
+							&& 0 === (int) $items[0]->get_price()
+							&& 2 === (int) $items[0]->get_quantity()
+							&& 0 === (int) ( $items[0]->get_price() * $items[0]->get_quantity() );
+					}
+				)
+			);
+
+		$tracking = new Tracking( array( $tracker ) );
+		$tracking->handle_checkout( $order->get_id() );
 	}
 }

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -213,4 +213,50 @@ class TrackingTest extends \WP_UnitTestCase {
 		$this->assertSame( 2, $items[0]->get_quantity() );
 		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
 	}
+
+	/**
+	 * Tests that checkout tracking excludes tax from the paid line unit price.
+	 */
+	public function test_checkout_uses_paid_order_item_unit_price_excluding_tax() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 20,
+				'price'         => 20,
+			)
+		);
+
+		$order = wc_create_order();
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_subtotal( 40 );
+		$item->set_total( 20 );
+		$item->set_total_tax( 4 );
+		$order->add_item( $item );
+		$order->set_total( 24 );
+		$order->save();
+
+		$captured = null;
+		$tracker  = $this->createMock( Tracker::class );
+		$tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with(
+				Tracking::EVENT_CHECKOUT,
+				$this->callback(
+					function ( Checkout $checkout ) use ( &$captured ) {
+						$captured = $checkout;
+						return true;
+					}
+				)
+			);
+
+		$tracking = new Tracking( array( $tracker ) );
+		$tracking->handle_checkout( $order->get_id() );
+
+		$items = $captured->get_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( 2, $items[0]->get_quantity() );
+		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes PIN4WOO-76.

This updates checkout tracking to derive each item's tracked unit price from the WooCommerce order line total instead of re-reading the product catalog price. That keeps `contents[].item_price` for the Conversions API and `line_items[].product_price` for the Pinterest Tag aligned with the discounted merchandise amount when cart-time pricing changes the product price.

The unit price is now computed via WooCommerce's official `WC_Order::get_item_total( $order_item, false, true )` helper, which:

- divides the order item's paid line total by quantity after discounts,
- excludes line tax so taxable orders do not overstate the merchandise unit price, and
- rounds the result to the store's currency decimals (`wc_get_price_decimals()`).

This matches Pinterest's event-value guidance for purchased items as pre-tax, pre-shipping revenue. A tax-inclusive item price would be a separate payload-semantics decision, not part of this bug fix.

This also preserves the default Conversions API `user_data` fields when a logged-in customer email is available. Previously the hashed email replaced the whole `user_data` array, so logged-in events lost `client_ip_address` and `client_user_agent`.

### Detailed test instructions:

#### Setup

1. Install or check out this PR on a test WordPress site with WooCommerce active.
2. For the most complete real-environment test, connect a Pinterest account first.
3. Enable Pinterest tracking in WP Admin at `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`.
4. A real Pinterest account is recommended, but not required for the browser Tag payload test; the site only needs `track_conversions` enabled and a non-empty `tracking_tag`.
5. If needed, set those test options with WP-CLI:
   - `wp eval 'Pinterest_For_Woocommerce::save_setting( "track_conversions", true ); Pinterest_For_Woocommerce::save_setting( "tracking_tag", "TESTTAG1175" );'`
6. Create a simple product with catalog price 20.
7. Create a 100% coupon, for example `FREE1175`, so the paid order line total becomes 0 while the product catalog price remains 20.
8. Add quantity 2 of the product to cart, apply the coupon, and place an order.
9. Enable Conversions API and debug logging in Pinterest settings.

#### Browser Tag validation

1. On the WooCommerce thank-you page, inspect page source or DevTools Elements and search for `pintrk( 'track', 'Checkout'`.
2. Alternatively, in DevTools Network, enable Preserve log before checkout and filter for `ct.pinterest.com` or `event=Checkout`; open the `https://ct.pinterest.com/v3/?event=Checkout...` request and inspect the encoded event data.
3. Expected browser Tag result: `line_items[].product_price` is `0`, `line_items[].product_quantity` is `2`, and the checkout value matches the actual paid order total. Before this fix, `product_price` would incorrectly be the product catalog price, `20`.
4. Optional regression check: repeat with a 50% coupon. For a product priced at 20 and quantity 2, the tracked unit price should be `10`, not `20`.
5. Optional taxable regression check: if that discounted line has 4 total line tax, the tracked unit price should remain `10`, not `12`.

#### Conversions API validation

If using a connected Pinterest account:

1. Go to WooCommerce > Status > Logs
2. Check the WooCommerce log source `pinterest-for-woocommerce-conversions`.
3. Expected CAPI checkout payload: `custom_data.contents[].item_price` matches the paid order line unit price, excluding tax.
4. Expected `user_data` includes `client_ip_address`, `client_user_agent`, and `em` together. For `customer@example.com`, `em` should contain `e233d4a29013e9d87150c6237c6777bedf379ebf1acdc5d6126fec7e8bb74fb5`.

<img width="2552" height="1316" alt="Screenshot 2026-05-11 at 4 32 22 PM" src="https://github.com/user-attachments/assets/3c9831ce-c945-42ea-b90e-0c53f7bd19c4" />

<img width="1540" height="1028" alt="Screenshot 2026-05-11 at 4 37 30 PM" src="https://github.com/user-attachments/assets/173e58bf-7a6e-4adc-a9ec-8b8556540488" />

<img width="2344" height="1293" alt="Screenshot 2026-05-11 at 4 41 00 PM" src="https://github.com/user-attachments/assets/bcf0401a-56dd-4332-b17c-8b2ffbf6fa0b" />


### Additional details:

This PR intentionally keeps checkout item prices tax-exclusive. Pinterest's Conversions API docs describe purchase `value` as the pre-tax, pre-shipping total for purchased items, and the per-item fields should use the same merchandise-revenue semantics.

### Changelog entry

> Fix - Correct checkout tracking item prices and preserve customer IP and user agent when sending hashed email.
