### PR TITLE
Add dev workflow scripts and pre-push checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,15 +144,22 @@ npm run lint:css:fix
 
 #### PHPUnit Tests
 
+The test environment requires a running MySQL instance. A Docker container is used locally:
+
 ```bash
-# Install WordPress test environment
-./bin/install-wp-tests.sh wordpress_test root root localhost
+# Start the database (only needed after Docker restart)
+docker start wp-tests-db
+
+# First-time setup (also run if /tmp is cleared — e.g. after a Mac restart)
+./bin/setup-test-env.sh
 
 # Run tests
 vendor/bin/phpunit
 # OR
 composer test-unit
 ```
+
+See `bin/setup-test-env.sh` for the full environment bootstrap steps.
 
 #### JavaScript Tests
 ```bash
@@ -188,7 +195,7 @@ This project follows **WooCommerce-Core** coding standards, which extend WordPre
 
 **PHPCS Configuration:** See `phpcs.xml` for complete ruleset.
 
-**CRITICAL:** ALWAYS run `vendor/bin/phpcs` before committing code. CI will fail if code doesn't pass phpcs checks.
+**CRITICAL:** ALWAYS run `composer exec phpcs-changed -- -s --git --git-base origin/develop` before committing code. This checks only the lines you changed against the develop baseline — the same check CI runs. CI will fail if code doesn't pass.
 
 ### JavaScript Standards
 
@@ -334,6 +341,29 @@ Refactor admin settings validation
 ```
 
 ### Pull Requests
+
+**MANDATORY workflow before opening or updating any PR:**
+
+1. **Rebase onto develop** — eliminates merge conflicts before they reach GitHub:
+   ```bash
+   git fetch origin
+   git rebase origin/develop
+   ```
+   Resolve any conflicts, then continue. A PR must never have merge conflicts when pushed.
+
+2. **Run all local checks** — use the pre-push script:
+   ```bash
+   ./bin/pre-push-check.sh
+   ```
+   This runs phpcs-changed and the full PHPUnit suite. Both must be green before pushing. Fix any failures first — do not push with failing tests or linting errors.
+
+3. **Build and test on the local test site** — build the installable zip and hand it to the user for manual verification:
+   ```bash
+   npm run build:zip
+   ```
+   Wait for the user to confirm the feature works correctly on their test site before pushing or creating the PR.
+
+4. **Push only when all three steps above pass.**
 
 When creating PRs:
 - Target the `develop` branch

--- a/bin/pre-push-check.sh
+++ b/bin/pre-push-check.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# pre-push-check.sh
+#
+# Run all local quality gates in the correct order before pushing or opening a PR.
+# Both checks must pass — fix any failures before pushing.
+#
+# Usage:
+#   ./bin/pre-push-check.sh
+#
+# Requirements:
+#   - Docker container wp-tests-db must be running  (docker start wp-tests-db)
+#   - WordPress test environment installed           (./bin/setup-test-env.sh)
+
+set -e
+
+PASS="\033[0;32m✔\033[0m"
+FAIL="\033[0;31m✘\033[0m"
+BASE_BRANCH=${1:-origin/develop}
+
+echo ""
+echo "=== Pre-push checks (base: $BASE_BRANCH) ==="
+echo ""
+
+# ── 1. PHP coding standards ────────────────────────────────────────────────────
+echo "→ Running phpcs-changed against $BASE_BRANCH..."
+CHANGED=$(git diff "$(git merge-base HEAD "$BASE_BRANCH")" --relative --name-only -- '*.php')
+
+if [ -z "$CHANGED" ]; then
+	echo -e "  $PASS No PHP files changed — skipping phpcs."
+else
+	if composer exec phpcs-changed -- -s --git --git-base "$BASE_BRANCH" $CHANGED; then
+		echo -e "  $PASS phpcs-changed passed."
+	else
+		echo -e "  $FAIL phpcs-changed failed. Fix the violations above before pushing."
+		exit 1
+	fi
+fi
+
+echo ""
+
+# ── 2. PHPUnit tests ───────────────────────────────────────────────────────────
+echo "→ Running PHPUnit..."
+if vendor/bin/phpunit; then
+	echo -e "  $PASS All tests passed."
+else
+	echo -e "  $FAIL Tests failed. Fix the failures above before pushing."
+	exit 1
+fi
+
+echo ""
+echo -e "=== $PASS All checks passed. Safe to push. ==="
+echo ""

