### PR TITLE
Align checkout value with line item totals

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -180,6 +180,7 @@ class Tracking {
 
 		$items          = array();
 		$total_quantity = 0;
+		$checkout_value = 0;
 		foreach ( $order->get_items() as $order_item ) {
 			if ( ! method_exists( $order_item, 'get_product' ) ) {
 				continue;
@@ -199,6 +200,7 @@ class Tracking {
 			);
 
 			$total_quantity += $order_item->get_quantity();
+			$checkout_value += (float) $order_item->get_total();
 		}
 
 		// Deterministic event id so Pinterest can deduplicate Tag/CAPI Checkout events when
@@ -206,7 +208,7 @@ class Tracking {
 		$data = new Checkout(
 			'checkout_' . $order->get_id(),
 			(string) $order->get_id(),
-			$order->get_total(),
+			wc_format_decimal( $checkout_value, wc_get_price_decimals() ),
 			$total_quantity,
 			$order->get_currency(),
 			$items

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -166,6 +166,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$items = $captured->get_items();
 		$this->assertCount( 1, $items );
+		$this->assertEqualsWithDelta( 0.0, (float) $captured->get_price(), 0.0001 );
 		$this->assertSame( 2, $items[0]->get_quantity() );
 		$this->assertEqualsWithDelta( 0.0, (float) $items[0]->get_price(), 0.0001 );
 	}
@@ -212,6 +213,7 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$items = $captured->get_items();
 		$this->assertCount( 1, $items );
+		$this->assertEqualsWithDelta( 20.0, (float) $captured->get_price(), 0.0001 );
 		$this->assertSame( 2, $items[0]->get_quantity() );
 		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
 	}
@@ -258,6 +260,61 @@ class TrackingTest extends \WP_UnitTestCase {
 
 		$items = $captured->get_items();
 		$this->assertCount( 1, $items );
+		$this->assertEqualsWithDelta( 20.0, (float) $captured->get_price(), 0.0001 );
+		$this->assertSame( 2, $items[0]->get_quantity() );
+		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
+	}
+
+	/**
+	 * Tests that checkout tracking excludes shipping from the order value.
+	 */
+	public function test_checkout_value_excludes_shipping() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 20,
+				'price'         => 20,
+			)
+		);
+
+		$order = wc_create_order();
+		$item  = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_subtotal( 40 );
+		$item->set_total( 20 );
+		$order->add_item( $item );
+
+		$shipping = new \WC_Order_Item_Shipping();
+		$shipping->set_method_title( 'Flat rate' );
+		$shipping->set_method_id( 'flat_rate' );
+		$shipping->set_total( 5 );
+		$order->add_item( $shipping );
+
+		$order->set_shipping_total( 5 );
+		$order->set_total( 25 );
+		$order->save();
+
+		$captured = null;
+		$tracker  = $this->createMock( Tracker::class );
+		$tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with(
+				Tracking::EVENT_CHECKOUT,
+				$this->callback(
+					function ( Checkout $checkout ) use ( &$captured ) {
+						$captured = $checkout;
+						return true;
+					}
+				)
+			);
+
+		$tracking = new Tracking( array( $tracker ) );
+		$tracking->handle_checkout( $order->get_id() );
+
+		$items = $captured->get_items();
+		$this->assertCount( 1, $items );
+		$this->assertEqualsWithDelta( 20.0, (float) $captured->get_price(), 0.0001 );
 		$this->assertSame( 2, $items[0]->get_quantity() );
 		$this->assertEqualsWithDelta( 10.0, (float) $items[0]->get_price(), 0.0001 );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PIN4WOO-84

Aligns checkout tracking value semantics with the per-item prices sent to Pinterest.

The checkout `value` is now calculated from summed WooCommerce order line totals, so it represents discounted merchandise revenue and excludes tax and shipping. This keeps both Pinterest Tag and Conversions API checkout payloads consistent with the existing per-item `item_price` / `product_price` values.

### Why this approach:

Summing `$order_item->get_total()` is the correct primitive for "post-discount merchandise revenue, pre-tax, pre-shipping". Per WooCommerce core (`WC_Order_Item_Product::get_total()` docblock):

