### PR TITLE
Evaluate tracking consent on wp_loaded instead of init

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -278,7 +278,11 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 
 			// ActionScheduler is activated on init 1 so lets make sure we are updating after that.
 			add_action( 'init', array( $this, 'maybe_update_plugin' ), 5 );
-			add_action( 'init', array( self::class, 'init_tracking' ) );
+			// Consent-management plugins (and WooCommerce core's consent integration) register their
+			// consent type on `init` at priority 20. Evaluating consent on `init` would read the WP
+			// Consent API permissive default before they run, so tracking is initialised on `wp_loaded`,
+			// after every `init` callback has registered.
+			add_action( 'wp_loaded', array( self::class, 'init_tracking' ) );
 			add_action( 'init', array( Pinterest\Heartbeat::class, 'schedule_events' ) );
 			add_action( 'init', array( Pinterest\ProductSync::class, 'maybe_init' ) );
 			add_action( 'init', array( Pinterest\TrackerSnapshot::class, 'maybe_init' ) );

--- a/tests/Unit/PinterestForWoocommerceTest.php
+++ b/tests/Unit/PinterestForWoocommerceTest.php
@@ -304,6 +304,30 @@ class PinterestForWoocommerceTest extends WP_UnitTestCase {
 		$this->assertFalse( as_has_scheduled_action( Heartbeat::DAILY, array(), 'pinterest-for-woocommerce' ) );
 	}
 
+	/**
+	 * Tracking must evaluate user consent only after consent-management plugins
+	 * have registered their consent type. They do so on `init` (priority 20) - the
+	 * same hook WooCommerce core uses for its consent integration. Reading consent
+	 * on `init` (priority 10) returns the WP Consent API permissive default before
+	 * the consent manager can say "deny", so tracking is hooked on `wp_loaded`
+	 * (after every `init` callback has run) instead of on `init`.
+	 *
+	 * @return void
+	 */
+	public function test_init_tracking_is_hooked_after_init_for_consent() {
+		Pinterest_For_Woocommerce();
+
+		$this->assertFalse(
+			has_action( 'init', array( Pinterest_For_Woocommerce::class, 'init_tracking' ) ),
+			'init_tracking must not run on init, where consent is read before consent managers register.'
+		);
+		$this->assertSame(
+			10,
+			has_action( 'wp_loaded', array( Pinterest_For_Woocommerce::class, 'init_tracking' ) ),
+			'init_tracking should run on wp_loaded, after all init callbacks have registered consent.'
+		);
+	}
+
 	public function test_init_tracking_inits_if_at_least_one_tracker() {
 		Pinterest_For_Woocommerce::save_setting( 'track_conversions', true );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses **[PIN4WOO-59](https://linear.app/a8c/issue/PIN4WOO-59/using-consentapi-too-soon)** (Linear; no public GitHub issue).

Pinterest initialises conversion tracking in `init_tracking()`, which was hooked on `init` at the default priority (10). That method reads the visitor's marketing consent immediately, via the `woocommerce_pinterest_disable_tracking_user_consent` filter (`wp_has_consent( 'marketing' )`).

Consent-management plugins — and WooCommerce core's own consent integration — register their consent **type** on `init` at priority **20**. The WP Consent API returns its permissive default (`true` / allow) until a consent type is registered. So at `init:10` Pinterest read "allow" before the consent manager had declared its `optin` type at `init:20`, and conversion tracking stayed enabled for visitors who had not granted marketing consent.

This PR moves `init_tracking()` from `init` to `wp_loaded`, which runs after every `init` callback. By then consent managers have registered, so Pinterest reads the settled consent value. The tracker hooks it registers (`wp_footer`, `woocommerce_add_to_cart`, `woocommerce_before_thankyou`, `shutdown`) all fire later in the request, so timing is unaffected.

### Detailed test instructions:

Environment: WordPress + WooCommerce + this plugin, with the [WP Consent API](https://wordpress.org/plugins/wp-consent-api/) plugin active and a consent manager (or a small mu-plugin stub) that registers an `optin` consent type on `init` priority 20, with **no** marketing consent granted.

1. Confirm where tracking is initialised:
   ```
   wp eval '$cb=["Pinterest_For_Woocommerce","init_tracking"]; var_dump(has_action("init",$cb), has_action("wp_loaded",$cb));'
   ```
   - Before this PR: `init => 10`, `wp_loaded => false`.
   - After this PR: `init => false`, `wp_loaded => 10`.
2. As a non-consenting visitor, load a front-end page and observe the value Pinterest resolves for `woocommerce_pinterest_disable_tracking_user_consent`:
   - Before: read during `init:10`, `consent_type` not yet set → `wp_has_consent('marketing')` = allow → `disable_tracking = false` (tracking stays on).
   - After: read during `wp_loaded`, `consent_type = 'optin'` already set → `wp_has_consent('marketing')` = deny → `disable_tracking = true` (tracking disabled).
3. Run the unit test: `test_init_tracking_is_hooked_after_init_for_consent` (asserts the hook is on `wp_loaded`, not `init`). The existing `init_tracking` tests continue to pass.

Hook-timing trace captured on a live site (consent manager registers `optin` at `init:20`):

```
Before fix:
init:10  Pinterest reads consent -> disable_tracking = false  (tracking STAYS ON)
init:20  consent manager registers 'optin'  -> wp_has_consent('marketing') becomes DENY

After fix:
init:20  consent manager registers 'optin'  -> wp_has_consent('marketing') = DENY
wp_loaded  Pinterest reads consent -> disable_tracking = true  (tracking OFF)
```

### Additional details:

The tracker hooks registered by the resulting `Tracking` object run on `wp_footer` and WooCommerce cart/checkout events, all of which fire after `wp_loaded`, so deferring initialisation has no functional impact beyond reading consent at the correct time. Admin/cron requests are unaffected (`init_tracking()` already guards `is_admin()` / `wp_doing_cron()`).

### Changelog entry

> Fix - Read marketing consent on `wp_loaded` instead of `init` so consent-management plugins that register their consent type on `init` are respected before conversion tracking initialises.