### PR TITLE
Release/1.4.27 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,21 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.4.27 - 2026-06-01 =
+* Add - WooCommerce product_brand to Pinterest feed as `g:brand`.
+* Fix - Align Pinterest checkout value with discounted merchandise line totals.
+* Fix - Correct checkout tracking item prices and preserve customer IP and user agent when sending hashed email.
+* Fix - Feed generator robustness at scale.
+* Fix - Feed location URL matching.
+* Fix - Log feed ingestion failure context to WooCommerce logs.
+* Fix - Restore class_exists guard on record_event.
+* Fix - Retry Pinterest feed ingestion sooner when Pinterest reports a FETCH_ERROR.
+* Fix - Scope failed feed ingestion logging deduplication and feed URL resolution by feed.
+* Fix - Skip Pinterest CAPI events for crawler requests to prevent CAPI vs Tag divergence.
+* Fix - Use deterministic Checkout tracking event IDs so refreshed thank-you pages can deduplicate purchases.
+* Fix - Variation feed description now falls back to the parent product's short/long description instead of the variation attribute summary.
+* Tweak - WC 10.8 compatibility.
+* Update - Treat additional Pinterest redeem error codes as terminal.
+
 = 1.4.26 - 2026-04-20 =
 * Add - Settings link to plugin action links.
 * Fix - Exclude orphaned variations from Pinterest feed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.26
+ * Version:           1.4.27
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 7.0
- * WC tested up to: 10.7
+ * WC tested up to: 10.8
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.26' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.27' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,22 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.27 - 2026-06-01 =
+* Add - WooCommerce product_brand to Pinterest feed as `g:brand`.
+* Fix - Align Pinterest checkout value with discounted merchandise line totals.
+* Fix - Correct checkout tracking item prices and preserve customer IP and user agent when sending hashed email.
+* Fix - Feed generator robustness at scale.
+* Fix - Feed location URL matching.
+* Fix - Log feed ingestion failure context to WooCommerce logs.
+* Fix - Restore class_exists guard on record_event.
+* Fix - Retry Pinterest feed ingestion sooner when Pinterest reports a FETCH_ERROR.
+* Fix - Scope failed feed ingestion logging deduplication and feed URL resolution by feed.
+* Fix - Skip Pinterest CAPI events for crawler requests to prevent CAPI vs Tag divergence.
+* Fix - Use deterministic Checkout tracking event IDs so refreshed thank-you pages can deduplicate purchases.
+* Fix - Variation feed description now falls back to the parent product's short/long description instead of the variation attribute summary.
+* Tweak - WC 10.8 compatibility.
+* Update - Treat additional Pinterest redeem error codes as terminal.
+
 = 1.4.26 - 2026-04-20 =
 * Add - Settings link to plugin action links.
 * Fix - Exclude orphaned variations from Pinterest feed.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.4.26
+Stable tag: 1.4.27
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -301,7 +301,7 @@ class ProductsXmlFeed {
 			 * fallback chain (e.g. emit a translated description, prefer parent
 			 * long over short, or inject a per-variation string).
 			 *
-			 * @since x.x.x
+			 * @since 1.4.27
 			 *
 			 * @param string          $description Resolved description after the variation→parent fallback.
 			 * @param WC_Product      $product     Variation product.

--- a/src/Utilities/CrawlerDetector.php
+++ b/src/Utilities/CrawlerDetector.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * browser-side Pinterest Tag, which would otherwise inflate CAPI counts
  * relative to Tag counts.
  *
- * @since x.x.x
+ * @since 1.4.27
  */
 class CrawlerDetector {
 
@@ -55,7 +55,7 @@ class CrawlerDetector {
 	 * runtime changes (added/removed hooks, test fixtures) without requiring
 	 * callers to remember to reset static state.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.27
 	 *
 	 * @return bool
 	 */
@@ -82,7 +82,7 @@ class CrawlerDetector {
 		 * `Vary: User-Agent` do not serve bot-rendered HTML (missing Tag JS)
 		 * to real users.
 		 *
-		 * @since x.x.x
+		 * @since 1.4.27
 		 *
 		 * @param bool   $is_crawler Whether the request looks like a crawler.
 		 * @param string $user_agent The raw (unslashed, unsanitized) User-Agent header value.


### PR DESCRIPTION
This PR merges the changes from [release v1.4.27](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.27) back into `develop`.