### PR TITLE
Fix variation feed description fallback to parent product

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -251,7 +251,7 @@ class ProductsXmlFeed {
 	 * @param WC_Product $product the product.
 	 * @param string     $property The name of the property.
 	 *
-	 * @return string
+	 * @return string|void
 	 */
 	private static function get_property_description( $product, $property ) {
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -271,6 +271,10 @@ class ProductsXmlFeed {
 				 * product's short description, then the parent's long description.
 				 * Avoid get_the_excerpt() here because WooCommerce stores the variation's
 				 * attribute summary in post_excerpt, which is not a useful description.
+				 *
+				 * wc_get_product() has its own per-request object cache, so sibling
+				 * variations of the same parent reuse the same load without
+				 * needing a second cache layer in this method.
 				 */
 				$parent = wc_get_product( $product->get_parent_id() );
 
@@ -289,7 +293,7 @@ class ProductsXmlFeed {
 			 * fallback chain (e.g. emit a translated description, prefer parent
 			 * long over short, or inject a per-variation string).
 			 *
-			 * @since x.y.z
+			 * @since x.x.x
 			 *
 			 * @param string          $description Resolved description after the variation→parent fallback.
 			 * @param WC_Product      $product     Variation product.

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -255,10 +255,32 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_description( $product, $property ) {
 
-		$description = $product->get_parent_id() ? $product->get_description() : $product->get_short_description();
+		if ( $product->get_parent_id() ) {
+			$description = $product->get_description();
 
-		if ( empty( $description ) ) {
-			$description = get_the_excerpt( $product->get_id() );
+			if ( empty( $description ) ) {
+				/*
+				 * For variations without their own description, fall back to the parent
+				 * product's short description, then the parent's long description.
+				 * Avoid get_the_excerpt() here because WooCommerce stores the variation's
+				 * attribute summary in post_excerpt, which is not a useful description.
+				 */
+				$parent = wc_get_product( $product->get_parent_id() );
+
+				if ( $parent ) {
+					$description = $parent->get_short_description();
+
+					if ( empty( $description ) ) {
+						$description = $parent->get_description();
+					}
+				}
+			}
+		} else {
+			$description = $product->get_short_description();
+
+			if ( empty( $description ) ) {
+				$description = get_the_excerpt( $product->get_id() );
+			}
 		}
 
 		if ( empty( $description ) ) {

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -255,8 +255,15 @@ class ProductsXmlFeed {
 	 */
 	private static function get_property_description( $product, $property ) {
 
+		// Guard against stale IDs or upstream lookup failures that pass a
+		// non-product value through to the feed pipeline.
+		if ( ! $product instanceof WC_Product ) {
+			return;
+		}
+
 		if ( $product->get_parent_id() ) {
 			$description = $product->get_description();
+			$parent      = null;
 
 			if ( empty( $description ) ) {
 				/*
@@ -275,6 +282,20 @@ class ProductsXmlFeed {
 					}
 				}
 			}
+
+			/**
+			 * Filters the description used for a variation product entry in the
+			 * Pinterest feed XML. Use this to override the variation→parent
+			 * fallback chain (e.g. emit a translated description, prefer parent
+			 * long over short, or inject a per-variation string).
+			 *
+			 * @since x.y.z
+			 *
+			 * @param string          $description Resolved description after the variation→parent fallback.
+			 * @param WC_Product      $product     Variation product.
+			 * @param WC_Product|null $parent      Parent product, or null when not loaded (variation had its own description, or the parent post was deleted).
+			 */
+			$description = apply_filters( 'pinterest_for_woocommerce_variation_description', $description, $product, $parent );
 		} else {
 			$description = $product->get_short_description();
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -228,7 +228,13 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		$child_id      = $variation_product->get_children()[0];
 		$child_product = wc_get_product( $child_id );
-		$xml           = $description_method( $child_product );
+
+		// Pin precondition: the variation must not have its own description,
+		// otherwise this test would pass for the wrong reason if WC ever
+		// auto-inherits the parent description on variations.
+		$this->assertSame( '', $child_product->get_description() );
+
+		$xml = $description_method( $child_product );
 
 		// Short description wins over long description.
 		$this->assertEquals( "<description><![CDATA[{$parent_short_desc}]]></description>", $xml );
@@ -285,6 +291,34 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		// No description should be emitted; the variation attribute summary
 		// must not leak into the feed.
+		$this->assertEquals( '', $xml );
+	}
+
+	/**
+	 * When the variation's parent product has been hard-deleted (orphaned
+	 * variation), the fallback chain must short-circuit safely instead of
+	 * throwing on the missing parent.
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionVariationHandlesMissingParent() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+		$parent_id         = $variation_product->get_id();
+
+		$child_id = $variation_product->get_children()[0];
+
+		// Hard-delete the parent so wc_get_product( $parent_id ) returns false.
+		wp_delete_post( $parent_id, true );
+
+		// Reload the variation post-deletion.
+		$child_product = wc_get_product( $child_id );
+
+		$xml = $description_method( $child_product );
+
+		// No description and no fatal: the fallback chain bailed out cleanly.
 		$this->assertEquals( '', $xml );
 	}
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -238,6 +238,11 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		// Short description wins over long description.
 		$this->assertEquals( "<description><![CDATA[{$parent_short_desc}]]></description>", $xml );
+
+		// Parent (variable) product itself must still render its own short description,
+		// so a regression in the non-variation branch is caught by this test too.
+		$xml_parent = $description_method( $variation_product );
+		$this->assertEquals( "<description><![CDATA[{$parent_short_desc}]]></description>", $xml_parent );
 	}
 
 	/**
@@ -323,6 +328,63 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		// No description and no fatal: the fallback chain bailed out cleanly.
 		$this->assertEquals( '', $xml );
+	}
+
+	/**
+	 * The pinterest_for_woocommerce_variation_description filter must run
+	 * after the variation→parent fallback chain resolves, receive the
+	 * resolved value plus the variation and parent objects, and be able to
+	 * override the emitted description.
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionVariationFilterCanOverrideFallback() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+
+		$variation_product->set_short_description( 'Parent short description.' );
+		$variation_product->save();
+
+		$child_id      = $variation_product->get_children()[0];
+		$child_product = wc_get_product( $child_id );
+
+		$captured = array();
+		$filter   = function ( $description, $variation, $parent_product ) use ( &$captured ) {
+			$captured = array(
+				'description' => $description,
+				'variation'   => $variation,
+				'parent'      => $parent_product,
+			);
+			return 'Filter override description.';
+		};
+		add_filter( 'pinterest_for_woocommerce_variation_description', $filter, 10, 3 );
+
+		$xml = $description_method( $child_product );
+
+		remove_filter( 'pinterest_for_woocommerce_variation_description', $filter, 10 );
+
+		$this->assertEquals( '<description><![CDATA[Filter override description.]]></description>', $xml );
+
+		// Filter receives the resolved fallback value, the variation, and the parent.
+		$this->assertEquals( 'Parent short description.', $captured['description'] );
+		$this->assertSame( $child_product->get_id(), $captured['variation']->get_id() );
+		$this->assertInstanceOf( \WC_Product::class, $captured['parent'] );
+		$this->assertSame( $variation_product->get_id(), $captured['parent']->get_id() );
+	}
+
+	/**
+	 * The function must short-circuit safely when handed a non-product
+	 * value (e.g. a stale ID that wc_get_product() resolved to false).
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionInvalidProductReturnsEmpty() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$this->assertEquals( '', $description_method( false ) );
+		$this->assertEquals( '', $description_method( null ) );
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -172,19 +172,32 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		// By passing manually created Variable Product the create_variation_product will add children to it.
 		$product           = new WC_Product_Variable();
 		$variation_product = WC_Helper_Product::create_variation_product( $product );
+
+		// Give the parent a short description so variations can fall back to it.
+		$parent_short_desc = 'Parent short description.';
+		$variation_product->set_short_description( $parent_short_desc );
+		$variation_product->save();
+
 		// create_variation_product creates multiple children, picking up the first one
 		$child_id      = $variation_product->get_children()[0];
 		$child_product = wc_get_product( $child_id );
 		$xml           = $description_method( $child_product );
 
 		/*
-		 * With no description set the code will use the excerpt.
-		 * The excerpt for the product variation is build from the attributes summary.
+		 * With no variation description set the feed should fall back to the parent's
+		 * short description, not the attribute summary stored in the variation excerpt.
 		 */
-		$attributes_summary = $child_product->get_attribute_summary( 'edit' );
-		$this->assertEquals( "<description><![CDATA[{$attributes_summary}]]></description>", $xml );
+		$this->assertEquals( "<description><![CDATA[{$parent_short_desc}]]></description>", $xml );
 
-		// Get the next variable product for tests with description set.
+		// When the parent has no short description, fall back to the parent's long description.
+		$parent_long_desc = 'Parent long description.';
+		$variation_product->set_short_description( '' );
+		$variation_product->set_description( $parent_long_desc );
+		$variation_product->save();
+		$xml = $description_method( $child_product );
+		$this->assertEquals( "<description><![CDATA[{$parent_long_desc}]]></description>", $xml );
+
+		// Get the next variable product child for tests with the variation description set directly.
 		$child_id      = $variation_product->get_children()[1];
 		$child_product = wc_get_product( $child_id );
 		$desc          = 'Test description.';

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -310,11 +310,14 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 
 		$child_id = $variation_product->get_children()[0];
 
-		// Hard-delete the parent so wc_get_product( $parent_id ) returns false.
-		wp_delete_post( $parent_id, true );
-
-		// Reload the variation post-deletion.
+		// Load the variation BEFORE hard-deleting the parent: WC cannot
+		// instantiate a variation whose parent post is missing, so the load
+		// has to happen first to capture a live variation object.
 		$child_product = wc_get_product( $child_id );
+
+		// Hard-delete the parent so wc_get_product( $parent_id ) returns false
+		// when the fallback chain calls it from inside get_property_description.
+		wp_delete_post( $parent_id, true );
 
 		$xml = $description_method( $child_product );
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -361,17 +361,20 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		};
 		add_filter( 'pinterest_for_woocommerce_variation_description', $filter, 10, 3 );
 
-		$xml = $description_method( $child_product );
+		try {
+			$xml = $description_method( $child_product );
 
-		remove_filter( 'pinterest_for_woocommerce_variation_description', $filter, 10 );
+			$this->assertEquals( '<description><![CDATA[Filter override description.]]></description>', $xml );
 
-		$this->assertEquals( '<description><![CDATA[Filter override description.]]></description>', $xml );
-
-		// Filter receives the resolved fallback value, the variation, and the parent.
-		$this->assertEquals( 'Parent short description.', $captured['description'] );
-		$this->assertSame( $child_product->get_id(), $captured['variation']->get_id() );
-		$this->assertInstanceOf( \WC_Product::class, $captured['parent'] );
-		$this->assertSame( $variation_product->get_id(), $captured['parent']->get_id() );
+			// Filter receives the resolved fallback value, the variation, and the parent.
+			$this->assertEquals( 'Parent short description.', $captured['description'] );
+			$this->assertSame( $child_product->get_id(), $captured['variation']->get_id() );
+			$this->assertInstanceOf( \WC_Product::class, $captured['parent'] );
+			$this->assertSame( $variation_product->get_id(), $captured['parent']->get_id() );
+		} finally {
+			// Always remove the filter so an assertion failure can't leak into subsequent tests.
+			remove_filter( 'pinterest_for_woocommerce_variation_description', $filter, 10 );
+		}
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -208,6 +208,87 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * When the parent has both short and long descriptions, variations without
+	 * their own description should fall back to the parent's short description
+	 * (not the long one) per the documented fallback order.
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionVariationPrefersParentShortOverLong() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+
+		$parent_short_desc = 'Parent short description.';
+		$parent_long_desc  = 'Parent long description.';
+		$variation_product->set_short_description( $parent_short_desc );
+		$variation_product->set_description( $parent_long_desc );
+		$variation_product->save();
+
+		$child_id      = $variation_product->get_children()[0];
+		$child_product = wc_get_product( $child_id );
+		$xml           = $description_method( $child_product );
+
+		// Short description wins over long description.
+		$this->assertEquals( "<description><![CDATA[{$parent_short_desc}]]></description>", $xml );
+	}
+
+	/**
+	 * When the variation has its own description, it should take precedence
+	 * over both the parent short and long descriptions.
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionVariationOwnDescriptionWinsOverParent() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+
+		$variation_product->set_short_description( 'Parent short description.' );
+		$variation_product->set_description( 'Parent long description.' );
+		$variation_product->save();
+
+		$child_id      = $variation_product->get_children()[0];
+		$child_product = wc_get_product( $child_id );
+
+		$own_desc = 'Variation specific description.';
+		$child_product->set_description( $own_desc );
+		$child_product->save();
+
+		$xml = $description_method( $child_product );
+		$this->assertEquals( "<description><![CDATA[{$own_desc}]]></description>", $xml );
+	}
+
+	/**
+	 * When neither the variation nor its parent provide a description, the
+	 * feed should emit no description element (rather than the variation's
+	 * auto-generated attribute summary stored in post_excerpt).
+	 *
+	 * @group feed
+	 */
+	public function testDescriptionVariationFallsBackToEmptyWhenParentEmpty() {
+		$description_method = $this->getProductsXmlFeedAttributeMethod( 'description' );
+
+		$product           = new WC_Product_Variable();
+		$variation_product = WC_Helper_Product::create_variation_product( $product );
+
+		// Explicitly clear both parent descriptions.
+		$variation_product->set_short_description( '' );
+		$variation_product->set_description( '' );
+		$variation_product->save();
+
+		$child_id      = $variation_product->get_children()[0];
+		$child_product = wc_get_product( $child_id );
+		$xml           = $description_method( $child_product );
+
+		// No description should be emitted; the variation attribute summary
+		// must not leak into the feed.
+		$this->assertEquals( '', $xml );
+	}
+
+	/**
 	 * @group feed
 	 */
 	public function testProductIdXML() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1181.

`ProductsXmlFeed::get_property_description()` previously fell back to `get_the_excerpt( $variation_id )` for variations without their own description. WooCommerce stores the auto-generated attribute summary (e.g. "Quantity: Set of Two Units") in the variation's `post_excerpt`, so that string ended up in the `<description>` element of the XML feed.

For variations, we now fall back to the parent product's short description, then its long description. Non-variation products keep the existing `get_the_excerpt()` fallback. Orphaned variations (parent hard-deleted) bail out cleanly with no description.

The function also short-circuits safely when handed a non-`WC_Product` value (e.g. a stale ID that `wc_get_product()` resolved to `false`), so a single bad row in a feed batch can no longer fatal the whole run.

### Behavior note: variation `post_excerpt` is no longer read

Stock WooCommerce stores the auto-generated attribute summary (e.g. "size: small") in a variation's `post_excerpt`, which is the bug this PR fixes. As a side effect, any custom value written into a variation's `post_excerpt` by an import plugin, migration script, or third-party flow is no longer surfaced in the feed. If you depend on a non-attribute-summary value living in `post_excerpt`, either move it into the variation's own description field or use the new filter below to inject it.

### New filter: `pinterest_for_woocommerce_variation_description`

```php
apply_filters(
    'pinterest_for_woocommerce_variation_description',
    string $description,        // Resolved description after the variation -> parent fallback.
    WC_Product $product,        // The variation product.
    ?WC_Product $parent         // Parent product, or null if not loaded
                                // (variation had its own description, or the parent post was deleted).
);
```

The filter runs after the variation -> parent fallback chain resolves and before tag stripping / clipping / CDATA wrapping. Use it to override the emitted description on a per-variation basis: emit a translated string, prefer parent long over short, restore a value previously stored in `post_excerpt`, etc. Returning an empty string causes the `<description>` element to be omitted entirely.


### Detailed test instructions:

1. Create a variable product with multiple variations.
2. On the parent product, set a Short description (e.g. "This is the parent short description.") and a long Description (e.g. "This is the parent long description.").
3. Leave each variation's Description field empty in the variation editor.
4. In WP admin, regenerate the Pinterest feed (Pinterest > Catalog, or trigger feed generation) and open the resulting XML file.
5. Locate a variation entry in the XML and inspect its `<description>` element.
   - Expected: contains the parent short description ("This is the parent short description.").
   - Without this fix: contains the variation attribute summary (e.g. "Quantity: Set of Two Units").
6. Clear the parent's short description, keep its long description, regenerate the feed, and verify the variation `<description>` now contains the parent long description.
7. Set a description directly on a variation, regenerate the feed, and verify the variation's own description is used.
8. Confirm simple (non-variation) products still use their short description, falling back to the post excerpt when empty.
9. Optional: add a `pinterest_for_woocommerce_variation_description` filter via a mu-plugin (e.g. return `'Filter override'`), regenerate the feed, and verify the variation `<description>` contains the overridden value.

### Changelog entry

> Fix - Variation feed description now falls back to the parent product's short/long description instead of the variation attribute summary.
