### PR TITLE
Retry feed ingestion on fetch errors

### DIFF
--- a/src/FeedRegistration.php
+++ b/src/FeedRegistration.php
@@ -173,6 +173,7 @@ class FeedRegistration {
 		try {
 			$processing_results = Feeds::get_feed_recent_processing_results( $feed_id );
 			FeedStatusService::log_failed_processing_result( $feed_id, $processing_results );
+			FeedStatusService::maybe_retry_on_fetch_error( $feed_id, $processing_results );
 		} catch ( Throwable $th ) {
 			Logger::log( $th->getMessage(), 'error', 'feed-ingestion-failure' );
 		}

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -431,14 +431,14 @@ class FeedStatusService {
 			Pinterest_For_WooCommerce()::save_data( self::LAST_RETRIED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
 			Logger::log(
 				"FETCH_ERROR retry triggered for processing_result_id={$processing_result_id}",
-				'error',
+				'info',
 				'feed-ingestion-failure'
 			);
 
 			return true;
 		} catch ( Throwable $th ) {
 			Logger::log(
-				"FETCH_ERROR retry failed: {$th->getMessage()}",
+				"FETCH_ERROR retry failed for processing_result_id={$processing_result_id}",
 				'error',
 				'feed-ingestion-failure'
 			);

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -427,7 +427,7 @@ class FeedStatusService {
 		}
 
 		try {
-			Feeds::update_feed( $feed_id, array() );
+			Feeds::reschedule_feed_fetch( $feed_id );
 			Pinterest_For_WooCommerce()::save_data( self::LAST_RETRIED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
 			Logger::log(
 				"FETCH_ERROR retry triggered for processing_result_id={$processing_result_id}",
@@ -438,7 +438,12 @@ class FeedStatusService {
 			return true;
 		} catch ( Throwable $th ) {
 			Logger::log(
-				"FETCH_ERROR retry failed for processing_result_id={$processing_result_id}",
+				sprintf(
+					'FETCH_ERROR retry failed for processing_result_id=%s: %s (code %s)',
+					$processing_result_id,
+					$th->getMessage(),
+					$th->getCode()
+				),
 				'error',
 				'feed-ingestion-failure'
 			);

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Pinterest;
 
 use Automattic\WooCommerce\Pinterest\API\Base;
 use Exception;
+use Throwable;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,6 +25,13 @@ class FeedStatusService {
 	 * @var string
 	 */
 	private const LAST_LOGGED_PROCESSING_RESULT_ID_KEY = 'last_logged_processing_result_id';
+
+	/**
+	 * Plugin data key used to avoid retrying the same failed processing result repeatedly.
+	 *
+	 * @var string
+	 */
+	private const LAST_RETRIED_PROCESSING_RESULT_ID_KEY = 'last_retried_processing_result_id';
 
 	/**
 	 * The error contexts to search for in the workflow responses.
@@ -387,5 +395,55 @@ class FeedStatusService {
 		);
 
 		Pinterest_For_WooCommerce()::save_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
+	}
+
+	/**
+	 * Retry Pinterest feed ingestion once when a transient FETCH_ERROR failure is observed.
+	 *
+	 * @param string $feed_id            Pinterest feed ID.
+	 * @param array  $processing_results Recent processing results array.
+	 *
+	 * @return bool Whether a retry was triggered successfully.
+	 */
+	public static function maybe_retry_on_fetch_error( string $feed_id, array $processing_results ): bool {
+		if ( Feeds::FEED_PROCESSING_STATUS_FAILED !== ( $processing_results['status'] ?? '' ) ) {
+			return false;
+		}
+
+		if ( ! isset( $processing_results['validation_details']['errors']['FETCH_ERROR'] ) ) {
+			return false;
+		}
+
+		$processing_result_id = $processing_results['id'] ?? '';
+		if ( empty( $processing_result_id ) ) {
+			return false;
+		}
+
+		$last_retried_processing_result_id = Pinterest_For_WooCommerce()::get_data(
+			self::LAST_RETRIED_PROCESSING_RESULT_ID_KEY
+		);
+		if ( $processing_result_id === $last_retried_processing_result_id ) {
+			return false;
+		}
+
+		try {
+			Feeds::update_feed( $feed_id, array() );
+			Pinterest_For_WooCommerce()::save_data( self::LAST_RETRIED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
+			Logger::log(
+				"FETCH_ERROR retry triggered for processing_result_id={$processing_result_id}",
+				'error',
+				'feed-ingestion-failure'
+			);
+
+			return true;
+		} catch ( Throwable $th ) {
+			Logger::log(
+				"FETCH_ERROR retry failed: {$th->getMessage()}",
+				'error',
+				'feed-ingestion-failure'
+			);
+
+			return false;
+		}
 	}
 }

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -222,6 +222,23 @@ class Feeds {
 	}
 
 	/**
+	 * Reschedule Pinterest's next feed fetch to roughly five minutes from now.
+	 *
+	 * Issuing an "empty" feed update is the idiom Pinterest expects to reset the
+	 * preferred processing schedule; this wrapper makes that intent explicit.
+	 *
+	 * @since 1.4.27
+	 *
+	 * @param string $feed_id The ID of the feed.
+	 *
+	 * @return array
+	 * @throws Throwable PHP Exception if there is an error updating the feed.
+	 */
+	public static function reschedule_feed_fetch( string $feed_id ) {
+		return static::update_feed( $feed_id, array() );
+	}
+
+	/**
 	 * Get a specific merchant feed using the given arguments.
 	 *
 	 * @param string $feed_id     The ID of the feed.

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -286,8 +286,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $this->update_feed_requests );
 		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' ) );
-		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed for processing_result_id=processing-result-1' );
-		$this->assert_log_entry_contains( 'Temporary Pinterest API failure.' );
+		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed for processing_result_id=processing-result-1: Temporary Pinterest API failure.' );
 	}
 
 	/**

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -114,8 +114,8 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $this->mock_logger->entries );
 
 		$entry             = $this->mock_logger->entries[0];
-		$expected_feed_url = trailingslashit( wp_get_upload_dir()['baseurl'] ) .
-			PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-local-feed.xml';
+		$configs           = LocalFeedConfigs::get_instance()->get_configurations();
+		$expected_feed_url = reset( $configs )['feed_url'];
 		$expected_message  = implode(
 			"\n",
 			array(

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -96,7 +96,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
 		Pinterest_For_Woocommerce::remove_data( 'last_retried_processing_result_id' );
 		LocalFeedConfigs::deregister();
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', array( $this, 'intercept_update_feed_request' ), 10 );
 
 		parent::tearDown();
 	}
@@ -287,6 +287,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $this->update_feed_requests );
 		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' ) );
 		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed for processing_result_id=processing-result-1' );
+		$this->assert_log_entry_contains( 'Temporary Pinterest API failure.' );
 	}
 
 	/**

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -235,7 +235,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 			'processing-result-1',
 			Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' )
 		);
-		$this->assert_log_entry_contains( 'FETCH_ERROR retry triggered for processing_result_id=processing-result-1' );
+		$this->assert_log_entry_contains( 'FETCH_ERROR retry triggered for processing_result_id=processing-result-1', 'info' );
 	}
 
 	/**
@@ -286,7 +286,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $this->update_feed_requests );
 		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' ) );
-		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed:' );
+		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed for processing_result_id=processing-result-1' );
 	}
 
 	/**
@@ -371,12 +371,13 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * Assert a log entry contains a given message fragment.
 	 *
 	 * @param string $message_fragment Message fragment.
+	 * @param string $expected_level   Expected log level.
 	 * @return void
 	 */
-	private function assert_log_entry_contains( string $message_fragment ): void {
+	private function assert_log_entry_contains( string $message_fragment, string $expected_level = 'error' ): void {
 		foreach ( $this->mock_logger->entries as $entry ) {
 			if ( false !== strpos( $entry['message'], $message_fragment ) ) {
-				$this->assertEquals( 'error', $entry['level'] );
+				$this->assertEquals( $expected_level, $entry['level'] );
 				$this->assertEquals(
 					array(
 						'source' => PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-feed-ingestion-failure',

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -21,6 +21,20 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	private $mock_logger;
 
 	/**
+	 * Captured feed update requests.
+	 *
+	 * @var array
+	 */
+	private $update_feed_requests = array();
+
+	/**
+	 * Whether to return an error response for feed update requests.
+	 *
+	 * @var bool
+	 */
+	private $should_fail_update_feed_request = false;
+
+	/**
 	 * Set up the WC logger mock and local feed configuration.
 	 *
 	 * @return void
@@ -30,7 +44,9 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		LocalFeedConfigs::deregister();
 		Pinterest_For_Woocommerce::set_default_settings();
+		Pinterest_For_Woocommerce::save_setting( 'tracking_advertiser', '114141241212' );
 		Pinterest_For_Woocommerce::save_setting( 'enable_debug_logging', false );
+		Pinterest_For_Woocommerce::save_token_data( array( 'access_token' => 'some-fake-access-token' ) );
 		Pinterest_For_Woocommerce::save_data(
 			'local_feed_ids',
 			array(
@@ -38,6 +54,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 			)
 		);
 		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
+		Pinterest_For_Woocommerce::remove_data( 'last_retried_processing_result_id' );
 
 		$this->mock_logger = new class() {
 
@@ -66,6 +83,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		};
 
 		Logger::$logger = $this->mock_logger;
+		add_filter( 'pre_http_request', array( $this, 'intercept_update_feed_request' ), 10, 3 );
 	}
 
 	/**
@@ -76,7 +94,9 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		Logger::$logger = null;
 		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
+		Pinterest_For_Woocommerce::remove_data( 'last_retried_processing_result_id' );
 		LocalFeedConfigs::deregister();
+		remove_all_filters( 'pre_http_request' );
 
 		parent::tearDown();
 	}
@@ -190,6 +210,139 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a FETCH_ERROR failed processing result triggers one feed update retry.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_retry_on_fetch_error_triggers_retry_once() {
+		$processing_results = $this->get_failed_processing_results();
+
+		$this->assertTrue( FeedStatusService::maybe_retry_on_fetch_error( 'feed-123', $processing_results ) );
+
+		$this->assertCount( 1, $this->update_feed_requests );
+		$this->assertEquals( 'PATCH', $this->update_feed_requests[0]['method'] );
+		$this->assertEquals(
+			'https://api.pinterest.com/v5/catalogs/feeds/feed-123?ad_account_id=114141241212',
+			$this->update_feed_requests[0]['url']
+		);
+		$this->assertEquals( 'ACTIVE', $this->update_feed_requests[0]['body']['status'] );
+		$this->assertEquals(
+			'Etc/UTC',
+			$this->update_feed_requests[0]['body']['preferred_processing_schedule']['timezone']
+		);
+		$this->assertEquals( 'RETAIL', $this->update_feed_requests[0]['body']['catalog_type'] );
+		$this->assertEquals(
+			'processing-result-1',
+			Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' )
+		);
+		$this->assert_log_entry_contains( 'FETCH_ERROR retry triggered for processing_result_id=processing-result-1' );
+	}
+
+	/**
+	 * Tests that duplicate processing result IDs are not retried twice.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_retry_on_fetch_error_does_not_retry_same_processing_result_id_twice() {
+		$processing_results = $this->get_failed_processing_results();
+
+		$this->assertTrue( FeedStatusService::maybe_retry_on_fetch_error( 'feed-123', $processing_results ) );
+		$this->assertFalse( FeedStatusService::maybe_retry_on_fetch_error( 'feed-123', $processing_results ) );
+
+		$this->assertCount( 1, $this->update_feed_requests );
+	}
+
+	/**
+	 * Tests that non-FETCH_ERROR failed processing results do not trigger a retry.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_retry_on_fetch_error_does_not_retry_non_fetch_error_failures() {
+		$processing_results                                   = $this->get_failed_processing_results();
+		$processing_results['validation_details']['errors']   = array(
+			'NO_VERIFIED_DOMAIN' => 1,
+		);
+		$processing_results['validation_details']['warnings'] = array();
+		$processing_results['product_counts']['ingested']     = 0;
+		$processing_results['product_counts']['original']     = 10;
+		$processing_results['id']                             = 'processing-result-no-verified-domain';
+
+		$this->assertFalse( FeedStatusService::maybe_retry_on_fetch_error( 'feed-123', $processing_results ) );
+
+		$this->assertCount( 0, $this->update_feed_requests );
+		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' ) );
+	}
+
+	/**
+	 * Tests that feed update exceptions are logged and swallowed.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_retry_on_fetch_error_logs_and_swallows_update_exceptions() {
+		$this->should_fail_update_feed_request = true;
+		$processing_results                    = $this->get_failed_processing_results();
+
+		$this->assertFalse( FeedStatusService::maybe_retry_on_fetch_error( 'feed-123', $processing_results ) );
+
+		$this->assertCount( 1, $this->update_feed_requests );
+		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'last_retried_processing_result_id' ) );
+		$this->assert_log_entry_contains( 'FETCH_ERROR retry failed:' );
+	}
+
+	/**
+	 * Intercept feed update requests.
+	 *
+	 * @param mixed  $response    Preemptive response.
+	 * @param array  $parsed_args Request arguments.
+	 * @param string $url         Request URL.
+	 * @return mixed
+	 */
+	public function intercept_update_feed_request( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds/feed-123?ad_account_id=114141241212' !== $url ) {
+			return $response;
+		}
+
+		$this->update_feed_requests[] = array(
+			'url'    => $url,
+			'method' => $parsed_args['method'],
+			'body'   => json_decode( $parsed_args['body'], true ),
+		);
+
+		if ( $this->should_fail_update_feed_request ) {
+			return array(
+				'headers'  => array(
+					'content-type' => 'application/json',
+				),
+				'body'     => wp_json_encode(
+					array(
+						'code'    => 500,
+						'message' => 'Temporary Pinterest API failure.',
+					)
+				),
+				'response' => array(
+					'code'    => 500,
+					'message' => 'Internal Server Error',
+				),
+				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+
+		return array(
+			'headers'  => array(
+				'content-type' => 'application/json',
+			),
+			'body'     => wp_json_encode( array( 'id' => 'feed-123' ) ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => '',
+		);
+	}
+
+	/**
 	 * Get a failed processing result fixture.
 	 *
 	 * @return array
@@ -212,5 +365,28 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 				'ingested' => 0,
 			),
 		);
+	}
+
+	/**
+	 * Assert a log entry contains a given message fragment.
+	 *
+	 * @param string $message_fragment Message fragment.
+	 * @return void
+	 */
+	private function assert_log_entry_contains( string $message_fragment ): void {
+		foreach ( $this->mock_logger->entries as $entry ) {
+			if ( false !== strpos( $entry['message'], $message_fragment ) ) {
+				$this->assertEquals( 'error', $entry['level'] );
+				$this->assertEquals(
+					array(
+						'source' => PINTEREST_FOR_WOOCOMMERCE_LOG_PREFIX . '-feed-ingestion-failure',
+					),
+					$entry['handler']
+				);
+				return;
+			}
+		}
+
+		$this->fail( "Expected log entry containing: {$message_fragment}" );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes PIN4WOO-81

This PR is stacked on #1179 (`fix/log-feed-ingestion-failure`) and should be reviewed as the retry-only follow-up to that failed-ingestion logging work.

When Pinterest reports the latest feed processing result as `FAILED` with a `FETCH_ERROR`, this calls the existing `Feeds::update_feed( $feed_id, array() )` immediately after logging the failed-ingestion context. That existing update path resets Pinterest's `preferred_processing_schedule` to roughly five minutes from now, avoiding the default wait for Pinterest's next daily fetch window.

The retry is idempotent by Pinterest processing-result ID via `last_retried_processing_result_id`, so each unique failed ingestion can trigger only one schedule reset. Feed update failures are logged to the feed-ingestion failure source and swallowed so the recurring registration action does not crash.

### Detailed test instructions:

1. Exercise the real scheduled-action code path on a WordPress/WooCommerce test site connected to Pinterest. The site must have a generated feed file in `wp-content/uploads/` and a non-empty registered Pinterest feed ID:
   ```bash
   wp eval 'echo \Pinterest_For_Woocommerce::get_data( "feed_registered" ), "\n";'
   ```
2. Drop the following mu-plugin into `wp-content/mu-plugins/pin4woo-81-test.php`. This mocks the latest `processing_results` response and the retry `PATCH` feed update response, which avoids account-state failures such as a disapproved Pinterest business account while still exercising the plugin's scheduled-action code path.
   <details><summary>pin4woo-81-test.php</summary>

   ```php
   <?php
   add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
       if ( false !== strpos( $url, '/processing_results' ) ) {
           return array(
               'headers'  => array( 'content-type' => 'application/json' ),
               'response' => array( 'code' => 200, 'message' => 'OK' ),
               'cookies'  => array(),
               'body'     => wp_json_encode( array(
                   'items' => array(
                       array(
                           'id'                 => 'pin4woo-81-fetch-error-1',
                           'status'             => 'FAILED',
                           'created_at'         => gmdate( 'c' ),
                           'validation_details' => array(
                               'errors'   => array( 'FETCH_ERROR' => 1 ),
                               'warnings' => array(),
                           ),
                           'product_counts'     => array( 'original' => 10, 'ingested' => 0 ),
                       ),
                   ),
               ) ),
           );
       }

       if (
           'PATCH' === strtoupper( $args['method'] ?? '' ) &&
           false !== strpos( $url, 'https://api.pinterest.com/v5/catalogs/feeds/' ) &&
           false === strpos( $url, '/processing_results' )
       ) {
           return array(
               'headers'  => array( 'content-type' => 'application/json' ),
               'response' => array( 'code' => 200, 'message' => 'OK' ),
               'cookies'  => array(),
               'body'     => wp_json_encode( array(
                   'id'     => \Pinterest_For_Woocommerce::get_data( 'feed_registered' ),
                   'status' => 'ACTIVE',
               ) ),
           );
       }

       return $preempt;
   }, 10, 3 );
   ```

   </details>
3. Reset dedupe state and trigger the scheduled handler:
   ```bash
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_retried_processing_result_id" );'
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
4. Verify `/wp-admin/admin.php?page=wc-status&tab=logs` shows the `pinterest-for-woocommerce-feed-ingestion-failure` log source with both:
   - `Feed ingestion FAILED`
   - `FETCH_ERROR retry triggered for processing_result_id=pin4woo-81-fetch-error-1`
5. Confirm the retry result ID was persisted:
   ```bash
   wp eval 'echo \Pinterest_For_Woocommerce::get_data( "last_retried_processing_result_id" ), "\n";'
   ```
   Expected: `pin4woo-81-fetch-error-1`
6. Re-run the scheduled handler with the same mocked processing result ID:
   ```bash
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
   Confirm no additional `FETCH_ERROR retry triggered` entry is appended for the same processing result ID.
7. Cleanup:
   ```bash
   rm wp-content/mu-plugins/pin4woo-81-test.php
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_retried_processing_result_id" );'
   ```

### Additional details:

No screenshots: this is a scheduled feed-registration/Pinterest API behavior change with no UI surface.

### Changelog entry

> Fix - Retry Pinterest feed ingestion sooner when Pinterest reports a FETCH_ERROR.
