### PR TITLE
Fix deterministic checkout event IDs

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -202,7 +202,7 @@ class Tracking {
 		}
 
 		$data = new Checkout(
-			uniqid( 'checkout' ),
+			'checkout_' . $order->get_id(),
 			(string) $order->get_id(),
 			$order->get_total(),
 			$total_quantity,

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -164,7 +164,7 @@ class Tracking {
 	}
 
 	/**
-	 * Used as a callback for the woocommerce_checkout_order_created hook.
+	 * Used as a callback for the woocommerce_before_thankyou hook.
 	 *
 	 * @since 1.4.0
 	 *
@@ -201,6 +201,8 @@ class Tracking {
 			$total_quantity += $order_item->get_quantity();
 		}
 
+		// Deterministic event id so Pinterest can deduplicate Tag/CAPI Checkout events when
+		// the thank-you page is re-rendered (woocommerce_before_thankyou fires on every render).
 		$data = new Checkout(
 			'checkout_' . $order->get_id(),
 			(string) $order->get_id(),

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -184,6 +184,14 @@ class TrackingTest extends \WP_UnitTestCase {
 		$this->assertSame( $expected_event_id, $tracked_events[0]['data']->get_event_id() );
 		$this->assertSame( $expected_event_id, $tracked_events[1]['data']->get_event_id() );
 
+		// Per-product line item event ids stay non-deterministic (uniqid) by design.
+		$first_call_items  = $tracked_events[0]['data']->get_items();
+		$second_call_items = $tracked_events[1]['data']->get_items();
+		$this->assertNotSame(
+			$first_call_items[0]->get_event_id(),
+			$second_call_items[0]->get_event_id()
+		);
+
 		$tag_data         = ( new Tag() )->prepare_request_data(
 			Tracking::EVENT_CHECKOUT,
 			$tracked_events[0]['data']

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -83,7 +83,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = new Tracking();
 
-		$pinterest_tag_tracker = $this->createMock( Tag::class );
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
 		$pinterest_capi_tracker = $this->createMock( Conversions::class );
 
 		$tracking->add_tracker( $pinterest_tag_tracker );
@@ -105,7 +105,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$tracking = new Tracking();
 
-		$pinterest_tag_tracker = $this->createMock( Tag::class );
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
 		$pinterest_capi_tracker = $this->createMock( Conversions::class );
 
 		$tracking->add_tracker( $pinterest_tag_tracker );
@@ -187,6 +187,8 @@ class TrackingTest extends \WP_UnitTestCase {
 		// Per-product line item event ids stay non-deterministic (uniqid) by design.
 		$first_call_items  = $tracked_events[0]['data']->get_items();
 		$second_call_items = $tracked_events[1]['data']->get_items();
+		$this->assertCount( 1, $first_call_items );
+		$this->assertCount( 1, $second_call_items );
 		$this->assertNotSame(
 			$first_call_items[0]->get_event_id(),
 			$second_call_items[0]->get_event_id()

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -3,8 +3,12 @@
 namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
+use Automattic\WooCommerce\Pinterest\Tracking\Data;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\Checkout;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\None;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\User;
 use Automattic\WooCommerce\Pinterest\Tracking\Tag;
+use Automattic\WooCommerce\Pinterest\Tracking\Tracker;
 use Pinterest_For_Woocommerce;
 
 class TrackingTest extends \WP_UnitTestCase {
@@ -117,5 +121,79 @@ class TrackingTest extends \WP_UnitTestCase {
 			->with( 'test', $data );
 
 		$tracking->track_event( 'test', $data );
+	}
+
+	/**
+	 * Test that checkout event ids remain stable for a given order.
+	 */
+	public function test_checkout_event_id_is_deterministic_for_order() {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 15,
+			)
+		);
+		$order   = wc_create_order();
+		$order->add_product( $product, 2 );
+		$order->set_currency( 'USD' );
+		$order->calculate_totals();
+		$order->save();
+
+		$tracker  = new class() extends Tracker {
+			/**
+			 * @var array Tracked event calls.
+			 */
+			private $tracked_events = array();
+
+			/**
+			 * Records a tracked event call.
+			 *
+			 * @param string $event_name Event name.
+			 * @param Data   $data       Event data.
+			 * @return true
+			 */
+			public function track_event( string $event_name, Data $data ) {
+				$this->tracked_events[] = array(
+					'event_name' => $event_name,
+					'data'       => $data,
+				);
+				return true;
+			}
+
+			/**
+			 * Gets recorded tracked event calls.
+			 *
+			 * @return array
+			 */
+			public function get_tracked_events() {
+				return $this->tracked_events;
+			}
+		};
+		$tracking = new Tracking( array( $tracker ) );
+
+		$tracking->handle_checkout( $order->get_id() );
+		$tracking->handle_checkout( $order->get_id() );
+
+		$expected_event_id = 'checkout_' . $order->get_id();
+		$tracked_events    = $tracker->get_tracked_events();
+
+		$this->assertCount( 2, $tracked_events );
+		$this->assertSame( Tracking::EVENT_CHECKOUT, $tracked_events[0]['event_name'] );
+		$this->assertSame( Tracking::EVENT_CHECKOUT, $tracked_events[1]['event_name'] );
+		$this->assertInstanceOf( Checkout::class, $tracked_events[0]['data'] );
+		$this->assertSame( $expected_event_id, $tracked_events[0]['data']->get_event_id() );
+		$this->assertSame( $expected_event_id, $tracked_events[1]['data']->get_event_id() );
+
+		$tag_data         = ( new Tag() )->prepare_request_data(
+			Tracking::EVENT_CHECKOUT,
+			$tracked_events[0]['data']
+		);
+		$conversions_data = ( new Conversions( new User( '127.0.0.1', 'test-agent' ) ) )->prepare_request_data(
+			Tracking::EVENT_CHECKOUT,
+			$tracked_events[0]['data']
+		);
+
+		$this->assertSame( $expected_event_id, $tag_data['event_id'] );
+		$this->assertSame( $expected_event_id, $conversions_data['event_id'] );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stabilizes Pinterest Checkout tracking deduplication for WooCommerce thank-you-page reloads.

