### PR TITLE
Scope feed failure logging by feed

### DIFF
--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -410,11 +410,24 @@ class FeedStatusService {
 	 * @return string
 	 */
 	private static function get_feed_url_for_feed_id( string $feed_id ): string {
-		foreach ( Feeds::get_feeds() as $feed ) {
+		$feeds = Feeds::get_feeds();
+
+		foreach ( $feeds as $feed ) {
 			if ( ( $feed['id'] ?? '' ) === $feed_id ) {
 				return $feed['location'] ?? '';
 			}
 		}
+
+		// Distinguish "no registered feeds returned" (e.g. feeds API unavailable) from
+		// "feeds returned but none match" (e.g. a stale or remote-only feed ID) so the
+		// empty feed_url in the failure log can be diagnosed.
+		Logger::log(
+			empty( $feeds )
+				? "Could not resolve feed_url: no registered feeds returned for feed_id={$feed_id}"
+				: "Could not resolve feed_url: no registered feed matched feed_id={$feed_id}",
+			'warning',
+			'feed-ingestion-failure'
+		);
 
 		return '';
 	}

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -374,6 +374,9 @@ class FeedStatusService {
 		}
 
 		$feed_url = self::get_feed_url_for_feed_id( $feed_id );
+		if ( '' === $feed_url ) {
+			$feed_url = '(unresolved)';
+		}
 
 		Logger::log(
 			sprintf(
@@ -431,7 +434,11 @@ class FeedStatusService {
 	}
 
 	/**
-	 * Get the local feed URL for a Pinterest feed ID.
+	 * Get the registered feed URL (location) for a Pinterest feed ID.
+	 *
+	 * The feed ID is the remote Pinterest feed ID, so it is resolved against the
+	 * registered remote feeds. Returns an empty string when no remote feed matches
+	 * (e.g. the feeds API is unavailable).
 	 *
 	 * @param string $feed_id Pinterest feed ID.
 	 * @return string
@@ -440,14 +447,6 @@ class FeedStatusService {
 		foreach ( Feeds::get_feeds() as $feed ) {
 			if ( ( $feed['id'] ?? '' ) === $feed_id ) {
 				return $feed['location'] ?? '';
-			}
-		}
-
-		$configs = LocalFeedConfigs::get_instance()->get_configurations();
-
-		foreach ( $configs as $config ) {
-			if ( ( $config['feed_id'] ?? '' ) === $feed_id ) {
-				return $config['feed_url'] ?? '';
 			}
 		}
 

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -377,9 +377,6 @@ class FeedStatusService {
 		}
 
 		$feed_url = self::get_feed_url_for_feed_id( $feed_id );
-		if ( '' === $feed_url ) {
-			$feed_url = '(unresolved)';
-		}
 
 		Logger::log(
 			sprintf(

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -364,7 +364,10 @@ class FeedStatusService {
 			return;
 		}
 
-		$last_logged_processing_result_ids = self::get_last_logged_processing_result_ids( $feed_id );
+		$last_logged_processing_result_ids = Pinterest_For_WooCommerce()::get_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY );
+		if ( ! is_array( $last_logged_processing_result_ids ) ) {
+			$last_logged_processing_result_ids = array();
+		}
 		if ( ( $last_logged_processing_result_ids[ $feed_id ] ?? '' ) === $processing_result_id ) {
 			return;
 		}
@@ -397,40 +400,6 @@ class FeedStatusService {
 			self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY,
 			$last_logged_processing_result_ids
 		);
-	}
-
-	/**
-	 * Get failed processing result log deduplication state by feed ID.
-	 *
-	 * @param string $feed_id Pinterest feed ID.
-	 * @return array
-	 */
-	private static function get_last_logged_processing_result_ids( string $feed_id ): array {
-		$last_logged_processing_result_ids = Pinterest_For_WooCommerce()::get_data(
-			self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY
-		);
-
-		if ( is_array( $last_logged_processing_result_ids ) ) {
-			return $last_logged_processing_result_ids;
-		}
-
-		if (
-			is_string( $last_logged_processing_result_ids ) &&
-			false !== strpos( $last_logged_processing_result_ids, ':' )
-		) {
-			$parts = explode( ':', $last_logged_processing_result_ids, 2 );
-			return array(
-				$parts[0] => $parts[1],
-			);
-		}
-
-		if ( is_string( $last_logged_processing_result_ids ) && '' !== $last_logged_processing_result_ids ) {
-			return array(
-				$feed_id => $last_logged_processing_result_ids,
-			);
-		}
-
-		return array();
 	}
 
 	/**

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -364,9 +364,8 @@ class FeedStatusService {
 			return;
 		}
 
-		$processing_result_log_key        = self::get_processing_result_log_key( $feed_id, $processing_result_id );
-		$last_logged_processing_result_id = Pinterest_For_WooCommerce()::get_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY );
-		if ( $processing_result_log_key === $last_logged_processing_result_id ) {
+		$last_logged_processing_result_ids = self::get_last_logged_processing_result_ids( $feed_id );
+		if ( ( $last_logged_processing_result_ids[ $feed_id ] ?? '' ) === $processing_result_id ) {
 			return;
 		}
 
@@ -390,18 +389,45 @@ class FeedStatusService {
 			'feed-ingestion-failure'
 		);
 
-		Pinterest_For_WooCommerce()::save_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY, $processing_result_log_key );
+		$last_logged_processing_result_ids[ $feed_id ] = $processing_result_id;
+		Pinterest_For_WooCommerce()::save_data(
+			self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY,
+			$last_logged_processing_result_ids
+		);
 	}
 
 	/**
-	 * Get the failed processing result log deduplication key.
+	 * Get failed processing result log deduplication state by feed ID.
 	 *
-	 * @param string $feed_id              Pinterest feed ID.
-	 * @param string $processing_result_id Pinterest processing result ID.
-	 * @return string
+	 * @param string $feed_id Pinterest feed ID.
+	 * @return array
 	 */
-	private static function get_processing_result_log_key( string $feed_id, string $processing_result_id ): string {
-		return "{$feed_id}:{$processing_result_id}";
+	private static function get_last_logged_processing_result_ids( string $feed_id ): array {
+		$last_logged_processing_result_ids = Pinterest_For_WooCommerce()::get_data(
+			self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY
+		);
+
+		if ( is_array( $last_logged_processing_result_ids ) ) {
+			return $last_logged_processing_result_ids;
+		}
+
+		if (
+			is_string( $last_logged_processing_result_ids ) &&
+			false !== strpos( $last_logged_processing_result_ids, ':' )
+		) {
+			$parts = explode( ':', $last_logged_processing_result_ids, 2 );
+			return array(
+				$parts[0] => $parts[1],
+			);
+		}
+
+		if ( is_string( $last_logged_processing_result_ids ) && '' !== $last_logged_processing_result_ids ) {
+			return array(
+				$feed_id => $last_logged_processing_result_ids,
+			);
+		}
+
+		return array();
 	}
 
 	/**
@@ -411,6 +437,12 @@ class FeedStatusService {
 	 * @return string
 	 */
 	private static function get_feed_url_for_feed_id( string $feed_id ): string {
+		foreach ( Feeds::get_feeds() as $feed ) {
+			if ( ( $feed['id'] ?? '' ) === $feed_id ) {
+				return $feed['location'] ?? '';
+			}
+		}
+
 		$configs = LocalFeedConfigs::get_instance()->get_configurations();
 
 		foreach ( $configs as $config ) {

--- a/src/FeedStatusService.php
+++ b/src/FeedStatusService.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class FeedStatusService {
 
 	/**
-	 * Plugin data key used to avoid logging the same failed processing result repeatedly.
+	 * Plugin data key used to avoid logging the same failed processing result for the same feed repeatedly.
 	 *
 	 * @var string
 	 */
@@ -346,7 +346,7 @@ class FeedStatusService {
 	}
 
 	/**
-	 * Log the full failed feed processing result context once per processing result ID.
+	 * Log the full failed feed processing result context once per feed and processing result ID.
 	 *
 	 * @param string $feed_id            Pinterest feed ID.
 	 * @param array  $processing_results Recent processing results array.
@@ -364,8 +364,9 @@ class FeedStatusService {
 			return;
 		}
 
+		$processing_result_log_key        = self::get_processing_result_log_key( $feed_id, $processing_result_id );
 		$last_logged_processing_result_id = Pinterest_For_WooCommerce()::get_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY );
-		if ( $processing_result_id === $last_logged_processing_result_id ) {
+		if ( $processing_result_log_key === $last_logged_processing_result_id ) {
 			return;
 		}
 
@@ -373,12 +374,7 @@ class FeedStatusService {
 			return;
 		}
 
-		$feed_url = '';
-		$configs  = LocalFeedConfigs::get_instance()->get_configurations();
-		if ( ! empty( $configs ) ) {
-			$config   = reset( $configs );
-			$feed_url = $config['feed_url'] ?? '';
-		}
+		$feed_url = self::get_feed_url_for_feed_id( $feed_id );
 
 		Logger::log(
 			sprintf(
@@ -394,7 +390,36 @@ class FeedStatusService {
 			'feed-ingestion-failure'
 		);
 
-		Pinterest_For_WooCommerce()::save_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY, $processing_result_id );
+		Pinterest_For_WooCommerce()::save_data( self::LAST_LOGGED_PROCESSING_RESULT_ID_KEY, $processing_result_log_key );
+	}
+
+	/**
+	 * Get the failed processing result log deduplication key.
+	 *
+	 * @param string $feed_id              Pinterest feed ID.
+	 * @param string $processing_result_id Pinterest processing result ID.
+	 * @return string
+	 */
+	private static function get_processing_result_log_key( string $feed_id, string $processing_result_id ): string {
+		return "{$feed_id}:{$processing_result_id}";
+	}
+
+	/**
+	 * Get the local feed URL for a Pinterest feed ID.
+	 *
+	 * @param string $feed_id Pinterest feed ID.
+	 * @return string
+	 */
+	private static function get_feed_url_for_feed_id( string $feed_id ): string {
+		$configs = LocalFeedConfigs::get_instance()->get_configurations();
+
+		foreach ( $configs as $config ) {
+			if ( ( $config['feed_id'] ?? '' ) === $feed_id ) {
+				return $config['feed_url'] ?? '';
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -50,7 +50,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		Pinterest_For_Woocommerce::save_data(
 			'local_feed_ids',
 			array(
-				Pinterest_For_Woocommerce::get_base_country() => 'local-feed',
+				Pinterest_For_Woocommerce::get_base_country() => 'feed-123',
 			)
 		);
 		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
@@ -155,7 +155,25 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $this->mock_logger->entries );
 		$this->assertEquals(
-			'processing-result-1',
+			'feed-123:processing-result-1',
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
+	}
+
+	/**
+	 * Tests that the same processing result ID can be logged once per feed ID.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_scopes_deduplication_by_feed_id() {
+		$processing_results = $this->get_failed_processing_results();
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
+		FeedStatusService::log_failed_processing_result( 'feed-456', $processing_results );
+
+		$this->assertCount( 2, $this->mock_logger->entries );
+		$this->assertEquals(
+			'feed-456:processing-result-1',
 			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
 		);
 	}
@@ -204,9 +222,36 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $this->mock_logger->entries );
 		$this->assertEquals(
-			'processing-result-2',
+			'feed-123:processing-result-2',
 			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
 		);
+	}
+
+	/**
+	 * Tests that the logged feed URL belongs to the failed feed ID.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_uses_failed_feed_url() {
+		$base_country  = Pinterest_For_Woocommerce::get_base_country();
+		$other_country = 'US' === $base_country ? 'CA' : 'US';
+		Pinterest_For_Woocommerce::save_data(
+			'local_feed_ids',
+			array(
+				$base_country  => 'feed-123',
+				$other_country => 'feed-456',
+			)
+		);
+
+		FeedStatusService::log_failed_processing_result( 'feed-456', $this->get_failed_processing_results() );
+
+		$configs                = LocalFeedConfigs::get_instance()->get_configurations();
+		$failing_feed_url       = $configs[ $other_country ]['feed_url'];
+		$non_failing_feed_url   = $configs[ $base_country ]['feed_url'];
+		$logged_failure_message = $this->mock_logger->entries[0]['message'];
+
+		$this->assertStringContainsString( "feed_url: {$failing_feed_url}", $logged_failure_message );
+		$this->assertStringNotContainsString( "feed_url: {$non_failing_feed_url}", $logged_failure_message );
 	}
 
 	/**

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -333,15 +333,15 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an unresolved feed URL is logged with a sentinel value.
+	 * Tests that an unknown feed ID logs an empty feed URL rather than another feed's URL.
 	 *
 	 * @return void
 	 */
-	public function test_log_failed_processing_result_logs_unresolved_feed_url_when_no_feed_matches() {
+	public function test_log_failed_processing_result_logs_empty_feed_url_when_no_feed_matches() {
 		FeedStatusService::log_failed_processing_result( 'unknown-feed', $this->get_failed_processing_results() );
 
 		$this->assertStringContainsString(
-			'feed_url: (unresolved)',
+			"feed_url: \n",
 			$this->mock_logger->entries[0]['message']
 		);
 	}

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -160,6 +160,12 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_does_not_log_same_processing_result_id_twice() {
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-123.xml',
+			),
+		);
 		$processing_results = $this->get_failed_processing_results();
 
 		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
@@ -180,6 +186,16 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_scopes_deduplication_by_feed_id() {
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-123.xml',
+			),
+			array(
+				'id'       => 'feed-456',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-456.xml',
+			),
+		);
 		$processing_results = $this->get_failed_processing_results();
 
 		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
@@ -201,8 +217,18 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_keeps_deduplication_per_feed_after_other_feed_logs() {
-		$feed_a = $this->get_failed_processing_results();
-		$feed_b = $this->get_failed_processing_results();
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-123.xml',
+			),
+			array(
+				'id'       => 'feed-456',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-456.xml',
+			),
+		);
+		$feed_a             = $this->get_failed_processing_results();
+		$feed_b             = $this->get_failed_processing_results();
 
 		$feed_b['id'] = 'processing-result-2';
 
@@ -253,8 +279,14 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_logs_new_processing_result_id_after_previous() {
-		$first  = $this->get_failed_processing_results();
-		$second = $this->get_failed_processing_results();
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-123.xml',
+			),
+		);
+		$first              = $this->get_failed_processing_results();
+		$second             = $this->get_failed_processing_results();
 
 		$second['id']         = 'processing-result-2';
 		$second['created_at'] = '2026-05-12T07:00:00';
@@ -340,9 +372,10 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	public function test_log_failed_processing_result_logs_empty_feed_url_when_no_feed_matches() {
 		FeedStatusService::log_failed_processing_result( 'unknown-feed', $this->get_failed_processing_results() );
 
-		$this->assertStringContainsString(
-			"feed_url: \n",
-			$this->mock_logger->entries[0]['message']
+		$this->assert_log_entry_contains( "feed_url: \n" );
+		$this->assert_log_entry_contains(
+			'Could not resolve feed_url: no registered feeds returned for feed_id=unknown-feed',
+			'warning'
 		);
 	}
 
@@ -361,9 +394,10 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		FeedStatusService::log_failed_processing_result( 'unknown-feed', $this->get_failed_processing_results() );
 
-		$this->assertStringContainsString(
-			"feed_url: \n",
-			$this->mock_logger->entries[0]['message']
+		$this->assert_log_entry_contains( "feed_url: \n" );
+		$this->assert_log_entry_contains(
+			'Could not resolve feed_url: no registered feed matched feed_id=unknown-feed',
+			'warning'
 		);
 	}
 

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -35,6 +35,13 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	private $should_fail_update_feed_request = false;
 
 	/**
+	 * Mock remote feed records returned by the Pinterest feeds API.
+	 *
+	 * @var array
+	 */
+	private $remote_feeds = array();
+
+	/**
 	 * Set up the WC logger mock and local feed configuration.
 	 *
 	 * @return void
@@ -83,7 +90,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		};
 
 		Logger::$logger = $this->mock_logger;
-		add_filter( 'pre_http_request', array( $this, 'intercept_update_feed_request' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'intercept_api_request' ), 10, 3 );
 	}
 
 	/**
@@ -96,7 +103,7 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 		Pinterest_For_Woocommerce::remove_data( 'last_logged_processing_result_id' );
 		Pinterest_For_Woocommerce::remove_data( 'last_retried_processing_result_id' );
 		LocalFeedConfigs::deregister();
-		remove_filter( 'pre_http_request', array( $this, 'intercept_update_feed_request' ), 10 );
+		remove_filter( 'pre_http_request', array( $this, 'intercept_api_request' ), 10 );
 
 		parent::tearDown();
 	}
@@ -155,7 +162,9 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $this->mock_logger->entries );
 		$this->assertEquals(
-			'feed-123:processing-result-1',
+			array(
+				'feed-123' => 'processing-result-1',
+			),
 			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
 		);
 	}
@@ -173,7 +182,35 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $this->mock_logger->entries );
 		$this->assertEquals(
-			'feed-456:processing-result-1',
+			array(
+				'feed-123' => 'processing-result-1',
+				'feed-456' => 'processing-result-1',
+			),
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
+	}
+
+	/**
+	 * Tests that another feed logging later does not allow an old result to be re-logged.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_keeps_deduplication_per_feed_after_other_feed_logs() {
+		$feed_a = $this->get_failed_processing_results();
+		$feed_b = $this->get_failed_processing_results();
+
+		$feed_b['id'] = 'processing-result-2';
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $feed_a );
+		FeedStatusService::log_failed_processing_result( 'feed-456', $feed_b );
+		FeedStatusService::log_failed_processing_result( 'feed-123', $feed_a );
+
+		$this->assertCount( 2, $this->mock_logger->entries );
+		$this->assertEquals(
+			array(
+				'feed-123' => 'processing-result-1',
+				'feed-456' => 'processing-result-2',
+			),
 			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
 		);
 	}
@@ -222,7 +259,9 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $this->mock_logger->entries );
 		$this->assertEquals(
-			'feed-123:processing-result-2',
+			array(
+				'feed-123' => 'processing-result-2',
+			),
 			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
 		);
 	}
@@ -252,6 +291,40 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( "feed_url: {$failing_feed_url}", $logged_failure_message );
 		$this->assertStringNotContainsString( "feed_url: {$non_failing_feed_url}", $logged_failure_message );
+	}
+
+	/**
+	 * Tests that remote feed IDs resolve feed URLs from their registered remote location.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_uses_registered_remote_feed_location() {
+		$base_country             = Pinterest_For_Woocommerce::get_base_country();
+		$remote_feed_location     = 'https://example.test/pinterest-for-woocommerce-local-feed-456.xml';
+		$this->remote_feeds       = array(
+			array(
+				'id'       => 'remote-feed-456',
+				'location' => $remote_feed_location,
+			),
+		);
+		$processing_results       = $this->get_failed_processing_results();
+		$processing_results['id'] = 'processing-result-remote-feed';
+
+		Pinterest_For_Woocommerce::save_data(
+			'local_feed_ids',
+			array(
+				$base_country => 'local-feed-123',
+			)
+		);
+
+		FeedStatusService::log_failed_processing_result( 'remote-feed-456', $processing_results );
+
+		$configs                = LocalFeedConfigs::get_instance()->get_configurations();
+		$local_feed_url         = $configs[ $base_country ]['feed_url'];
+		$logged_failure_message = $this->mock_logger->entries[0]['message'];
+
+		$this->assertStringContainsString( "feed_url: {$remote_feed_location}", $logged_failure_message );
+		$this->assertStringNotContainsString( "feed_url: {$local_feed_url}", $logged_failure_message );
 	}
 
 	/**
@@ -335,14 +408,29 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Intercept feed update requests.
+	 * Intercept Pinterest API requests.
 	 *
 	 * @param mixed  $response    Preemptive response.
 	 * @param array  $parsed_args Request arguments.
 	 * @param string $url         Request URL.
 	 * @return mixed
 	 */
-	public function intercept_update_feed_request( $response, $parsed_args, $url ) {
+	public function intercept_api_request( $response, $parsed_args, $url ) {
+		if ( 'https://api.pinterest.com/v5/catalogs/feeds?ad_account_id=114141241212' === $url ) {
+			return array(
+				'headers'  => array(
+					'content-type' => 'application/json',
+				),
+				'body'     => wp_json_encode( array( 'items' => $this->remote_feeds ) ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => '',
+			);
+		}
+
 		if ( 'https://api.pinterest.com/v5/catalogs/feeds/feed-123?ad_account_id=114141241212' !== $url ) {
 			return $response;
 		}

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -347,58 +347,6 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a legacy single-value dedup state is recognized and migrated to the per-feed format.
-	 *
-	 * @return void
-	 */
-	public function test_log_failed_processing_result_migrates_legacy_single_value_state() {
-		Pinterest_For_Woocommerce::save_data( 'last_logged_processing_result_id', 'processing-result-1' );
-
-		FeedStatusService::log_failed_processing_result( 'feed-123', $this->get_failed_processing_results() );
-
-		$this->assertCount( 0, $this->mock_logger->entries );
-
-		$new_result       = $this->get_failed_processing_results();
-		$new_result['id'] = 'processing-result-2';
-
-		FeedStatusService::log_failed_processing_result( 'feed-123', $new_result );
-
-		$this->assertCount( 1, $this->mock_logger->entries );
-		$this->assertEquals(
-			array(
-				'feed-123' => 'processing-result-2',
-			),
-			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
-		);
-	}
-
-	/**
-	 * Tests that a legacy feed_id:processing_result_id dedup state is recognized and migrated.
-	 *
-	 * @return void
-	 */
-	public function test_log_failed_processing_result_migrates_legacy_scoped_string_state() {
-		Pinterest_For_Woocommerce::save_data( 'last_logged_processing_result_id', 'feed-123:processing-result-1' );
-
-		FeedStatusService::log_failed_processing_result( 'feed-123', $this->get_failed_processing_results() );
-
-		$this->assertCount( 0, $this->mock_logger->entries );
-
-		$new_result       = $this->get_failed_processing_results();
-		$new_result['id'] = 'processing-result-2';
-
-		FeedStatusService::log_failed_processing_result( 'feed-123', $new_result );
-
-		$this->assertCount( 1, $this->mock_logger->entries );
-		$this->assertEquals(
-			array(
-				'feed-123' => 'processing-result-2',
-			),
-			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
-		);
-	}
-
-	/**
 	 * Tests that a FETCH_ERROR failed processing result triggers one feed update retry.
 	 *
 	 * @return void

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -114,23 +114,28 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_logs_expected_payload_without_debug_logging_enabled() {
+		$feed_url           = 'https://example.test/pinterest-for-woocommerce-feed-123.xml';
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => $feed_url,
+			),
+		);
 		$processing_results = $this->get_failed_processing_results();
 
 		FeedStatusService::log_failed_processing_result( 'feed-123', $processing_results );
 
 		$this->assertCount( 1, $this->mock_logger->entries );
 
-		$entry             = $this->mock_logger->entries[0];
-		$configs           = LocalFeedConfigs::get_instance()->get_configurations();
-		$expected_feed_url = reset( $configs )['feed_url'];
-		$expected_message  = implode(
+		$entry            = $this->mock_logger->entries[0];
+		$expected_message = implode(
 			"\n",
 			array(
 				'Feed ingestion FAILED',
 				'feed_id: feed-123',
 				'processing_result_id: processing-result-1',
 				'created_at: 2026-05-12T06:00:00',
-				"feed_url: {$expected_feed_url}",
+				"feed_url: {$feed_url}",
 				'validation_details: {"errors":{"FETCH_ERROR":1},"warnings":{"IMAGE_LINK_WARNING":2}}',
 				'product_counts: {"original":10,"ingested":0}',
 			)
@@ -272,21 +277,21 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_log_failed_processing_result_uses_failed_feed_url() {
-		$base_country  = Pinterest_For_Woocommerce::get_base_country();
-		$other_country = 'US' === $base_country ? 'CA' : 'US';
-		Pinterest_For_Woocommerce::save_data(
-			'local_feed_ids',
+		$failing_feed_url     = 'https://example.test/pinterest-for-woocommerce-feed-456.xml';
+		$non_failing_feed_url = 'https://example.test/pinterest-for-woocommerce-feed-123.xml';
+		$this->remote_feeds   = array(
 			array(
-				$base_country  => 'feed-123',
-				$other_country => 'feed-456',
-			)
+				'id'       => 'feed-123',
+				'location' => $non_failing_feed_url,
+			),
+			array(
+				'id'       => 'feed-456',
+				'location' => $failing_feed_url,
+			),
 		);
 
 		FeedStatusService::log_failed_processing_result( 'feed-456', $this->get_failed_processing_results() );
 
-		$configs                = LocalFeedConfigs::get_instance()->get_configurations();
-		$failing_feed_url       = $configs[ $other_country ]['feed_url'];
-		$non_failing_feed_url   = $configs[ $base_country ]['feed_url'];
 		$logged_failure_message = $this->mock_logger->entries[0]['message'];
 
 		$this->assertStringContainsString( "feed_url: {$failing_feed_url}", $logged_failure_message );
@@ -325,6 +330,72 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( "feed_url: {$remote_feed_location}", $logged_failure_message );
 		$this->assertStringNotContainsString( "feed_url: {$local_feed_url}", $logged_failure_message );
+	}
+
+	/**
+	 * Tests that an unresolved feed URL is logged with a sentinel value.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_logs_unresolved_feed_url_when_no_feed_matches() {
+		FeedStatusService::log_failed_processing_result( 'unknown-feed', $this->get_failed_processing_results() );
+
+		$this->assertStringContainsString(
+			'feed_url: (unresolved)',
+			$this->mock_logger->entries[0]['message']
+		);
+	}
+
+	/**
+	 * Tests that a legacy single-value dedup state is recognized and migrated to the per-feed format.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_migrates_legacy_single_value_state() {
+		Pinterest_For_Woocommerce::save_data( 'last_logged_processing_result_id', 'processing-result-1' );
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $this->get_failed_processing_results() );
+
+		$this->assertCount( 0, $this->mock_logger->entries );
+
+		$new_result       = $this->get_failed_processing_results();
+		$new_result['id'] = 'processing-result-2';
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $new_result );
+
+		$this->assertCount( 1, $this->mock_logger->entries );
+		$this->assertEquals(
+			array(
+				'feed-123' => 'processing-result-2',
+			),
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
+	}
+
+	/**
+	 * Tests that a legacy feed_id:processing_result_id dedup state is recognized and migrated.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_migrates_legacy_scoped_string_state() {
+		Pinterest_For_Woocommerce::save_data( 'last_logged_processing_result_id', 'feed-123:processing-result-1' );
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $this->get_failed_processing_results() );
+
+		$this->assertCount( 0, $this->mock_logger->entries );
+
+		$new_result       = $this->get_failed_processing_results();
+		$new_result['id'] = 'processing-result-2';
+
+		FeedStatusService::log_failed_processing_result( 'feed-123', $new_result );
+
+		$this->assertCount( 1, $this->mock_logger->entries );
+		$this->assertEquals(
+			array(
+				'feed-123' => 'processing-result-2',
+			),
+			Pinterest_For_Woocommerce::get_data( 'last_logged_processing_result_id' )
+		);
 	}
 
 	/**

--- a/tests/Unit/FeedStatusServiceTest.php
+++ b/tests/Unit/FeedStatusServiceTest.php
@@ -347,6 +347,27 @@ class FeedStatusServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an empty feed URL is logged when remote feeds are returned but none match the feed ID.
+	 *
+	 * @return void
+	 */
+	public function test_log_failed_processing_result_logs_empty_feed_url_when_remote_feeds_do_not_match() {
+		$this->remote_feeds = array(
+			array(
+				'id'       => 'feed-123',
+				'location' => 'https://example.test/pinterest-for-woocommerce-feed-123.xml',
+			),
+		);
+
+		FeedStatusService::log_failed_processing_result( 'unknown-feed', $this->get_failed_processing_results() );
+
+		$this->assertStringContainsString(
+			"feed_url: \n",
+			$this->mock_logger->entries[0]['message']
+		);
+	}
+
+	/**
 	 * Tests that a FETCH_ERROR failed processing result triggers one feed update retry.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Linear: PIN4WOO-86.

This builds on #1179 (unreleased) and prepares failed feed ingestion logging for future multi-feed support by:

- persisting the last logged processing result per Pinterest `feed_id` (an array keyed by feed ID) instead of a single global last value, so a failure logged for one feed no longer suppresses logging for another feed
- resolving the logged `feed_url` from the matching registered remote feed `location` (via `Feeds::get_feeds()`) instead of always using the first local feed config; logs an empty `feed_url` when no registered feed matches
- adding regression coverage for cross-feed dedup scoping and for remote feed IDs that differ from local feed config IDs

Because #1179 has not shipped, no migration is needed for the previously stored single-value dedup state.

### Detailed test instructions:

These steps exercise the real scheduled-action code path, following the same approach as #1179. The site must be connected to Pinterest (so a feed file exists in `wp-content/uploads/` and `feed_registered` plugin data is set). Only the `processing_results` HTTP call is mocked — every other Pinterest API call in `register_feed()`, including the feeds list used to resolve `feed_url`, hits the real API.

1. Confirm preconditions — expect a non-empty Pinterest feed ID:
   ```bash
   wp eval 'echo \Pinterest_For_Woocommerce::get_data( "feed_registered" ), "\n";'
   ```
2. Drop the following mu-plugin into `wp-content/mu-plugins/pin4woo-86-test.php` (the leading `<?php` is required). It returns a stable `FAILED` processing result (a fixed `id`, so the dedup check can be verified across re-runs):
   <details><summary>pin4woo-86-test.php</summary>

   ```php
   <?php
   add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
       if ( false === strpos( $url, '/processing_results' ) ) {
           return $preempt;
       }
       return array(
           'headers'  => array( 'content-type' => 'application/json' ),
           'response' => array( 'code' => 200, 'message' => 'OK' ),
           'cookies'  => array(),
           'body'     => wp_json_encode( array(
               'items' => array(
                   array(
                       'id'                 => 'pin4woo-86-failed-1',
                       'status'             => 'FAILED',
                       'created_at'         => gmdate( 'c' ),
                       'validation_details' => array(
                           'errors'   => array( 'FETCH_ERROR' => 1 ),
                           'warnings' => array(),
                       ),
                       'product_counts'     => array( 'original' => 10, 'ingested' => 0 ),
                   ),
               ),
           ) ),
       );
   }, 10, 3 );
   ```

   </details>

3. Flush cached API responses, reset dedup state, and trigger the scheduled handler. The `processing_results` response is cached as a transient for 60s, so without flushing the handler returns the previously cached (live) result and the mock above never fires:
   ```bash
   wp transient delete --all
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
4. Go to `/wp-admin/admin.php?page=wc-status&tab=logs` and open the `pinterest-for-woocommerce-feed-ingestion-failure` log. Confirm the `Feed ingestion FAILED` block shows:
   - `feed_id:` matching the value from step 1
   - `processing_result_id: pin4woo-86-failed-1` (if you instead see a long numeric ID and a past `created_at`, the cache was not flushed and you are looking at live data — re-run step 3)
   - `feed_url:` matching the **registered remote feed's `location`** (the actual Pinterest catalog feed URL for this feed), not just the first local feed config
5. Confirm the dedup state is now an array keyed by feed ID (not a bare string):
   ```bash
   wp eval 'print_r( \Pinterest_For_Woocommerce::get_data( "last_logged_processing_result_id" ) );'
   ```
   Expect e.g. `Array ( [<feed_id>] => pin4woo-86-failed-1 )`.

<img width="1459" height="195" alt="Screenshot 2026-05-25 at 2 45 37 PM" src="https://github.com/user-attachments/assets/5f3ebb13-abe6-410c-9ff0-c6faeca690c6" />

6. Re-run the trigger to verify dedup — the same feed + same processing result must not be logged again. Do **not** flush again here, so the mocked `pin4woo-86-failed-1` result is served from its own 60s cache:
   ```bash
   wp eval 'do_action( "pinterest-for-woocommerce-handle-feed-registration" );'
   ```
   No additional `Feed ingestion FAILED` block is appended.
7. (Optional) Cross-check that the logged `feed_url` came from the registered feed `location`:
   ```bash
   wp eval '$f = \Automattic\WooCommerce\Pinterest\Feeds::get_feeds(); print_r( wp_list_pluck( $f, "location", "id" ) );'
   ```
8. Cleanup:
   ```bash
   rm wp-content/mu-plugins/pin4woo-86-test.php
   wp eval '\Pinterest_For_Woocommerce::remove_data( "last_logged_processing_result_id" );'
   ```

> **Note on multi-feed scoping:** cross-feed deduplication (a failure on feed A not suppressing feed B, and vice-versa) is hard to exercise manually on a single-feed install. It is covered by the unit tests in `tests/Unit/FeedStatusServiceTest.php` (`..._scopes_deduplication_by_feed_id` and `..._keeps_deduplication_per_feed_after_other_feed_logs`).

### Changelog entry

> Fix - Scope failed feed ingestion logging deduplication and feed URL resolution by feed.
