### PR TITLE
Send Pinterest PageVisit through native page call

### DIFF
--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -26,6 +26,7 @@ class Tag extends Tracker {
 
 	private const TAG_ID_SLUG       = '%%TAG_ID%%';
 	private const HASHED_EMAIL_SLUG = '%%HASHED_EMAIL%%';
+	private const PAGE_VISIT_SLUG   = '%%PAGE_VISIT%%';
 
 	/**
 	 * The base tracking snippet.
@@ -33,7 +34,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n" . self::PAGE_VISIT_SLUG . "</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The base tracking snippet with Enchanced match support.
@@ -41,7 +42,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n" . self::PAGE_VISIT_SLUG . "</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The noscript base tracking snippet.
@@ -64,6 +65,13 @@ class Tag extends Tracker {
 	 * @var array
 	 */
 	private static $deferred_events = array();
+
+	/**
+	 * Page visit event data to be passed to the native Pinterest page signal.
+	 *
+	 * @var array
+	 */
+	private static $page_visit_data = array();
 
 	/**
 	 * Initialises hooks a tracker need to operate.
@@ -106,8 +114,8 @@ class Tag extends Tracker {
 
 		$script = ! empty( $email ) ? self::$base_tag_em : self::$base_tag;
 		$script = str_replace(
-			array( self::TAG_ID_SLUG, self::HASHED_EMAIL_SLUG ),
-			array( sanitize_key( $active_tag ), $email ),
+			array( self::TAG_ID_SLUG, self::HASHED_EMAIL_SLUG, self::PAGE_VISIT_SLUG ),
+			array( sanitize_key( $active_tag ), $email, static::get_page_visit_code() ),
 			$script
 		);
 		//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -159,6 +167,22 @@ class Tag extends Tracker {
 			$event_name,
 			empty( $data_string ) ? '' : ', ' . $data_string
 		);
+	}
+
+	/**
+	 * Generates the native Pinterest Tag page call.
+	 *
+	 * @since 1.4.27
+	 *
+	 * @return string A generated page call.
+	 */
+	private static function get_page_visit_code() {
+		if ( empty( static::$page_visit_data ) ) {
+			return '';
+		}
+
+		$data_string = wp_json_encode( static::$page_visit_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+		return sprintf( "  pintrk('page', %s);\n", $data_string );
 	}
 
 	/**
@@ -246,6 +270,11 @@ class Tag extends Tracker {
 	 */
 	public function track_event( string $event_name, Data $data ) {
 		$data = $this->prepare_request_data( $event_name, $data );
+		if ( Tracking::EVENT_PAGE_VISIT === $event_name ) {
+			static::$page_visit_data = $data;
+			return true;
+		}
+
 		if ( wp_doing_ajax() ) {
 			return static::maybe_add_fragment( $event_name, $data );
 		}

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -33,7 +33,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The base tracking snippet with Enchanced match support.
@@ -41,7 +41,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The noscript base tracking snippet.

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -2,9 +2,29 @@
 
 namespace Automattic\WooCommerce\Pinterest\Tracking;
 
+use Automattic\WooCommerce\Pinterest\Tracking as MainTracking;
 use Pinterest_For_Woocommerce;
+use ReflectionClass;
 
 class TagTest extends \WP_UnitTestCase {
+
+	/**
+	 * Reset static tag state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->reset_tag_state();
+	}
+
+	/**
+	 * Reset static tag state after each test.
+	 */
+	public function tearDown(): void {
+		$this->reset_tag_state();
+
+		parent::tearDown();
+	}
 
 	public function test_adds_hooks() {
 		$tag = new Tag();
@@ -57,6 +77,30 @@ class TagTest extends \WP_UnitTestCase {
 		$this->assertEquals( $expected, $script );
 	}
 
+	/**
+	 * Test that page visits use the native page call with event data.
+	 */
+	public function test_print_script_prints_page_visit_with_event_data() {
+		Pinterest_For_Woocommerce::save_settings(
+			array(
+				'tracking_tag'           => 'YU9AOV86F',
+				'enhanced_match_support' => false,
+			)
+		);
+
+		$tag = new Tag();
+		$tag->track_event( MainTracking::EVENT_PAGE_VISIT, new Data\None( 'page-id-123' ) );
+
+		ob_start();
+		$tag->print_script();
+		$script = ob_get_contents();
+		ob_end_clean();
+
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n  pintrk('page', {\"event_id\":\"page-id-123\"});\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$this->assertEquals( $expected, $script );
+		$this->assertStringNotContainsString( "pintrk( 'track', 'page_visit'", $script );
+	}
+
 	public function test_print_noscript() {
 		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'VR5R2GDTE' ) );
 
@@ -90,5 +134,18 @@ class TagTest extends \WP_UnitTestCase {
 			"pintrk( 'track', 'some_event_name_13512345' , {\"data\":\"James B0nd\"});"
 		);
 		$this->assertEquals( $expected, $events );
+	}
+
+	/**
+	 * Reset static tag data between tests.
+	 */
+	private function reset_tag_state() {
+		$reflection = new ReflectionClass( Tag::class );
+
+		foreach ( array( 'events', 'deferred_events', 'page_visit_data' ) as $property_name ) {
+			$property = $reflection->getProperty( $property_name );
+			$property->setAccessible( true );
+			$property->setValue( null, array() );
+		}
 	}
 }

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -36,7 +36,7 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 
@@ -53,7 +53,7 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', 'ju9rag86q', { em: '122dc8b4cb47fa7179db75f0c04b28dd', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', 'ju9rag86q', { em: '122dc8b4cb47fa7179db75f0c04b28dd', np: \"woocommerce\" });\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Linear: PIN4WOO-78

This changes the browser Tag PageVisit path so it uses Pinterest's native `pintrk('page', {...})` page signal with the generated `event_id`, instead of emitting a second explicit `pintrk( 'track', 'page_visit', ... )` browser event.

The important behavior is that `Tracking::handle_page_visit()` still generates one PageVisit data object and dispatches it to all trackers. The Tag tracker now stores that prepared event data for the base script's native page call, while the Conversions tracker continues sending the same `event_id` to CAPI. Non-PageVisit Tag events still use the existing explicit `pintrk( 'track', ... )` queue.

This keeps Enhanced Match on `pintrk('load', ...)` before the native page signal. It also preserves the intended 404 behavior: because `handle_page_visit()` returns early on 404s, no PageVisit data is generated and the base script renders only `pintrk('load', ...)`, with no browser PageVisit call.

### Screenshots:

Not applicable; this changes generated tracking script output and has no visual UI surface.

### Detailed test instructions:

#### Automated validation

1. Run `composer lint` and confirm it exits successfully for changed PHP lines.
2. Run `composer lint-branch` and confirm it exits successfully against `develop`.
3. Run `npm run test:php:wp-env -- --filter TagTest` and confirm `8 tests, 13 assertions` pass.
4. Run `npm run test:php:wp-env` and confirm `208 tests, 436 assertions` pass.
5. Note: `vendor/bin/phpcs --extensions=php -s -p src/Tracking/Tag.php tests/Unit/Tracking/TagTest.php` still reports pre-existing full-file docblock/array-format issues in `TagTest.php` and `Tag::get_active_tag()` that are outside this PR's changed lines; the changed-line lint commands above pass.

#### Setup

1. Install or check out this PR on a test WordPress site with WooCommerce active.
2. Connect a Pinterest account and enable tracking in WP Admin at `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`.
3. If you do not want to connect a real Pinterest account, exercise browser Tag output with `track_conversions` enabled and a non-empty `tracking_tag`:
   - `wp eval 'Pinterest_For_Woocommerce::save_setting( "track_conversions", true ); Pinterest_For_Woocommerce::save_setting( "tracking_tag", "TESTTAG1177" );'`
4. Create at least one simple product so the shop, single product, cart, checkout, and thank-you pages are all reachable.
5. To verify the Enhanced Match path, log in as a WooCommerce customer and reload the front end.

#### Browser Tag network validation

1. Open DevTools -> Network, enable Preserve log, and filter for `ct.pinterest.com`.
2. Visit each page type below and confirm the browser PageVisit path is a single native page signal carrying the generated event data, not an additional explicit `event=page_visit` Tag request:
   - Shop / archive page
   - Single product page
   - Cart page
   - Checkout page before placing an order
   - Thank-you page (`/checkout/order-received/<order_id>/`)
   - My Account page
   - Static page, including homepage
   - Search results page (`/?s=test`)
3. Confirm the matching CAPI PageVisit request still sends the same generated `event_id`.
4. Repeat one page while logged in as a customer to exercise the Enhanced Match base tag template.

#### 404 negative case

1. Visit a guaranteed 404 URL such as `/this-url-does-not-exist-1177/`.
2. Expected: zero browser or CAPI PageVisit events, because `Tracking::handle_page_visit()` returns before PageVisit data is generated.

### Additional details:

The first version of this PR removed `pintrk('page')` entirely and relied on the explicit Tag `page_visit` call. A browser probe against Pinterest's current tag showed that omitting the native page call can activate an additional `PAGE_LOAD` request in Pinterest `core.js`, so the implementation now keeps the native page path and removes only the redundant explicit Tag PageVisit event.

### Changelog entry

> Fix - Send Pinterest PageVisit through the native page call with event data.