PIN4WOO-77 reports that `handle_checkout()` generated Checkout `event_id` values with `uniqid( 'checkout' )`, so refreshing `/checkout/order-received/<id>/` emitted a fresh event id for the same order. Pinterest could not deduplicate the browser Tag and CAPI Checkout events, which could double-count purchases.

This PR changes only the checkout-level event id to `checkout_<order_id>`. Action-scoped event ids for page visits, add-to-cart, category views, search, and product line items continue using their existing per-action `uniqid()` behavior, because their hooks fire once per real action — only `woocommerce_before_thankyou` fires on every page render.

### Detailed test instructions:

#### Unit tests

1. Run `composer lint` and confirm it exits successfully for the current diff.
2. Run `composer lint-branch` and confirm it exits successfully against `develop`.
3. Run `npm run test:php:wp-env -- --filter TrackingTest` and confirm the suite passes.
4. Review `tests/Unit/TrackingTest.php::test_checkout_event_id_is_deterministic_for_order()` to confirm two repeated checkout tracking calls for one order produce the same `checkout_<order_id>` id, that Tag/CAPI payload preparation preserves that same id, and that per-product line-item event ids remain non-deterministic (`uniqid`) by design.

#### Setup

1. Install or check out this PR on a test WordPress site with WooCommerce active.
2. For the most complete real-environment test, connect a Pinterest account first.
3. Enable Pinterest tracking in WP Admin at `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`.
4. A real Pinterest account is recommended, but not required for the browser Tag payload test; the site only needs `track_conversions` enabled and a non-empty `tracking_tag`.
5. If needed, set those test options with WP-CLI:
   - `wp eval 'Pinterest_For_Woocommerce::save_setting( "track_conversions", true ); Pinterest_For_Woocommerce::save_setting( "tracking_tag", "TESTTAG1176" );'`
6. Create a simple product (any price).
7. Add the product to cart and place an order to land on `/checkout/order-received/<order_id>/`.

#### Browser Tag validation

1. On the thank-you page, inspect page source or DevTools Elements and search for `pintrk( 'track', 'Checkout'`.
2. Alternatively, in DevTools Network, enable Preserve log before checkout and filter for `ct.pinterest.com` or `event=Checkout`; open the `https://ct.pinterest.com/v3/?event=Checkout...` request and inspect the encoded event data.
3. Note the `event_id` value. Expected: `checkout_<order_id>` (e.g. `checkout_123`).
4. Hard-refresh the thank-you page (Cmd+Shift+R) 3–4 times. Re-inspect after each refresh.
5. Expected: every refresh emits the **same** `event_id`. Before this fix, each refresh produced a fresh `uniqid()`-based id, breaking Pinterest's dedupe.
6. Optional cross-order check: place a second, different order. Its `event_id` should be `checkout_<new_order_id>` — different from the first order but still deterministic across its own reloads.

<img width="1485" height="417" alt="Screenshot 2026-05-11 at 6 00 05 PM" src="https://github.com/user-attachments/assets/e146702c-8677-4e4b-966e-51d1f19ab5c6" />


### Additional details:

Scope is intentionally narrow: only the order-level Checkout `event_id` becomes deterministic, because `woocommerce_before_thankyou` is the only tracking hook that fires on every page render. Other tracking hooks (`wp_footer` page/category/search, `woocommerce_add_to_cart`) fire once per real action and are not affected by page reloads.

### Changelog entry

> Fix - Use deterministic Checkout tracking event IDs so refreshed thank-you pages can deduplicate purchases.