### PR TITLE
Remove duplicate Pinterest PageVisit fire

### DIFF
--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -33,7 +33,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The base tracking snippet with Enchanced match support.
@@ -41,7 +41,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The noscript base tracking snippet.

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -36,7 +36,7 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 
@@ -53,7 +53,7 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', 'ju9rag86q', { em: '122dc8b4cb47fa7179db75f0c04b28dd', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', 'ju9rag86q', { em: '122dc8b4cb47fa7179db75f0c04b28dd', np: \"woocommerce\" });\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Linear: PIN4WOO-78

The Pinterest base tag currently calls `pintrk('page')` immediately after `pintrk('load', ...)`. The plugin also queues an explicit `PageVisit` event through `Tracking::handle_page_visit()`, which prints as `pintrk( 'track', 'page_visit', ... )` with an event ID and is deduplicated with the CAPI event.

This removes the base tag's redundant auto-fired `pintrk('page')` call from both the standard and Enhanced Match snippets. Page views continue to be sent through the explicit `page_visit` call, preserving event IDs for browser/CAPI deduplication. Enhanced Match still passes the hashed email on `pintrk('load', ...)` before later explicit events are printed.

One behavior change: 404 pages no longer emit a PageVisit event. `Tracking::handle_page_visit()` already returns early on `is_404()`, and removing the base auto-fire means the tag no longer bypasses that guard.

### Screenshots:

Not applicable; this is a non-visual storefront tracking script output change.

### Detailed test instructions:

1. Confirm automated validation passes:
   - `composer lint`
   - `npm run test:php:wp-env -- --filter TagTest`
   - `npm run test:php:wp-env`
2. With Pinterest tracking configured, load each storefront page type and watch the Network tab for `ct.pinterest.com` requests:
   - Shop / archive
   - Single product
   - Cart
   - Checkout before purchase
   - Thank-you page
   - My Account
   - Static page / homepage
   - Search results page
3. For every non-404 page above, confirm exactly one PageVisit browser event fires and that it includes `event_id`.
4. Load a 404 page and confirm zero PageVisit browser events fire.
5. Confirm the CAPI PageVisit request still uses the same `event_id` as the explicit browser PageVisit event.

### Additional details:

### Changelog entry

> Fix - Remove a duplicate Pinterest PageVisit browser event fired by the base tag.
