### PR TITLE
Log failed feed ingestion context

### DIFF
--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -163,17 +163,19 @@ class FeedRegistration {
 	/**
 	 * Log the latest failed feed processing result context if Pinterest reported a failed ingestion.
 	 *
+	 * Failures inside this helper must never propagate back to the registration action — a
+	 * diagnostic-only side path should not be able to mark the parent scheduled action as failed.
+	 *
 	 * @param string $feed_id Feed ID.
 	 * @return void
 	 */
 	private static function maybe_log_failed_processing_result( string $feed_id ): void {
-		$processing_results = Feeds::get_feed_recent_processing_results( $feed_id );
-
-		if ( Feeds::FEED_PROCESSING_STATUS_FAILED !== ( $processing_results['status'] ?? '' ) ) {
-			return;
+		try {
+			$processing_results = Feeds::get_feed_recent_processing_results( $feed_id );
+			FeedStatusService::log_failed_processing_result( $feed_id, $processing_results );
+		} catch ( Throwable $th ) {
+			Logger::log( $th->getMessage(), 'error', 'feed-ingestion-failure' );
 		}
-
-		FeedStatusService::log_failed_processing_result( $feed_id, $processing_results );
 	}
 
 	/**

--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -98,7 +98,14 @@ class FeedRegistration {
 		}
 
 		try {
-			return self::register_feed();
+			$result  = self::register_feed();
+			$feed_id = self::get_locally_stored_registered_feed_id();
+
+			if ( ! empty( $feed_id ) ) {
+				self::maybe_log_failed_processing_result( $feed_id );
+			}
+
+			return $result;
 		} catch ( PinterestApiLocaleException $e ) {
 			Pinterest_For_Woocommerce()::save_data( 'merchant_locale_not_valid', true );
 
@@ -151,6 +158,22 @@ class FeedRegistration {
 
 		static::maybe_delete_stale_feeds_for_merchant( $feed_id );
 		return true;
+	}
+
+	/**
+	 * Log the latest failed feed processing result context if Pinterest reported a failed ingestion.
+	 *
+	 * @param string $feed_id Feed ID.
+	 * @return void
+	 */
+	private static function maybe_log_failed_processing_result( string $feed_id ): void {
+		$processing_results = Feeds::get_feed_recent_processing_results( $feed_id );
+
+		if ( Feeds::FEED_PROCESSING_STATUS_FAILED !== ( $processing_results['status'] ?? '' ) ) {
+			return;
+		}
+
+		FeedStatusService::log_failed_processing_result( $feed_id, $processing_results );
 	}
 
 	/**

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -19,6 +19,13 @@ defined( 'ABSPATH' ) || exit;
 class FeedStatusService {
 
 	/**
+	 * Plugin data key used to avoid logging the same failed processing result repeatedly.
+	 *
+	 * @var string
+	 */
+	private const LAST_LOGGED_PROCESSING_RESULT_ID_KEY = 'last_logged_processing_result_id';
+
+	/**
 	 * The error contexts to search for in the workflow responses.
 	 *
 	 * @var array
@@ -53,6 +60,7 @@ class FeedStatusService {
 		'ACCOUNT_FLAGGED',
 	);
 
+	// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Keep legacy message map readable.
 	public const ERROR_MESSAGES = array(
 		// Validation errors.
 		'FETCH_ERROR'                       => 'Pinterest couldn\'t download your feed.',
@@ -163,6 +171,7 @@ class FeedStatusService {
 		'OUT_OF_STOCK' => 'The number of ingested products that are in out of stock.',
 		'PREORDER'     => 'The number of ingested products that are in preorder.',
 	);
+	// phpcs:enable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 
 	const FEED_STATUS_NOT_REGISTERED = 'not_registered';
 
@@ -328,5 +337,49 @@ class FeedStatusService {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Log the full failed feed processing result context once per processing result ID.
+	 *
+	 * @param string $feed_id            Pinterest feed ID.
+	 * @param array  $processing_results Recent processing results array.
+	 *
+	 * @return void
+	 */
+	public static function log_failed_processing_result( string $feed_id, array $processing_results ): void {
+		$processing_result_id = $processing_results['id'] ?? '';
+
+		if ( empty( $processing_result_id ) ) {
+			return;
+		}
+
+		$last_logged_processing_result_id = Pinterest_For_WooCommerce()::get_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY );
+		if ( $processing_result_id === $last_logged_processing_result_id ) {
+			return;
+		}
+
+		$feed_url = '';
+		$configs  = LocalFeedConfigs::get_instance()->get_configurations();
+		if ( ! empty( $configs ) ) {
+			$config   = reset( $configs );
+			$feed_url = $config['feed_url'] ?? '';
+		}
+
+		Logger::log(
+			sprintf(
+				"Feed ingestion FAILED\nfeed_id: %s\nprocessing_result_id: %s\ncreated_at: %s\nfeed_url: %s\nvalidation_details: %s\nproduct_counts: %s",
+				$feed_id,
+				$processing_result_id,
+				$processing_results['created_at'] ?? '',
+				$feed_url,
+				wp_json_encode( $processing_results['validation_details'] ?? array() ),
+				wp_json_encode( $processing_results['product_counts'] ?? array() )
+			),
+			'error',
+			'feed-ingestion-failure'
+		);
+
+		Pinterest_For_WooCommerce()::save_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
 	}
 }

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -60,42 +60,41 @@ class FeedStatusService {
 		'ACCOUNT_FLAGGED',
 	);
 