--- a/bin/setup-test-env.sh
+++ b/bin/setup-test-env.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# setup-test-env.sh
+#
+# Bootstrap the local PHPUnit test environment from scratch.
+# Safe to re-run — skips steps that are already complete.
+#
+# What it does:
+#   1. Ensures the Docker MySQL container is running
+#   2. Creates the test database inside the container
+#   3. Runs install-wp-tests.sh (downloads WordPress + WooCommerce + test scaffold)
+#   4. Stubs any missing entries in WooCommerce's jetpack autoload filemap
+#      (newer jetpack packages remove files like actions.php that older filemaps
+#      still reference; the stubs are empty <?php files that satisfy the loader)
+#
+# After running this once, a Mac restart only requires:
+#   docker start wp-tests-db
+
+set -e
+
+PASS="\033[0;32m✔\033[0m"
+FAIL="\033[0;31m✘\033[0m"
+INFO="\033[0;34m→\033[0m"
+
+TMPDIR="${TMPDIR:-/tmp}"
+TMPDIR="${TMPDIR%/}"   # strip trailing slash
+
+WP_DIR="$TMPDIR/wordpress"
+WC_PLUGIN_DIR="$WP_DIR/wp-content/plugins/woocommerce"
+WP_TESTS_DIR="$TMPDIR/wordpress-tests-lib"
+
+DB_NAME="wordpress_test"
+DB_USER="root"
+DB_PASS="root"
+DB_HOST="127.0.0.1"
+CONTAINER="wp-tests-db"
+
+# ── 1. Docker MySQL container ──────────────────────────────────────────────────
+echo -e "$INFO Checking Docker MySQL container ($CONTAINER)..."
+if docker inspect "$CONTAINER" &>/dev/null; then
+	if [ "$(docker inspect -f '{{.State.Running}}' $CONTAINER)" != "true" ]; then
+		docker start "$CONTAINER"
+		echo -e "   $PASS Started existing container."
+	else
+		echo -e "   $PASS Already running."
+	fi
+else
+	echo "   Creating new MySQL 8 container..."
+	docker run -d --name "$CONTAINER" \
+		-e MYSQL_ROOT_PASSWORD="$DB_PASS" \
+		-e MYSQL_DATABASE="$DB_NAME" \
+		-p 3306:3306 \
+		mysql:8
+
+	echo -n "   Waiting for MySQL to be ready"
+	until docker exec "$CONTAINER" mysqladmin ping -u"$DB_USER" -p"$DB_PASS" --silent 2>/dev/null; do
+		sleep 2; echo -n "."
+	done
+	echo -e " $PASS Ready."
+fi
+
+# ── 2. WordPress + WooCommerce + test scaffold ─────────────────────────────────
+echo -e "$INFO Checking WordPress test environment..."
+if [ -f "$WC_PLUGIN_DIR/woocommerce.php" ] && [ -f "$WP_TESTS_DIR/includes/functions.php" ]; then
+	echo -e "   $PASS Already installed."
+else
+	echo "   Creating test database..."
+	docker exec "$CONTAINER" mysql -u"$DB_USER" -p"$DB_PASS" \
+		-e "DROP DATABASE IF EXISTS $DB_NAME; CREATE DATABASE $DB_NAME;" 2>/dev/null
+
+	echo "   Running install-wp-tests.sh (downloads WP + WC + test scaffold)..."
+	echo "   This takes a few minutes on first run..."
+	bash "$(dirname "$0")/install-wp-tests.sh" \
+		"$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" latest true 2>&1 | grep -v "^+" || true
+	echo -e "   $PASS Done."
+fi
+
+# ── 3. Stub missing jetpack autoload filemap entries ──────────────────────────
+echo -e "$INFO Checking WooCommerce jetpack autoload filemap..."
+WC_VENDOR="$WC_PLUGIN_DIR/vendor"
+if [ -f "$WC_VENDOR/composer/jetpack_autoload_filemap.php" ]; then
+	STUBBED=$(php -r "
+\$map = include '$WC_VENDOR/composer/jetpack_autoload_filemap.php';
+\$n = 0;
+foreach (\$map as \$entry) {
+    \$path = \$entry['path'];
+    if (!file_exists(\$path)) {
+        \$dir = dirname(\$path);
+        if (!is_dir(\$dir)) mkdir(\$dir, 0755, true);
+        file_put_contents(\$path, '<?php');
+        \$n++;
+    }
+}
+echo \$n;
+" 2>/dev/null)
+	if [ "$STUBBED" -gt 0 ]; then
+		echo -e "   $PASS Stubbed $STUBBED missing filemap entries."
+	else
+		echo -e "   $PASS All filemap entries present."
+	fi
+else
+	echo -e "   $PASS No jetpack filemap found (skipping)."
+fi
+
+echo ""
+echo -e "$PASS Test environment ready. Run: vendor/bin/phpunit"
+echo ""


### PR DESCRIPTION
## Summary

- Adds `bin/setup-test-env.sh`: bootstraps the local PHPUnit test environment (Docker MySQL, WordPress + WooCommerce scaffold, jetpack filemap stubs). Safe to re-run; skips steps already complete.
- Adds `bin/pre-push-check.sh`: runs `phpcs-changed` + the full PHPUnit suite. Must be green before pushing.
- Updates `AGENTS.md` with a mandatory pre-push workflow: rebase onto develop → run pre-push-check.sh → build zip + manual site testing → only then push/open PR.

These are development-tooling changes only — no production code is touched.

## Test plan

- [ ] Run `./bin/setup-test-env.sh` on a fresh Mac (or after wiping `/tmp/wordpress`)
- [ ] Verify `vendor/bin/phpunit` reports all tests passing afterwards
- [ ] Run `./bin/pre-push-check.sh` on a branch with clean PHP and tests — confirm it exits 0
- [ ] Run `./bin/pre-push-check.sh` on a branch with a phpcs violation — confirm it exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)