> The price of the item times the quantity excluding taxes after coupon discounts.

This matches the same per-item source used for `item_price` (`$order->get_item_total( $order_item, false, true )`), so order-level `value` and item-level prices share one definition.

Alternatives considered:

- **`$order->get_total()` (previous behavior)** — includes tax, shipping, and fees. Caused the order-level `value` to exceed `Σ(item_price × quantity)`, which is exactly the inconsistency this PR fixes.
- **`$order->get_subtotal()`** — per core docblock: "all items excluding taxes, fees, shipping cost, **and coupon discounts**". This is pre-discount, so it would overstate revenue whenever a coupon is applied. Not suitable.
- **Iterating once and accumulating both `$items[]` and `$checkout_value` in the same loop** — chosen so the two values stay in sync if the loop logic changes later.

`wc_format_decimal( $checkout_value, wc_get_price_decimals() )` matches the precision used elsewhere in the plugin (e.g. `ProductsXmlFeed`) and keeps the emitted string format stable across locales.

### Detailed test instructions:

#### Setup

1. Install or check out this PR on a test WordPress site with WooCommerce active.
2. Enable Pinterest tracking in WP Admin at `/wp-admin/admin.php?page=wc-admin&path=%2Fpinterest%2Fsettings`.
3. A real Pinterest account is recommended, but not required for the browser Tag payload test; the site only needs `track_conversions` enabled and a non-empty `tracking_tag`.
4. If needed, set those test options with WP-CLI:
   - `wp eval 'Pinterest_For_Woocommerce::save_setting( "track_conversions", true ); Pinterest_For_Woocommerce::save_setting( "tracking_tag", "TESTTAG1185" );'`
5. Create a simple product with catalog price 20.
6. Create a 50% coupon, for example `HALF1185`, so the paid line total becomes 20 for quantity 2 while each unit price is 10.
7. In WooCommerce > Settings > Tax, enable taxes and add a standard rate (e.g. 20%) so the order picks up tax.
8. In WooCommerce > Settings > Shipping, add a flat-rate shipping method with a non-zero cost (e.g. 5).
9. Add quantity 2 of the product to cart, apply the coupon, choose the shipping method, and place an order. The final order total should be roughly: merchandise 20 + tax 4 + shipping 5 = 29.
10. Enable Conversions API and debug logging in Pinterest settings.

#### Browser Tag validation

1. On the WooCommerce thank-you page, inspect page source or DevTools Elements and search for `pintrk( 'track', 'Checkout'`.
2. Alternatively, in DevTools Network, enable Preserve log before checkout and filter for `ct.pinterest.com` or `event=Checkout`; open the `https://ct.pinterest.com/v3/?event=Checkout...` request and inspect the encoded event data.
3. Expected browser Tag result:
   - `value` is `20.00` (merchandise only, excludes the 4 tax and 5 shipping).
   - `line_items[].product_price` is `10`.
   - `line_items[].product_quantity` is `2`.
   - `value` equals `Σ(line_items[].product_price × product_quantity)`.
4. Before this fix, `value` would be `29` (full `$order->get_total()` including tax and shipping), which contradicted the per-line-item prices.

#### Conversions API validation (Optional)

If using a connected Pinterest account:

1. Go to WooCommerce > Status > Logs.
2. Check the WooCommerce log source `pinterest-for-woocommerce-conversions`.
3. Expected CAPI checkout payload:
   - `custom_data.value` is `"20.00"`.
   - `custom_data.contents[].item_price` is `"10"`.
   - `custom_data.contents[].quantity` is `2`.
   - `custom_data.num_items` is `2`.

#### Regression checks

- Full-discount order (100% coupon, line total 0): `value` should be `0.00`, not the shipping amount.
- No-tax, no-shipping order: `value` should match `$order->get_total()` exactly — no behavior change for merchandise-only orders.

### Additional details:

Pinterest's Conversions API guidance describes purchase `value` as the pre-tax, pre-shipping total for purchased items. This PR brings the order-level `value` in line with that semantic, which was already true for `contents[].item_price` after PIN4WOO-76 (#1175).

### Changelog entry

> Fix - Align Pinterest checkout value with discounted merchandise line totals.