-	// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Keep legacy message map readable.
 	public const ERROR_MESSAGES = array(
 		// Validation errors.
-		'FETCH_ERROR'                       => 'Pinterest couldn\'t download your feed.',
-		'FETCH_INACTIVE_FEED_ERROR'         => 'Your feed wasn\'t ingested because it hasn\'t changed in the previous 90 days.',
-		'ENCODING_ERROR'                    => 'Your feed includes data with an unsupported encoding format.',
-		'DELIMITER_ERROR'                   => 'Your feed includes data with formatting errors.',
-		'REQUIRED_COLUMNS_MISSING'          => 'Your feed is missing some required column headers.',
-		'DUPLICATE_PRODUCTS'                => 'Some products are duplicated.',
-		'IMAGE_LINK_INVALID'                => 'Some image links are formatted incorrectly.',
-		'ITEMID_MISSING'                    => 'Some items are missing an item id in their product metadata, those items will not be published.',
-		'TITLE_MISSING'                     => 'Some items are missing a title in their product metadata, those items will not be published.',
-		'DESCRIPTION_MISSING'               => 'Some items are missing a description in their product metadata, those items will not be published.',
-		'PRODUCT_LINK_MISSING'              => 'Some items are missing a link URL in their product metadata, those items will not be published.',
-		'IMAGE_LINK_MISSING'                => 'Some items are missing an image link URL in their product metadata, those items will not be published.',
-		'AVAILABILITY_INVALID'              => 'Some items are missing an availability value in their product metadata, those items will not be published.',
-		'PRODUCT_PRICE_INVALID'             => 'Some items have price formatting errors in their product metadata, those items will not be published.',
-		'LINK_FORMAT_INVALID'               => 'Some link values are formatted incorrectly.',
-		'PARSE_LINE_ERROR'                  => 'Your feed contains formatting errors for some items.',
-		'ADWORDS_FORMAT_INVALID'            => 'Some adwords links contain too many characters.',
-		'INTERNAL_SERVICE_ERROR'            => 'We experienced a technical difficulty and were unable to ingest your feed. The next ingestion will happen in 24 hours.',
-		'NO_VERIFIED_DOMAIN'                => 'Your merchant domain needs to be claimed.',
-		'ADULT_INVALID'                     => 'Some items have invalid adult values.',
-		'IMAGE_LINK_LENGTH_TOO_LONG'        => 'Some items have image_link URLs that contain too many characters, so those items will not be published.',
-		'INVALID_DOMAIN'                    => 'Some of your product link values don\'t match the verified domain associated with this account.',
-		'FEED_LENGTH_TOO_LONG'              => 'Your feed contains too many items, some items will not be published.',
-		'LINK_LENGTH_TOO_LONG'              => 'Some product links contain too many characters, those items will not be published.',
-		'MALFORMED_XML'                     => 'Your feed couldn\'t be validated because the xml file is formatted incorrectly.',
-		'PRICE_MISSING'                     => 'Some products are missing a price, those items will not be published.',
-		'FEED_TOO_SMALL'                    => 'Your feed couldn\'t be validated because the file doesn\'t contain the minimum number of lines required.',
-		'MAX_ITEMS_PER_ITEM_GROUP_EXCEEDED' => 'Some items exceed the maximum number of items per item group, those items will not be published.',
-		'ITEM_MAIN_IMAGE_DOWNLOAD_FAILURE'  => 'Some items\' main images can\'t be found.',
-		'PINJOIN_CONTENT_UNSAFE'            => 'Some items were not published because they don\'t meet Pinterest\'s Merchant Guidelines.',
-		'BLOCKLISTED_IMAGE_SIGNATURE'       => 'Some items were not published because they don\'t meet Pinterest\'s Merchant Guidelines.',
-		'LIST_PRICE_INVALID'                => 'Some items have list price formatting errors in their product metadata, those items will not be published.',
-		'PRICE_CANNOT_BE_DETERMINED'        => 'Some items were not published because price cannot be determined. The price, list price, and sale price are all different, so those items will not be published.',
+		'FETCH_ERROR'                            => 'Pinterest couldn\'t download your feed.',
+		'FETCH_INACTIVE_FEED_ERROR'              => 'Your feed wasn\'t ingested because it hasn\'t changed in the previous 90 days.',
+		'ENCODING_ERROR'                         => 'Your feed includes data with an unsupported encoding format.',
+		'DELIMITER_ERROR'                        => 'Your feed includes data with formatting errors.',
+		'REQUIRED_COLUMNS_MISSING'               => 'Your feed is missing some required column headers.',
+		'DUPLICATE_PRODUCTS'                     => 'Some products are duplicated.',
+		'IMAGE_LINK_INVALID'                     => 'Some image links are formatted incorrectly.',
+		'ITEMID_MISSING'                         => 'Some items are missing an item id in their product metadata, those items will not be published.',
+		'TITLE_MISSING'                          => 'Some items are missing a title in their product metadata, those items will not be published.',
+		'DESCRIPTION_MISSING'                    => 'Some items are missing a description in their product metadata, those items will not be published.',
+		'PRODUCT_LINK_MISSING'                   => 'Some items are missing a link URL in their product metadata, those items will not be published.',
+		'IMAGE_LINK_MISSING'                     => 'Some items are missing an image link URL in their product metadata, those items will not be published.',
+		'AVAILABILITY_INVALID'                   => 'Some items are missing an availability value in their product metadata, those items will not be published.',
+		'PRODUCT_PRICE_INVALID'                  => 'Some items have price formatting errors in their product metadata, those items will not be published.',
+		'LINK_FORMAT_INVALID'                    => 'Some link values are formatted incorrectly.',
+		'PARSE_LINE_ERROR'                       => 'Your feed contains formatting errors for some items.',
+		'ADWORDS_FORMAT_INVALID'                 => 'Some adwords links contain too many characters.',
+		'INTERNAL_SERVICE_ERROR'                 => 'We experienced a technical difficulty and were unable to ingest your feed. The next ingestion will happen in 24 hours.',
+		'NO_VERIFIED_DOMAIN'                     => 'Your merchant domain needs to be claimed.',
+		'ADULT_INVALID'                          => 'Some items have invalid adult values.',
+		'IMAGE_LINK_LENGTH_TOO_LONG'             => 'Some items have image_link URLs that contain too many characters, so those items will not be published.',
+		'INVALID_DOMAIN'                         => 'Some of your product link values don\'t match the verified domain associated with this account.',
+		'FEED_LENGTH_TOO_LONG'                   => 'Your feed contains too many items, some items will not be published.',
+		'LINK_LENGTH_TOO_LONG'                   => 'Some product links contain too many characters, those items will not be published.',
+		'MALFORMED_XML'                          => 'Your feed couldn\'t be validated because the xml file is formatted incorrectly.',
+		'PRICE_MISSING'                          => 'Some products are missing a price, those items will not be published.',
+		'FEED_TOO_SMALL'                         => 'Your feed couldn\'t be validated because the file doesn\'t contain the minimum number of lines required.',
+		'MAX_ITEMS_PER_ITEM_GROUP_EXCEEDED'      => 'Some items exceed the maximum number of items per item group, those items will not be published.',
+		'ITEM_MAIN_IMAGE_DOWNLOAD_FAILURE'       => 'Some items\' main images can\'t be found.',
+		'PINJOIN_CONTENT_UNSAFE'                 => 'Some items were not published because they don\'t meet Pinterest\'s Merchant Guidelines.',
+		'BLOCKLISTED_IMAGE_SIGNATURE'            => 'Some items were not published because they don\'t meet Pinterest\'s Merchant Guidelines.',
+		'LIST_PRICE_INVALID'                     => 'Some items have list price formatting errors in their product metadata, those items will not be published.',
+		'PRICE_CANNOT_BE_DETERMINED'             => 'Some items were not published because price cannot be determined. The price, list price, and sale price are all different, so those items will not be published.',
 
 		// Validation warnings.
 		'AD_LINK_FORMAT_WARNING'                 => 'Some items have ad links that are formatted incorrectly.',
@@ -149,29 +148,28 @@ class FeedStatusService {
 		'MPN_INVALID'                            => 'Some items include incorrectly formatted MPNs.',
 
 		// Ingestion errors.
-		'LINE_LEVEL_INTERNAL_ERROR'    => 'We experienced a technical difficulty and were unable to ingest this some items. The next ingestion will happen in 24 hours.',
-		'LARGE_PRODUCT_COUNT_DECREASE' => 'The product count has decreased by more than 99% compared to the last successful ingestion.',
-		'ACCOUNT_FLAGGED'              => 'We detected an issue with your account and are not currently ingesting your items. Please review our policies at policy.pinterest.com/community-guidelines#section-spam or contact us at help.pinterest.com/contact for more information.',
-		'IMAGE_LEVEL_INTERNAL_ERROR'   => 'We experienced a technical difficulty and were unable to download some images. The next download attempt will happen in 24 hours.',
-		'IMAGE_FILE_NOT_ACCESSIBLE'    => 'Image files are unreadable. Please upload new files to continue.',
-		'IMAGE_MALFORMED_URL'          => 'Image files are unreadable. Please check your link and upload new files to continue.',
-		'IMAGE_FILE_NOT_FOUND'         => 'Image files are unreadable. Please upload new files to continue.',
-		'IMAGE_INVALID_FILE'           => 'Image files are unreadable. Please upload new files to continue.',
+		'LINE_LEVEL_INTERNAL_ERROR'              => 'We experienced a technical difficulty and were unable to ingest this some items. The next ingestion will happen in 24 hours.',
+		'LARGE_PRODUCT_COUNT_DECREASE'           => 'The product count has decreased by more than 99% compared to the last successful ingestion.',
+		'ACCOUNT_FLAGGED'                        => 'We detected an issue with your account and are not currently ingesting your items. Please review our policies at policy.pinterest.com/community-guidelines#section-spam or contact us at help.pinterest.com/contact for more information.',
+		'IMAGE_LEVEL_INTERNAL_ERROR'             => 'We experienced a technical difficulty and were unable to download some images. The next download attempt will happen in 24 hours.',
+		'IMAGE_FILE_NOT_ACCESSIBLE'              => 'Image files are unreadable. Please upload new files to continue.',
+		'IMAGE_MALFORMED_URL'                    => 'Image files are unreadable. Please check your link and upload new files to continue.',
+		'IMAGE_FILE_NOT_FOUND'                   => 'Image files are unreadable. Please upload new files to continue.',
+		'IMAGE_INVALID_FILE'                     => 'Image files are unreadable. Please upload new files to continue.',
 
 		// Ingestion warnings.
-		'ADDITIONAL_IMAGE_LEVEL_INTERNAL_ERROR' => 'We experienced a technical difficulty and were unable to download some additional images. The next download attempt will happen in 24 hours.',
-		'ADDITIONAL_IMAGE_FILE_NOT_ACCESSIBLE'  => 'Additional image files are unreadable. Please upload new files to continue.',
-		'ADDITIONAL_IMAGE_MALFORMED_URL'        => 'Additional image files are unreadable. Please check your link and upload new files to continue.',
-		'ADDITIONAL_IMAGE_FILE_NOT_FOUND'       => 'Additional image files are unreadable. Please upload new files to continue.',
-		'ADDITIONAL_IMAGE_INVALID_FILE'         => 'Additional image files are unreadable. Please upload new files to continue.',
-		'HOTEL_PRICE_HEADER_IS_PRESENT'         => 'Price is not a supported column. Use base_price and sale_price instead.',
+		'ADDITIONAL_IMAGE_LEVEL_INTERNAL_ERROR'  => 'We experienced a technical difficulty and were unable to download some additional images. The next download attempt will happen in 24 hours.',
+		'ADDITIONAL_IMAGE_FILE_NOT_ACCESSIBLE'   => 'Additional image files are unreadable. Please upload new files to continue.',
+		'ADDITIONAL_IMAGE_MALFORMED_URL'         => 'Additional image files are unreadable. Please check your link and upload new files to continue.',
+		'ADDITIONAL_IMAGE_FILE_NOT_FOUND'        => 'Additional image files are unreadable. Please upload new files to continue.',
+		'ADDITIONAL_IMAGE_INVALID_FILE'          => 'Additional image files are unreadable. Please upload new files to continue.',
+		'HOTEL_PRICE_HEADER_IS_PRESENT'          => 'Price is not a supported column. Use base_price and sale_price instead.',
 
 		// Ingestion info.
-		'IN_STOCK'     => 'The number of ingested products that are in stock.',
-		'OUT_OF_STOCK' => 'The number of ingested products that are in out of stock.',
-		'PREORDER'     => 'The number of ingested products that are in preorder.',
+		'IN_STOCK'                               => 'The number of ingested products that are in stock.',
+		'OUT_OF_STOCK'                           => 'The number of ingested products that are in out of stock.',
+		'PREORDER'                               => 'The number of ingested products that are in preorder.',
 	);
-	// phpcs:enable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 
 	const FEED_STATUS_NOT_REGISTERED = 'not_registered';
 
@@ -348,6 +346,10 @@ class FeedStatusService {
 	 * @return void
 	 */
 	public static function log_failed_processing_result( string $feed_id, array $processing_results ): void {
+		if ( Feeds::FEED_PROCESSING_STATUS_FAILED !== ( $processing_results['status'] ?? '' ) ) {
+			return;
+		}
+
 		$processing_result_id = $processing_results['id'] ?? '';
 
 		if ( empty( $processing_result_id ) ) {

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -361,6 +361,10 @@ class FeedStatusService {
 			return;
 		}
 
+		if ( ! function_exists( 'wc_get_logger' ) ) {
+			return;
+		}
+
 		$feed_url = '';
 		$configs  = LocalFeedConfigs::get_instance()->get_configurations();
 		if ( ! empty( $configs ) ) {

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -141,6 +141,55 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a non-FAILED processing result is ignored even if a result ID is present.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_skips_when_status_is_not_failed() {
+		$processing_results           = $this->get_failed_processing_results();
+		$processing_results['status'] = 'COMPLETED';
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
+
+		$this->assertCount( 0, $this->mock_logger->entries );
+		$this->assertEmpty( Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' ) );
+	}
+
+	/**
+	 * Tests that an empty processing result payload (e.g. empty API response) is ignored.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_skips_when_processing_result_id_missing() {
+		FeedStatusService::log_failed_processing_result( 'feed-123', array( 'status' => 'FAILED' ) );
+
+		$this->assertCount( 0, $this->mock_logger->entries );
+		$this->assertEmpty( Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' ) );
+	}
+
+	/**
+	 * Tests that a new failed processing result ID is logged even after a previous one was recorded.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_logs_new_processing_result_id_after_previous() {
+		$first  = $this->get_failed_processing_results();
+		$second = $this->get_failed_processing_results();
+
+		$second['id']         = 'processing-result-2';
+		$second['created_at'] = '2026-05-12T07:00:00';
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $first );
+		FeedStatusService::log_failed_processing_result( 'feed-123', $second );
+
+		$this->assertCount( 2, $this->mock_logger->entries );
+		$this->assertEquals(
+			'processing-result-2',
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
+	}
+
+	/**
 	 * Get a failed processing result fixture.
 	 *
 	 * @return array

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit;
+
+use Automattic\WooCommerce\Pinterest\FeedStatusService;
+use Automattic\WooCommerce\Pinterest\LocalFeedConfigs;
+use Automattic\WooCommerce\Pinterest\Logger;
+use Pinterest_For_Woocommerce;
+use WP_UnitTestCase;
+
+/**
+ * Tests Feed Status Service helpers.
+ */
+class FeedStatusServiceTest extends WP_UnitTestCase {
+
+	/**
+	 * Mocked WC logger.
+	 *
+	 * @var object
+	 */
+	private $mock_logger;
+
+	/**
+	 * Set up the WC logger mock and local feed configuration.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		LocalFeedConfigs::deregister();
+		Pinterest_For_Woocommerce::set_default_settings();
+		Pinterest_For_Woocommerce::save_setting( 'enable_debug_logging', false );
+		Pinterest_For_Woocommerce::save_data(
+			'local_feed_ids',
+			array(
+				Pinterest_For_Woocommerce::get_base_country() => 'local-feed',
+			)
+		);
+		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
+
+		$this->mock_logger = new class() {
+
+			/**
+			 * Captured log entries.
+			 *
+			 * @var array
+			 */
+			public $entries = array();
+
+			/**
+			 * Capture a log entry.
+			 *
+			 * @param string $level   Log level.
+			 * @param string $message Log message.
+			 * @param array  $handler Log handler context.
+			 * @return void
+			 */
+			public function log( $level, $message, $handler = array() ) {
+				$this->entries[] = array(
+					'level'   => $level,
+					'message' => $message,
+					'handler' => $handler,
+				);
+			}
+		};
+
+		Logger::$logger = $this->mock_logger;
+	}
+
+	/**
+	 * Reset logger state.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Logger::$logger = null;
+		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
+		LocalFeedConfigs::deregister();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that the full failed processing context is logged at error level.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_logs_expected_payload_without_debug_logging_enabled() {
+		$processing_results = $this->get_failed_processing_results();
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
+
+		$this->assertCount( 1, $this->mock_logger->entries );
+
+		$entry             = $this->mock_logger->entries[0];
+		$expected_feed_url = trailingslashit( wp_get_upload_dir()['baseurl'] ) .
+			PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-local-feed.xml';
+		$expected_message  = implode(
+			"\n",
+			array(
+				'Feed ingestion FAILED',
+				'feed_id: feed-123',
+				'processing_result_id: processing-result-1',
+				'created_at: 2026-05-12T06:00:00',
+				"feed_url: {$expected_feed_url}",
+				'validation_details: {"errors":{"FETCH_ERROR":1},"warnings":{"IMAGE_LINK_WARNING":2}}',
+				'product_counts: {"original":10,"ingested":0}',
+			)
+		);
+
+		$this->assertEquals( 'error', $entry['level'] );
+		$this->assertEquals(
+			array(
+				'source' => PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-feed-ingestion-failure',
+			),
+			$entry['handler']
+		);
+		$this->assertEquals(
+			$expected_message,
+			$entry['message']
+		);
+	}
+
+	/**
+	 * Tests that duplicate processing result IDs are not logged twice.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_does_not_log_same_processing_result_id_twice() {
+		$processing_results = $this->get_failed_processing_results();
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
+		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
+
+		$this->assertCount( 1, $this->mock_logger->entries );
+		$this->assertEquals(
+			'processing-result-1',
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
+	}
+
+	/**
+	 * Get a failed processing result fixture.
+	 *
+	 * @return array
+	 */
+	private function get_failed_processing_results(): array {
+		return array(
+			'id'                 => 'processing-result-1',
+			'status'             => 'FAILED',
+			'created_at'         => '2026-05-12T06:00:00',
+			'validation_details' => array(
+				'errors'   => array(
+					'FETCH_ERROR' => 1,
+				),
+				'warnings' => array(
+					'IMAGE_LINK_WARNING' => 2,
+				),
+			),
+			'product_counts'     => array(
+				'original' => 10,
+				'ingested' => 0,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This addresses PIN4WOO-80 by logging full Pinterest feed ingestion failure context when the scheduled feed-registration poll observes a latest processing result with `status = FAILED`.

- Adds `FeedStatusService::log_failed_processing_result()` to write an error-level WC Logger entry to the `pinterest-for-woocommerce-feed-ingestion-failure-*` log source.
- Includes the feed ID, processing result ID, created timestamp, local feed URL, full `validation_details`, and full `product_counts` in the log message.
- Stores `last_logged_processing_result_id` in plugin data so the same failed processing result is only logged once across recurring 10-minute polling runs.
- Calls the helper from `FeedRegistration::handle_feed_registration()` after the existing registration logic, without adding Pinterest API mutations or merchant-visible UI changes.

### Detailed test instructions:

These steps exercise the real scheduled-action code path. The site must be connected to Pinterest (so a feed file exists in `wp-content/uploads/` and `feed_registered` plugin data is set). Only the `processing_results` HTTP call is mocked — every other Pinterest API call in `register_feed()` hits the real API.

4. Confirm preconditions — expect a non-empty Pinterest feed ID:
   ```bash
   wp eval 'echo \Pinterest_For_Woocommerce::get_data( "feed_registered" ), "\n";'
   ```
5. Drop the following mu-plugin into `wp-content/mu-plugins/pin4woo-80-test.php`:
   <details><summary>pin4woo-80-test.php</summary>

   ```php
   <?php
   add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
       if ( false === strpos( $url, '/processing_results' ) ) {
           return $preempt;
       }
       return array(
           'headers'  => array( 'content-type' => 'application/json' ),
           'response' => array( 'code' => 200, 'message' => 'OK' ),
           'cookies'  => array(),
           'body'     => wp_json_encode( array(
               'items' => array(
                   array(
                       'id'                 => 'pin4woo-80-' . time(),
                       'status'             => 'FAILED',
                       'created_at'         => gmdate( 'c' ),
                       'validation_details' => array(
                           'errors'   => array( 'FETCH_ERROR' => 1 ),
                           'warnings' => array(),
                       ),
                       'product_counts'     => array( 'original' => 10, 'ingested' => 0 ),
                   ),
               ),
           ) ),
       );
   }, 10, 3 );
   ```

   </details>

6. Reset dedup state and trigger the scheduled handler:
   ```bash
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
7. Verify the `pinterest-for-woocommerce-feed-ingestion-failure` log entry by going to `/wp-admin/admin.php?page=wc-status&tab=logs`
8. Re-run the trigger to verify dedup — AC 1:
   ```bash
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
   No additional `Feed ingestion FAILED` block is appended; 
9. Cleanup:
   ```bash
   rm wp-content/mu-plugins/pin4woo-80-test.php
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   ```

<img width="1586" height="664" alt="Screenshot 2026-05-12 at 3 57 17 PM" src="https://github.com/user-attachments/assets/3929c0da-775c-4025-b323-6f4cb8a37d77" />

### Additional details:

Full `composer phpcs` currently exits before scanning because the composer script does not pass a file/path to PHPCS. Running the equivalent full scan with `vendor/bin/phpcs --extensions=php -s -p .` reports pre-existing unrelated repo-wide errors in untouched files; the changed files pass targeted PHPCS and `composer lint`.

### Changelog entry

> Fix - Log feed ingestion failure context to WooCommerce logs.
