### PR TITLE
Skip Pinterest tracking events for crawler requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"automattic/jetpack-autoloader": "^2.10.1",
 		"defuse/php-encryption": "^2.2",
 		"woocommerce/action-scheduler-job-framework": "^2.0.0",
-		"woocommerce/grow": "dev-compat-checker"
+		"woocommerce/grow": "dev-compat-checker",
+		"automattic/jetpack-device-detection": "^3.4"
 	},
 	"require-dev": {
 		"composer/installers": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2d464c01f8847a28d7030570fd20169",
+    "content-hash": "48368e5d682dfc9e908cc3b1b1cb4045",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -67,6 +67,56 @@
                 "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.12.0"
             },
             "time": "2023-09-28T18:33:34+00:00"
+        },
+        {
+            "name": "automattic/jetpack-device-detection",
+            "version": "v3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-device-detection.git",
+                "reference": "b4b4c7b18c4e377f676458a5af11a1a8757dc1f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-device-detection/zipball/b4b4c7b18c4e377f676458a5af11a1a8757dc1f4",
+                "reference": "b4b4c7b18c4e377f676458a5af11a1a8757dc1f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "^1.0.6",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-device-detection",
+                "branch-alias": {
+                    "dev-trunk": "3.4.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A way to detect device types based on User-Agent header.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-device-detection/tree/v3.4.2"
+            },
+            "time": "2026-05-19T09:16:56+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -3786,5 +3836,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Pinterest;
 
+use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
 use Automattic\WooCommerce\Pinterest\Tracking\Data;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\Category;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\Checkout;
@@ -16,6 +17,7 @@ use Automattic\WooCommerce\Pinterest\Tracking\Data\Product;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\Search;
 use Automattic\WooCommerce\Pinterest\Tracking\Tag;
 use Automattic\WooCommerce\Pinterest\Tracking\Tracker;
+use Automattic\WooCommerce\Pinterest\Utilities\CrawlerDetector;
 use Throwable;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -87,11 +89,6 @@ class Tracking {
 			return;
 		}
 
-		if ( $this->is_crawler_request() ) {
-			// Do not track crawler requests to avoid inflating CAPI vs Tag.
-			return;
-		}
-
 		// Dumy data for when we can't get product data.
 		$data = new None( uniqid( 'page' ) );
 
@@ -129,11 +126,6 @@ class Tracking {
 	 */
 	public function handle_view_category() {
 		if ( ! is_product_category() ) {
-			return;
-		}
-
-		if ( $this->is_crawler_request() ) {
-			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
 		$queried_object = get_queried_object();
@@ -234,11 +226,6 @@ class Tracking {
 			return;
 		}
 
-		if ( $this->is_crawler_request() ) {
-			// Do not track crawler requests to avoid inflating CAPI vs Tag.
-			return;
-		}
-
 		$data = new Search(
 			uniqid( 'pinterest-for-woocommerce-tag-and-conversions-event-id' ),
 			get_search_query()
@@ -247,44 +234,12 @@ class Tracking {
 	}
 
 	/**
-	 * Detects whether the current request looks like it is coming from a crawler/bot.
-	 *
-	 * WordPress core does not ship a public crawler-detection helper, so we use a
-	 * conservative User-Agent match against the most common crawler/bot tokens.
-	 * The goal is to avoid firing server-side CAPI events for requests that will
-	 * never fire the browser-side Pinterest Tag (because bots do not execute JS),
-	 * which would otherwise inflate CAPI counts relative to Tag counts.
-	 *
-	 * @since 1.4.27
-	 *
-	 * @return bool
-	 */
-	private function is_crawler_request() {
-		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
-			: '';
-
-		if ( '' === $user_agent ) {
-			return false;
-		}
-
-		$is_crawler = (bool) preg_match( '/bot|crawl|spider|slurp|curl|wget|feed|phantom|headless/i', $user_agent );
-
-		/**
-		 * Filters whether the current request is treated as a crawler for tracking purposes.
-		 *
-		 * When true, PageVisit, ViewCategory, and Search events are not dispatched.
-		 *
-		 * @since 1.4.27
-		 *
-		 * @param bool   $is_crawler Whether the request looks like a crawler.
-		 * @param string $user_agent The raw User-Agent header value.
-		 */
-		return (bool) apply_filters( 'pinterest_for_woocommerce_is_crawler_request', $is_crawler, $user_agent );
-	}
-
-	/**
 	 * Method which iterates over all the attached trackers and delegates the event to them.
+	 *
+	 * Server-side trackers (Conversions API) are skipped for crawler/bot requests.
+	 * Browser-side rendering (Tag JS) is intentionally NOT skipped, so full-page
+	 * caches that omit `Vary: User-Agent` do not serve bot-rendered HTML missing
+	 * Tag JS to real users on a subsequent cache hit. See CrawlerDetector.
 	 *
 	 * @since 1.4.0
 	 *
@@ -294,9 +249,17 @@ class Tracking {
 	 * @return void
 	 */
 	public function track_event( string $event_name, Data $data ) {
+		$is_crawler = CrawlerDetector::is_crawler_request();
+
 		foreach ( $this->get_trackers() as $tracker ) {
 			// Skip Pinterest tag tracking if tag is not active.
 			if ( $tracker instanceof Tag && ! Tag::get_active_tag() ) {
+				continue;
+			}
+
+			// Skip server-side CAPI dispatch for crawler requests so bot
+			// traffic does not inflate CAPI counts vs Tag counts.
+			if ( $is_crawler && $tracker instanceof Conversions ) {
 				continue;
 			}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -87,6 +87,11 @@ class Tracking {
 			return;
 		}
 
+		if ( wp_is_crawler() ) {
+			// Do not track crawler requests to avoid inflating CAPI vs Tag.
+			return;
+		}
+
 		// Dumy data for when we can't get product data.
 		$data = new None( uniqid( 'page' ) );
 
@@ -124,6 +129,11 @@ class Tracking {
 	 */
 	public function handle_view_category() {
 		if ( ! is_product_category() ) {
+			return;
+		}
+
+		if ( wp_is_crawler() ) {
+			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
 		$queried_object = get_queried_object();
@@ -221,6 +231,11 @@ class Tracking {
 	 */
 	public function handle_search() {
 		if ( ! is_search() ) {
+			return;
+		}
+
+		if ( wp_is_crawler() ) {
+			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -87,7 +87,7 @@ class Tracking {
 			return;
 		}
 
-		if ( wp_is_crawler() ) {
+		if ( $this->is_crawler_request() ) {
 			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
@@ -132,7 +132,7 @@ class Tracking {
 			return;
 		}
 
-		if ( wp_is_crawler() ) {
+		if ( $this->is_crawler_request() ) {
 			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
@@ -234,7 +234,7 @@ class Tracking {
 			return;
 		}
 
-		if ( wp_is_crawler() ) {
+		if ( $this->is_crawler_request() ) {
 			// Do not track crawler requests to avoid inflating CAPI vs Tag.
 			return;
 		}
@@ -244,6 +244,43 @@ class Tracking {
 			get_search_query()
 		);
 		$this->track_event( static::EVENT_SEARCH, $data );
+	}
+
+	/**
+	 * Detects whether the current request looks like it is coming from a crawler/bot.
+	 *
+	 * WordPress core does not ship a public crawler-detection helper, so we use a
+	 * conservative User-Agent match against the most common crawler/bot tokens.
+	 * The goal is to avoid firing server-side CAPI events for requests that will
+	 * never fire the browser-side Pinterest Tag (because bots do not execute JS),
+	 * which would otherwise inflate CAPI counts relative to Tag counts.
+	 *
+	 * @since 1.4.27
+	 *
+	 * @return bool
+	 */
+	private function is_crawler_request() {
+		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
+			: '';
+
+		if ( '' === $user_agent ) {
+			return false;
+		}
+
+		$is_crawler = (bool) preg_match( '/bot|crawl|spider|slurp|curl|wget|feed|phantom|headless/i', $user_agent );
+
+		/**
+		 * Filters whether the current request is treated as a crawler for tracking purposes.
+		 *
+		 * When true, PageVisit, ViewCategory, and Search events are not dispatched.
+		 *
+		 * @since 1.4.27
+		 *
+		 * @param bool   $is_crawler Whether the request looks like a crawler.
+		 * @param string $user_agent The raw User-Agent header value.
+		 */
+		return (bool) apply_filters( 'pinterest_for_woocommerce_is_crawler_request', $is_crawler, $user_agent );
 	}
 
 	/**

--- a/src/Utilities/CrawlerDetector.php
+++ b/src/Utilities/CrawlerDetector.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Pinterest\Utilities;
 
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -16,8 +18,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Detects whether the current HTTP request appears to come from a crawler/bot.
  *
- * WordPress core does not ship a public crawler-detection helper, so we use a
- * conservative User-Agent match against the most common crawler/bot tokens.
+ * Primary detection is delegated to Jetpack's
+ * `Automattic\Jetpack\Device_Detection\User_Agent_Info::is_bot_user_agent()`,
+ * which ships an actively-maintained list of search-engine bots, AI crawlers,
+ * social-network preview fetchers and other indexers. A small supplementary
+ * regex catches programmatic / headless HTTP clients (curl, wget, Feedly,
+ * PhantomJS, HeadlessChrome) that will never execute the browser-side
+ * Pinterest Tag JS and are therefore still relevant to CAPI inflation, but
+ * which Jetpack does not flag as bots.
  *
  * Tracking-domain code (Conversions API in particular) uses this to avoid
  * dispatching server-side events for requests that will never fire the
@@ -29,10 +37,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CrawlerDetector {
 
 	/**
+	 * Supplementary User-Agent regex for programmatic / headless clients that
+	 * Jetpack's bot list intentionally does not cover. These clients will not
+	 * execute the browser-side Pinterest Tag JS, so any CAPI dispatch from
+	 * them is by definition CAPI-only and inflates the CAPI vs Tag ratio.
+	 *
+	 * @var string
+	 */
+	const PROGRAMMATIC_CLIENT_REGEX = '/curl|wget|feed|phantom|headless/i';
+
+	/**
 	 * Returns true when the current request looks like a crawler/bot.
 	 *
-	 * Detection is intentionally NOT memoized: the regex and the filter call
-	 * are both cheap, and re-evaluating per call keeps the
+	 * Detection is intentionally NOT memoized: the underlying checks and the
+	 * filter call are cheap, and re-evaluating per call keeps the
 	 * `pinterest_for_woocommerce_is_crawler_request` filter responsive to
 	 * runtime changes (added/removed hooks, test fixtures) without requiring
 	 * callers to remember to reset static state.
@@ -44,13 +62,16 @@ class CrawlerDetector {
 	public static function is_crawler_request(): bool {
 		// Unslashed raw value for the filter, so consumers see exactly what the
 		// client sent. The sanitized copy below is only used internally for the
-		// regex check.
+		// detection checks.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$raw_user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
 		$user_agent     = '' === $raw_user_agent ? '' : sanitize_text_field( $raw_user_agent );
 
 		$is_crawler = '' !== $user_agent
-			&& (bool) preg_match( '/bot|crawl|spider|slurp|curl|wget|feed|phantom|headless/i', $user_agent );
+			&& (
+				User_Agent_Info::is_bot_user_agent( $user_agent )
+				|| 1 === preg_match( self::PROGRAMMATIC_CLIENT_REGEX, $user_agent )
+			);
 
 		/**
 		 * Filters whether the current request is treated as a crawler.

--- a/src/Utilities/CrawlerDetector.php
+++ b/src/Utilities/CrawlerDetector.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Crawler / bot detection helper.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Utilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects whether the current HTTP request appears to come from a crawler/bot.
+ *
+ * WordPress core does not ship a public crawler-detection helper, so we use a
+ * conservative User-Agent match against the most common crawler/bot tokens.
+ *
+ * Tracking-domain code (Conversions API in particular) uses this to avoid
+ * dispatching server-side events for requests that will never fire the
+ * browser-side Pinterest Tag, which would otherwise inflate CAPI counts
+ * relative to Tag counts.
+ *
+ * @since x.x.x
+ */
+class CrawlerDetector {
+
+	/**
+	 * Per-request memoized result. Null = not yet computed.
+	 *
+	 * The detection runs against `$_SERVER['HTTP_USER_AGENT']`, which is
+	 * immutable for a given PHP request, so the result is safe to cache for
+	 * the lifetime of the request. Multiple tracking hooks call this on the
+	 * same request (page_visit, view_category, search and any future caller),
+	 * so the cache avoids re-running the regex and re-applying the filter.
+	 *
+	 * @var bool|null
+	 */
+	private static $cached_result = null;
+
+	/**
+	 * Returns true when the current request looks like a crawler/bot.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public static function is_crawler_request() {
+		if ( null !== self::$cached_result ) {
+			return self::$cached_result;
+		}
+
+		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
+			: '';
+
+		$is_crawler = '' !== $user_agent
+			&& (bool) preg_match( '/bot|crawl|spider|slurp|curl|wget|feed|phantom|headless/i', $user_agent );
+
+		/**
+		 * Filters whether the current request is treated as a crawler.
+		 *
+		 * When true, server-side tracking events (Conversions API) are not
+		 * dispatched for the request. Browser-side rendering (Pinterest Tag
+		 * JS) is intentionally NOT suppressed, so full-page caches that omit
+		 * `Vary: User-Agent` do not serve bot-rendered HTML (missing Tag JS)
+		 * to real users.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool   $is_crawler Whether the request looks like a crawler.
+		 * @param string $user_agent The raw User-Agent header value.
+		 */
+		self::$cached_result = (bool) apply_filters(
+			'pinterest_for_woocommerce_is_crawler_request',
+			$is_crawler,
+			$user_agent
+		);
+
+		return self::$cached_result;
+	}
+
+	/**
+	 * Resets the memoized result. Intended for use in tests only.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function reset_cache() {
+		self::$cached_result = null;
+	}
+}

--- a/src/Utilities/CrawlerDetector.php
+++ b/src/Utilities/CrawlerDetector.php
@@ -5,6 +5,8 @@
  * @package Automattic\WooCommerce\Pinterest
  */
 
+declare( strict_types=1 );
+
 namespace Automattic\WooCommerce\Pinterest\Utilities;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -39,10 +41,13 @@ class CrawlerDetector {
 	 *
 	 * @return bool
 	 */
-	public static function is_crawler_request() {
-		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
-			: '';
+	public static function is_crawler_request(): bool {
+		// Unslashed raw value for the filter, so consumers see exactly what the
+		// client sent. The sanitized copy below is only used internally for the
+		// regex check.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$raw_user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
+		$user_agent     = '' === $raw_user_agent ? '' : sanitize_text_field( $raw_user_agent );
 
 		$is_crawler = '' !== $user_agent
 			&& (bool) preg_match( '/bot|crawl|spider|slurp|curl|wget|feed|phantom|headless/i', $user_agent );
@@ -59,12 +64,12 @@ class CrawlerDetector {
 		 * @since x.x.x
 		 *
 		 * @param bool   $is_crawler Whether the request looks like a crawler.
-		 * @param string $user_agent The raw User-Agent header value.
+		 * @param string $user_agent The raw (unslashed, unsanitized) User-Agent header value.
 		 */
 		return (bool) apply_filters(
 			'pinterest_for_woocommerce_is_crawler_request',
 			$is_crawler,
-			$user_agent
+			$raw_user_agent
 		);
 	}
 }

--- a/src/Utilities/CrawlerDetector.php
+++ b/src/Utilities/CrawlerDetector.php
@@ -27,30 +27,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CrawlerDetector {
 
 	/**
-	 * Per-request memoized result. Null = not yet computed.
-	 *
-	 * The detection runs against `$_SERVER['HTTP_USER_AGENT']`, which is
-	 * immutable for a given PHP request, so the result is safe to cache for
-	 * the lifetime of the request. Multiple tracking hooks call this on the
-	 * same request (page_visit, view_category, search and any future caller),
-	 * so the cache avoids re-running the regex and re-applying the filter.
-	 *
-	 * @var bool|null
-	 */
-	private static $cached_result = null;
-
-	/**
 	 * Returns true when the current request looks like a crawler/bot.
+	 *
+	 * Detection is intentionally NOT memoized: the regex and the filter call
+	 * are both cheap, and re-evaluating per call keeps the
+	 * `pinterest_for_woocommerce_is_crawler_request` filter responsive to
+	 * runtime changes (added/removed hooks, test fixtures) without requiring
+	 * callers to remember to reset static state.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return bool
 	 */
 	public static function is_crawler_request() {
-		if ( null !== self::$cached_result ) {
-			return self::$cached_result;
-		}
-
 		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
 			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
 			: '';
@@ -72,23 +61,10 @@ class CrawlerDetector {
 		 * @param bool   $is_crawler Whether the request looks like a crawler.
 		 * @param string $user_agent The raw User-Agent header value.
 		 */
-		self::$cached_result = (bool) apply_filters(
+		return (bool) apply_filters(
 			'pinterest_for_woocommerce_is_crawler_request',
 			$is_crawler,
 			$user_agent
 		);
-
-		return self::$cached_result;
-	}
-
-	/**
-	 * Resets the memoized result. Intended for use in tests only.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return void
-	 */
-	public static function reset_cache() {
-		self::$cached_result = null;
 	}
 }

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -9,8 +9,38 @@ use Pinterest_For_Woocommerce;
 
 class TrackingTest extends \WP_UnitTestCase {
 
-	function setUp(): void {
+	/**
+	 * Original $_SERVER['HTTP_USER_AGENT'] value, restored after each test.
+	 *
+	 * @var string|null
+	 */
+	private $original_user_agent;
+
+	/**
+	 * Per-test setup. Snapshots the inbound User-Agent so tests can mutate it
+	 * freely and have it restored in tearDown.
+	 */
+	public function setUp(): void {
 		parent::setUp();
+		// Snapshot raw value for verbatim restoration in tearDown.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+	}
+
+	/**
+	 * Per-test cleanup. Restores the inbound User-Agent and removes any
+	 * filters added by tests on the crawler-detection hook.
+	 */
+	public function tearDown(): void {
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		remove_all_filters( 'pinterest_for_woocommerce_is_crawler_request' );
+
+		parent::tearDown();
 	}
 
 	function test_tracking_adds_actions_monitoring() {
@@ -92,6 +122,94 @@ class TrackingTest extends \WP_UnitTestCase {
 		$pinterest_capi_tracker->expects( $this->once() )
 			->method( 'track_event' )
 			->with( 'test', $data );
+
+		$tracking->track_event( 'test', $data );
+	}
+
+	/**
+	 * Crawler requests must skip the Conversions (CAPI) tracker while still
+	 * dispatching to the Tag tracker. Browser-side rendering needs to keep
+	 * happening so cached HTML carries Tag JS for real users.
+	 */
+	public function test_crawler_request_skips_conversions_tracker_only() {
+		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'WD7AFW51GS' ) );
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+		$tracking = new Tracking();
+
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
+		$pinterest_capi_tracker = $this->createMock( Conversions::class );
+
+		$tracking->add_tracker( $pinterest_tag_tracker );
+		$tracking->add_tracker( $pinterest_capi_tracker );
+
+		$data = new None( 'event_id' );
+
+		$pinterest_tag_tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with( 'test', $data );
+		$pinterest_capi_tracker->expects( $this->never() )
+			->method( 'track_event' );
+
+		$tracking->track_event( 'test', $data );
+	}
+
+	/**
+	 * Non-crawler requests must dispatch to BOTH trackers (regression guard
+	 * against an over-broad skip).
+	 */
+	public function test_non_crawler_request_fires_all_trackers() {
+		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'WD7AFW51GS' ) );
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+		$tracking = new Tracking();
+
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
+		$pinterest_capi_tracker = $this->createMock( Conversions::class );
+
+		$tracking->add_tracker( $pinterest_tag_tracker );
+		$tracking->add_tracker( $pinterest_capi_tracker );
+
+		$data = new None( 'event_id' );
+
+		$pinterest_tag_tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with( 'test', $data );
+		$pinterest_capi_tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with( 'test', $data );
+
+		$tracking->track_event( 'test', $data );
+	}
+
+	/**
+	 * The `pinterest_for_woocommerce_is_crawler_request` filter must be able
+	 * to flag an otherwise-human UA as a crawler and skip CAPI.
+	 */
+	public function test_filter_can_force_crawler_classification() {
+		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'WD7AFW51GS' ) );
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0';
+
+		add_filter( 'pinterest_for_woocommerce_is_crawler_request', '__return_true' );
+
+		$tracking = new Tracking();
+
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
+		$pinterest_capi_tracker = $this->createMock( Conversions::class );
+
+		$tracking->add_tracker( $pinterest_tag_tracker );
+		$tracking->add_tracker( $pinterest_capi_tracker );
+
+		$data = new None( 'event_id' );
+
+		$pinterest_tag_tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with( 'test', $data );
+		$pinterest_capi_tracker->expects( $this->never() )
+			->method( 'track_event' );
 
 		$tracking->track_event( 'test', $data );
 	}

--- a/tests/Unit/Utilities/CrawlerDetectorTest.php
+++ b/tests/Unit/Utilities/CrawlerDetectorTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tests\Unit\Utilities;
+
+use Automattic\WooCommerce\Pinterest\Utilities\CrawlerDetector;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for CrawlerDetector.
+ */
+class CrawlerDetectorTest extends WP_UnitTestCase {
+
+	/**
+	 * Original $_SERVER['HTTP_USER_AGENT'] value, restored after each test.
+	 *
+	 * @var string|null
+	 */
+	private $original_user_agent;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+	}
+
+	public function tearDown(): void {
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		remove_all_filters( 'pinterest_for_woocommerce_is_crawler_request' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Missing User-Agent header should be treated as a non-crawler.
+	 */
+	public function test_empty_user_agent_is_not_crawler() {
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+		$this->assertFalse( CrawlerDetector::is_crawler_request() );
+	}
+
+	/**
+	 * Empty-string User-Agent should be treated as a non-crawler.
+	 */
+	public function test_empty_string_user_agent_is_not_crawler() {
+		$_SERVER['HTTP_USER_AGENT'] = '';
+		$this->assertFalse( CrawlerDetector::is_crawler_request() );
+	}
+
+	/**
+	 * @dataProvider crawler_user_agents
+	 *
+	 * @param string $user_agent The user agent string to test.
+	 */
+	public function test_crawler_user_agents_are_detected( $user_agent ) {
+		$_SERVER['HTTP_USER_AGENT'] = $user_agent;
+		$this->assertTrue(
+			CrawlerDetector::is_crawler_request(),
+			"Expected '{$user_agent}' to be detected as a crawler."
+		);
+	}
+
+	/**
+	 * @return array<string, array<string>>
+	 */
+	public function crawler_user_agents() {
+		return array(
+			'Googlebot'  => array( 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ),
+			'Bingbot'    => array( 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' ),
+			'curl'       => array( 'curl/8.4.0' ),
+			'wget'       => array( 'Wget/1.21.4' ),
+			'spider'     => array( 'Mozilla/5.0 (compatible; YandexSpider/3.0)' ),
+			'slurp'      => array( 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)' ),
+			'crawl'      => array( 'CCBot/2.0 (https://commoncrawl.org/faq/)' ),
+			'feed'       => array( 'Feedly/1.0 (+http://www.feedly.com/fetcher.html)' ),
+			'headless'   => array( 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36' ),
+			'phantom'    => array( 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1' ),
+		);
+	}
+
+	/**
+	 * @dataProvider human_user_agents
+	 *
+	 * @param string $user_agent The user agent string to test.
+	 */
+	public function test_human_user_agents_are_not_detected( $user_agent ) {
+		$_SERVER['HTTP_USER_AGENT'] = $user_agent;
+		$this->assertFalse(
+			CrawlerDetector::is_crawler_request(),
+			"Did not expect '{$user_agent}' to be detected as a crawler."
+		);
+	}
+
+	/**
+	 * @return array<string, array<string>>
+	 */
+	public function human_user_agents() {
+		return array(
+			'Chrome desktop'  => array( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' ),
+			'Firefox desktop' => array( 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0' ),
+			'Safari iPhone'   => array( 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1' ),
+			'Edge'            => array( 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0' ),
+		);
+	}
+
+	/**
+	 * The filter must be able to flip a crawler classification to non-crawler.
+	 */
+	public function test_filter_can_override_crawler_to_false() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+		add_filter( 'pinterest_for_woocommerce_is_crawler_request', '__return_false' );
+
+		$this->assertFalse( CrawlerDetector::is_crawler_request() );
+	}
+
+	/**
+	 * The filter must be able to flag a human UA as a crawler.
+	 */
+	public function test_filter_can_override_human_to_crawler() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0';
+
+		add_filter( 'pinterest_for_woocommerce_is_crawler_request', '__return_true' );
+
+		$this->assertTrue( CrawlerDetector::is_crawler_request() );
+	}
+
+	/**
+	 * The filter receives both the detection result and the raw user agent.
+	 */
+	public function test_filter_receives_user_agent_and_classification() {
+		$ua                          = 'Mozilla/5.0 (compatible; CustomScanner/1.0)';
+		$_SERVER['HTTP_USER_AGENT']  = $ua;
+		$captured                    = array();
+
+		add_filter(
+			'pinterest_for_woocommerce_is_crawler_request',
+			function ( $is_crawler, $user_agent ) use ( &$captured ) {
+				$captured = array(
+					'is_crawler' => $is_crawler,
+					'user_agent' => $user_agent,
+				);
+				return $is_crawler;
+			},
+			10,
+			2
+		);
+
+		CrawlerDetector::is_crawler_request();
+
+		$this->assertFalse( $captured['is_crawler'] );
+		$this->assertSame( $ua, $captured['user_agent'] );
+	}
+
+	/**
+	 * Filter changes must take effect immediately on the next call (no static
+	 * caching that would hold the first result).
+	 */
+	public function test_filter_changes_take_effect_without_reset() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0';
+
+		$this->assertFalse( CrawlerDetector::is_crawler_request() );
+
+		add_filter( 'pinterest_for_woocommerce_is_crawler_request', '__return_true' );
+		$this->assertTrue( CrawlerDetector::is_crawler_request() );
+
+		remove_all_filters( 'pinterest_for_woocommerce_is_crawler_request' );
+		$this->assertFalse( CrawlerDetector::is_crawler_request() );
+	}
+}

--- a/tests/Unit/Utilities/CrawlerDetectorTest.php
+++ b/tests/Unit/Utilities/CrawlerDetectorTest.php
@@ -164,6 +164,34 @@ class CrawlerDetectorTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The filter must receive the RAW (unsanitized) User-Agent so consumers can
+	 * match against the exact string the client sent. Using a UA with characters
+	 * that sanitize_text_field would strip (HTML-tag-like sequence) proves the
+	 * value passed to the filter is not pre-sanitized.
+	 */
+	public function test_filter_receives_raw_unsanitized_user_agent() {
+		$raw_ua                     = 'Mozilla/5.0 <weird> Scanner/1.0';
+		$_SERVER['HTTP_USER_AGENT'] = $raw_ua;
+		$captured                   = null;
+
+		add_filter(
+			'pinterest_for_woocommerce_is_crawler_request',
+			function ( $is_crawler, $user_agent ) use ( &$captured ) {
+				$captured = $user_agent;
+				return $is_crawler;
+			},
+			10,
+			2
+		);
+
+		CrawlerDetector::is_crawler_request();
+
+		// The raw value must reach the filter unchanged; sanitize_text_field
+		// would have stripped the `<weird>` token.
+		$this->assertSame( $raw_ua, $captured );
+	}
+
+	/**
 	 * Filter changes must take effect immediately on the next call (no static
 	 * caching that would hold the first result).
 	 */

--- a/tests/Unit/Utilities/CrawlerDetectorTest.php
+++ b/tests/Unit/Utilities/CrawlerDetectorTest.php
@@ -17,11 +17,19 @@ class CrawlerDetectorTest extends WP_UnitTestCase {
 	 */
 	private $original_user_agent;
 
+	/**
+	 * Per-test setup. Snapshots the inbound User-Agent for restoration.
+	 */
 	public function setUp(): void {
 		parent::setUp();
+		// Snapshot raw value for verbatim restoration in tearDown.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
 	}
 
+	/**
+	 * Per-test cleanup. Restores the User-Agent and removes any added filters.
+	 */
 	public function tearDown(): void {
 		if ( null === $this->original_user_agent ) {
 			unset( $_SERVER['HTTP_USER_AGENT'] );
@@ -68,16 +76,16 @@ class CrawlerDetectorTest extends WP_UnitTestCase {
 	 */
 	public function crawler_user_agents() {
 		return array(
-			'Googlebot'  => array( 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ),
-			'Bingbot'    => array( 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' ),
-			'curl'       => array( 'curl/8.4.0' ),
-			'wget'       => array( 'Wget/1.21.4' ),
-			'spider'     => array( 'Mozilla/5.0 (compatible; YandexSpider/3.0)' ),
-			'slurp'      => array( 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)' ),
-			'crawl'      => array( 'CCBot/2.0 (https://commoncrawl.org/faq/)' ),
-			'feed'       => array( 'Feedly/1.0 (+http://www.feedly.com/fetcher.html)' ),
-			'headless'   => array( 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36' ),
-			'phantom'    => array( 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1' ),
+			'Googlebot' => array( 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ),
+			'Bingbot'   => array( 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' ),
+			'curl'      => array( 'curl/8.4.0' ),
+			'wget'      => array( 'Wget/1.21.4' ),
+			'spider'    => array( 'Mozilla/5.0 (compatible; YandexSpider/3.0)' ),
+			'slurp'     => array( 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)' ),
+			'crawl'     => array( 'CCBot/2.0 (https://commoncrawl.org/faq/)' ),
+			'feed'      => array( 'Feedly/1.0 (+http://www.feedly.com/fetcher.html)' ),
+			'headless'  => array( 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36' ),
+			'phantom'   => array( 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1' ),
 		);
 	}
 
@@ -132,9 +140,9 @@ class CrawlerDetectorTest extends WP_UnitTestCase {
 	 * The filter receives both the detection result and the raw user agent.
 	 */
 	public function test_filter_receives_user_agent_and_classification() {
-		$ua                          = 'Mozilla/5.0 (compatible; CustomScanner/1.0)';
-		$_SERVER['HTTP_USER_AGENT']  = $ua;
-		$captured                    = array();
+		$ua                         = 'Mozilla/5.0 (compatible; CustomScanner/1.0)';
+		$_SERVER['HTTP_USER_AGENT'] = $ua;
+		$captured                   = array();
 
 		add_filter(
 			'pinterest_for_woocommerce_is_crawler_request',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1182.

The `wp_footer` handlers in `src/Tracking.php` dispatched PageVisit / ViewCategory / Search events for every request, including crawlers. Because the server-side CAPI tracker fires from `Tracking::track_event()`, bot traffic was inflating CAPI event counts without corresponding browser-side Pinterest Tag fires, producing a CAPI vs Tag divergence.

This PR introduces `Automattic\WooCommerce\Pinterest\Utilities\CrawlerDetector` (a small utility with a static `is_crawler_request()` method and a `pinterest_for_woocommerce_is_crawler_request` filter for extensibility). Crawler detection is delegated to [`automattic/jetpack-device-detection`](https://packagist.org/packages/automattic/jetpack-device-detection) (`User_Agent_Info::is_bot_user_agent()`), which ships an actively-maintained list of search-engine bots, AI crawlers, social-network preview fetchers and other indexers. A small supplementary regex (`/curl|wget|feed|phantom|headless/i`) catches programmatic / headless HTTP clients that will never execute the browser-side Pinterest Tag JS and are therefore still relevant to CAPI inflation, but which Jetpack does not flag as bots.

The gate is applied inside `Tracking::track_event()`, scoped to the `Conversions` (CAPI) tracker only:

* Crawler request -> CAPI dispatch is skipped.
* `Tag` JS rendering is intentionally NOT suppressed. Full-page caches that omit `Vary: User-Agent` would otherwise be able to cache bot-rendered HTML (missing Tag JS) and serve it to real users.

### Scope note

Because the gate lives in `track_event` (not in the three individual `wp_footer` handlers), it now also applies to AddToCart and Checkout dispatch when the originating request looks like a bot. In practice crawlers do not trigger `woocommerce_add_to_cart` or `woocommerce_before_thankyou`, so the observed behavior is unchanged. This is called out only because the dispatch path is shared: any third-party code that programmatically fires those WooCommerce actions from a bot-classified request will now also skip CAPI for the event (Tag still fires).

### Cache strategy

`CrawlerDetector::is_crawler_request()` is intentionally NOT memoized. The underlying checks and the filter call are cheap, and re-evaluating per call keeps the `pinterest_for_woocommerce_is_crawler_request` filter responsive to runtime changes without requiring callers to manage static state (a real concern across PHPUnit test cases).

### Test coverage

* `tests/Unit/Utilities/CrawlerDetectorTest.php` -- empty / missing UA, real-world crawler UA matrix (Googlebot, Bingbot, curl, wget, spider, slurp, Common Crawl, Feedly, HeadlessChrome, PhantomJS), real-world human UA matrix (Chrome, Firefox, Safari iPhone, Edge), filter override in both directions, and a no-cache assertion that filter changes take effect immediately.
* `tests/Unit/TrackingTest.php` -- adds three tests: CAPI-skipped + Tag-fired on crawler UA, both fired on human UA, and filter-forced crawler classification.

### Detailed test instructions:

1. Enable plugin debug logging (Pinterest for WooCommerce settings, or `WP_DEBUG_LOG`).
2. From a terminal, hit a product page with a crawler User-Agent:
   ```
   curl -A "Googlebot/2.1 (+http://www.google.com/bot.html)" https://yourstore.example/some-product
   ```
3. Open WooCommerce -> Status -> Logs and inspect the latest `pinterest-for-woocommerce-*` log. Confirm there is NO `Sending Pinterest Conversions API event PageVisit` (or `ViewCategory` / `Search`) entry for that request.
4. Inspect the HTML body returned by the curl request above (still with the crawler UA) and confirm the inline Pinterest Tag JS IS present in the footer. What to look for:
   - The marker comment `<!-- Pinterest Pixel Base Code -->` followed by an inline `<script>` block that calls `pintrk('load', '<TAG_ID>', ...)` and `pintrk('page')`.
   - A `<noscript>` fallback containing `<img ... src="https://ct.pinterest.com/v3/?tid=<TAG_ID>&noscript=1" />`.
   - Both must appear inside the page (typically just before `</body>`). Quick grep:
     ```
     curl -A "Googlebot/2.1 (+http://www.google.com/bot.html)" https://yourstore.example/some-product | grep -c "Pinterest Pixel Base Code"
     ```
     Expected: `2` (one for the script block, one for the noscript block). This protects cached pages: if a CDN or page cache stores the bot-rendered HTML without `Vary: User-Agent` and later serves it to a real user, the Tag still fires in the browser.
5. Hit the same URL with a browser-like User-Agent (the default `curl/X.Y` UA is itself classified as a crawler by the supplementary regex, so override it explicitly):
   ```
   curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" https://yourstore.example/some-product
   ```
   Or simply load the URL in a real browser. Confirm both the CAPI event log entry AND the Tag JS appear.
6. Place a test order through the normal checkout flow and confirm `AddToCart` and `Checkout` events still fire as before (scope unchanged for real users).
7. Optional: add a filter to override detection for a custom UA (note: `strpos` is used instead of `str_contains` because the plugin supports PHP 7.4+):
   ```php
   add_filter( 'pinterest_for_woocommerce_is_crawler_request', function ( $is_crawler, $ua ) {
       return $is_crawler || false !== strpos( $ua, 'MyInternalScanner' );
   }, 10, 2 );
   ```

### Changelog entry

> Fix - Skip Pinterest CAPI events for crawler requests to prevent CAPI vs Tag divergence. 
