### PR TITLE
Improve feed generator robustness at scale

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -68,6 +68,9 @@ $system = array(
 );
 
 // 2. Product counts — same queries the feed uses.
+$variable_like = $wpdb->esc_like( 'variable' ) . '%';
+
+// All published product posts (simple + variable parents) — matches WC admin dashboard count.
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 $simple_count = (int) $wpdb->get_var(
 	"SELECT COUNT(*)
@@ -75,7 +78,38 @@ $simple_count = (int) $wpdb->get_var(
 	 WHERE post_type = 'product' AND post_status = 'publish'"
 );
 
-$variable_like = $wpdb->esc_like( 'variable' ) . '%';
+// Simple products only (not variable type).
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$simple_products = (int) $wpdb->get_var(
+	$wpdb->prepare(
+		"SELECT COUNT(*)
+		 FROM {$wpdb->posts}
+		 WHERE post_type = 'product' AND post_status = 'publish'
+		   AND ID NOT IN (
+		       SELECT object_id
+		       FROM {$wpdb->term_relationships} tr
+		       JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		       JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+		       WHERE tt.taxonomy = 'product_type' AND t.slug LIKE %s
+		   )",
+		$variable_like
+	)
+);
+
+// Variable product parents only.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$variable_parents = (int) $wpdb->get_var(
+	$wpdb->prepare(
+		"SELECT COUNT(*)
+		 FROM {$wpdb->posts} p
+		 JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+		 JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		 JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+		 WHERE p.post_type = 'product' AND p.post_status = 'publish'
+		   AND tt.taxonomy = 'product_type' AND t.slug LIKE %s",
+		$variable_like
+	)
+);
 
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 $feed_total = (int) $wpdb->get_var(
@@ -193,7 +227,7 @@ if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}actionscheduler_actions'"
 $integrity_ok = null;
 if ( $feed_total > 0 && isset( $feed_status['product_count'] ) ) {
 	$written      = (int) $feed_status['product_count'];
-	$integrity_ok = $written <= (int) ceil( $feed_total * 1.5 );
+	$integrity_ok = $written <= (int) ceil( $feed_total * 1.1 );
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -317,13 +351,17 @@ if ( $simple_count !== $feed_total ) {
 
 echo '<table>';
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo p4wc_debug_row( 'WC dashboard count', number_format( $simple_count ), 'SELECT COUNT(*) WHERE post_type=product AND post_status=publish' );
+echo p4wc_debug_row( 'WC dashboard count', number_format( $simple_count ), 'all published products (simple + variable parents)' );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo p4wc_debug_row( 'Feed query total rows', number_format( $feed_total ), 'same WHERE clause the feed iterates (products + variations)' );
+echo p4wc_debug_row( '  -> simple products', number_format( $simple_products ), 'non-variable product type' );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo p4wc_debug_row( '  -> published product posts', number_format( $product_posts ) );
+echo p4wc_debug_row( '  -> variable products (parents)', number_format( $variable_parents ), 'variable product type; do NOT appear in feed directly' );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo p4wc_debug_row( '  -> published variation posts', number_format( $variation_count ) );
+echo p4wc_debug_row( 'Feed query total rows', number_format( $feed_total ), 'rows the feed iterates: simple products + variations (not variable parents)' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( '  -> simple products in feed', number_format( $product_posts - $variable_parents ), 'simple products counted by feed query' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( '  -> variation posts in feed', number_format( $variation_count ), 'published variations with published variable parent' );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 echo p4wc_debug_row( 'Batches needed @ 100/batch', number_format( $batches_needed ) );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -387,7 +425,7 @@ if ( empty( $feed_status ) ) {
 		echo '<div class="err">'
 			. '&#10008; Content integrity: ' . esc_html( number_format( $written ) ) . ' entries written vs ' . esc_html( number_format( $feed_total ) ) . ' published products '
 			. '(' . esc_html( (string) round( $written / max( $feed_total, 1 ), 2 ) ) . 'x). '
-			. 'Ratio exceeds 1.5 &mdash; cursor was likely reset mid-cycle causing duplicates.'
+			. 'Ratio exceeds 1.1 &mdash; cursor was likely reset mid-cycle causing duplicates.'
 			. '</div>';
 	} elseif ( true === $integrity_ok ) {
 		echo '<div class="ok">'
@@ -488,7 +526,7 @@ if ( $simple_count !== $feed_total ) {
 	$issues[] = 'Product count mismatch: WC admin shows ' . number_format( $simple_count ) . ' but feed iterates ' . number_format( $feed_total ) . ' rows. Extra posts with post_type=product may exist in the database.';
 }
 if ( false === $integrity_ok ) {
-	$issues[] = 'Feed content integrity breach: written product count (' . number_format( (int) ( $feed_status['product_count'] ?? 0 ) ) . ') is more than 1.5x the published product count. Cursor was reset mid-cycle &mdash; duplicates were written to the feed.';
+	$issues[] = 'Feed content integrity breach: written product count (' . number_format( (int) ( $feed_status['product_count'] ?? 0 ) ) . ') is more than 1.1x the published product count. Cursor was reset mid-cycle &mdash; duplicates were written to the feed.';
 }
 if ( null === $cursor_dedicated ) {
 	$issues[] = 'Dedicated cursor option not found. The cursor race-condition fix is not yet active on this site. Apply the workaround snippet or update the plugin.';

--- a/debug.php
+++ b/debug.php
@@ -190,9 +190,10 @@ if ( class_exists( '\Automattic\WooCommerce\Pinterest\ProductFeedStatus' ) ) {
 }
 
 // 5. Action Scheduler — all Pinterest actions, last 48 h.
-$as_actions = array();
+$as_actions    = array();
+$as_table_like = $wpdb->esc_like( $wpdb->prefix . 'actionscheduler_actions' );
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}actionscheduler_actions'" ) ) {
+if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $as_table_like ) ) ) {
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 	$as_actions = $wpdb->get_results(
 		$wpdb->prepare(
@@ -505,7 +506,7 @@ if ( empty( $as_actions ) ) {
 			esc_html( (string) $batch_num ),
 			esc_html( $row->scheduled_date_gmt ),
 			esc_html( $last_attempt ),
-			esc_html( mb_substr( $row->log_message ?? '', 0, 140 ) )
+			esc_html( substr( $row->log_message ?? '', 0, 140 ) )
 		);
 	}
 	echo '</table>';

--- a/debug.php
+++ b/debug.php
@@ -1,0 +1,511 @@
+<?php
+/**
+ * Pinterest for WooCommerce — Feed Debug Tool
+ *
+ * URL: https://{site}/wp-content/plugins/pinterest-for-woocommerce/debug.php
+ *
+ * Shows feed generation state, product counts, Action Scheduler history, and
+ * system info in one page. Everything needed to diagnose feed generation
+ * problems without asking the merchant to run SQL queries or install extra
+ * plugins.
+ *
+ * Access: requires an active WordPress administrator session. Visitors who are
+ * not logged in are redirected to wp-login.php; non-administrators receive a
+ * 403. The page is not linked from any admin menu — it is intentionally
+ * accessed only by support staff who know the URL.
+ *
+ * @package Automattic\WooCommerce\Pinterest
+ */
+
+// ── Bootstrap WordPress ───────────────────────────────────────────────────────
+$p4wc_wp_load = '';
+$p4wc_dir     = __DIR__;
+for ( $p4wc_i = 0; $p4wc_i < 8; $p4wc_i++ ) {
+	if ( file_exists( $p4wc_dir . '/wp-load.php' ) ) {
+		$p4wc_wp_load = $p4wc_dir . '/wp-load.php';
+		break;
+	}
+	$p4wc_dir = dirname( $p4wc_dir );
+}
+if ( ! $p4wc_wp_load ) {
+	http_response_code( 500 );
+	exit( 'Could not locate wp-load.php. Place this file inside a WordPress installation.' );
+}
+require_once $p4wc_wp_load;
+unset( $p4wc_wp_load, $p4wc_dir, $p4wc_i );
+
+// ── Authentication ────────────────────────────────────────────────────────────
+if ( ! is_user_logged_in() ) {
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+	wp_safe_redirect( wp_login_url( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ) ) );
+	exit;
+}
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die(
+		'<p>You do not have permission to access this page.</p>',
+		'Access Denied',
+		array( 'response' => 403 )
+	);
+}
+
+// ── Guard: plugin must be active ──────────────────────────────────────────────
+if ( ! defined( 'PINTEREST_FOR_WOOCOMMERCE_VERSION' ) ) {
+	wp_die( '<p>Pinterest for WooCommerce is not active on this site.</p>', 'Plugin Not Active' );
+}
+
+// ── Data collection ───────────────────────────────────────────────────────────
+global $wpdb;
+
+// 1. System info.
+$system = array(
+	'Pinterest for WooCommerce' => PINTEREST_FOR_WOOCOMMERCE_VERSION,
+	'WooCommerce'               => defined( 'WC_VERSION' ) ? WC_VERSION : 'n/a',
+	'WordPress'                 => get_bloginfo( 'version' ),
+	'PHP'                       => PHP_VERSION,
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	'MySQL'                     => $wpdb->get_var( 'SELECT VERSION()' ),
+	'Site URL'                  => get_site_url(),
+);
+
+// 2. Product counts — same queries the feed uses.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$simple_count = (int) $wpdb->get_var(
+	"SELECT COUNT(*)
+	 FROM {$wpdb->posts}
+	 WHERE post_type = 'product' AND post_status = 'publish'"
+);
+
+$variable_like = $wpdb->esc_like( 'variable' ) . '%';
+
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$feed_total = (int) $wpdb->get_var(
+	$wpdb->prepare(
+		"SELECT COUNT( post.ID )
+		 FROM {$wpdb->posts} AS post
+		 LEFT JOIN {$wpdb->posts} AS parent ON post.post_parent = parent.ID
+		 WHERE
+		     (
+		         ( post.post_type = 'product_variation'
+		             AND parent.post_status = 'publish'
+		             AND EXISTS (
+		                 SELECT 1
+		                 FROM {$wpdb->term_relationships} tr
+		                 INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		                 INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+		                 WHERE tr.object_id = parent.ID
+		                   AND tt.taxonomy = 'product_type'
+		                   AND t.slug LIKE %s
+		             )
+		         )
+		     OR ( post.post_type = 'product' AND post.post_status = 'publish' )
+		     )",
+		$variable_like
+	)
+);
+
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$variation_count = (int) $wpdb->get_var(
+	$wpdb->prepare(
+		"SELECT COUNT( post.ID )
+		 FROM {$wpdb->posts} AS post
+		 INNER JOIN {$wpdb->posts} AS parent ON post.post_parent = parent.ID
+		 WHERE post.post_type = 'product_variation'
+		   AND parent.post_status = 'publish'
+		   AND EXISTS (
+		       SELECT 1
+		       FROM {$wpdb->term_relationships} tr
+		       INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+		       INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+		       WHERE tr.object_id = parent.ID
+		         AND tt.taxonomy = 'product_type'
+		         AND t.slug LIKE %s
+		   )",
+		$variable_like
+	)
+);
+
+$product_posts  = $feed_total - $variation_count;
+$batches_needed = $feed_total > 0 ? (int) ceil( $feed_total / 100 ) : 0;
+$buffered       = $batches_needed > 0 ? (int) ceil( $batches_needed * 1.25 ) : 0;
+$recommended    = $feed_total > 0 ? max( 500, (int) ( ceil( $buffered / 500 ) * 500 ) ) : 0;
+
+// 3. Feed cursor and configuration.
+/**
+ * Filters the maximum number of batches per feed generation cycle.
+ *
+ * @since 1.4.0
+ * @param int $limit Default batch limit.
+ */
+$active_limit = (int) apply_filters( 'pinterest_for_woocommerce_max_feed_batches_per_cycle', 1000 );
+
+$cursor_dedicated = get_option( 'pinterest-for-woocommerce_feed_cursor', null );
+$reset_flag       = get_option( 'pinterest-for-woocommerce_cursor_reset_flag', null );
+
+$data_option     = get_option( 'pinterest_for_woocommerce_data', array() );
+$cursor_legacy   = $data_option['feed_last_queued_item_id'] ?? 'not set';
+$batch_size_ovr  = $data_option['feed_product_batch_size'] ?? null;
+$batch_attempt   = $data_option['feed_product_batch_attempt'] ?? null;
+$feed_dirty      = isset( $data_option['feed_dirty'] ) ? ( $data_option['feed_dirty'] ? 'yes' : 'no' ) : 'not set';
+$feed_registered = $data_option['feed_registered'] ?? 'not set';
+$merchant_id     = $data_option['merchant_id'] ?? 'not set';
+
+// 4. ProductFeedStatus.
+$feed_status = array();
+if ( class_exists( '\Automattic\WooCommerce\Pinterest\ProductFeedStatus' ) ) {
+	$feed_status = \Automattic\WooCommerce\Pinterest\ProductFeedStatus::get();
+}
+
+// 5. Action Scheduler — all Pinterest actions, last 48 h.
+$as_actions = array();
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}actionscheduler_actions'" ) ) {
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$as_actions = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT a.action_id,
+			        a.hook,
+			        a.status,
+			        a.args,
+			        a.scheduled_date_gmt,
+			        a.last_attempt_gmt,
+			        l.message AS log_message
+			 FROM {$wpdb->prefix}actionscheduler_actions a
+			 INNER JOIN {$wpdb->prefix}actionscheduler_groups g ON g.group_id = a.group_id
+			 LEFT JOIN (
+			     SELECT action_id, message
+			     FROM {$wpdb->prefix}actionscheduler_logs
+			     WHERE log_id IN (
+			         SELECT MAX(log_id)
+			         FROM {$wpdb->prefix}actionscheduler_logs
+			         GROUP BY action_id
+			     )
+			 ) l ON l.action_id = a.action_id
+			 WHERE g.slug = %s
+			   AND a.scheduled_date_gmt >= DATE_SUB( NOW(), INTERVAL 48 HOUR )
+			 ORDER BY a.scheduled_date_gmt DESC
+			 LIMIT 100",
+			'pinterest-for-woocommerce'
+		)
+	);
+}
+
+// 6. Integrity ratio.
+$integrity_ok = null;
+if ( $feed_total > 0 && isset( $feed_status['product_count'] ) ) {
+	$written      = (int) $feed_status['product_count'];
+	$integrity_ok = $written <= (int) ceil( $feed_total * 1.5 );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Return a coloured status badge span.
+ *
+ * @param string $status Action Scheduler status string.
+ * @return string HTML span.
+ */
+function p4wc_debug_badge( string $status ): string {
+	$map                = array(
+		'complete'    => array( '#d4edda', '#155724' ),
+		'pending'     => array( '#cce5ff', '#004085' ),
+		'in-progress' => array( '#fff3cd', '#856404' ),
+		'failed'      => array( '#f8d7da', '#721c24' ),
+		'canceled'    => array( '#e2e3e5', '#383d41' ),
+	);
+	list( $bg, $color ) = isset( $map[ $status ] ) ? $map[ $status ] : array( '#e2e3e5', '#383d41' );
+	return sprintf(
+		'<span style="background:%s;color:%s;padding:2px 7px;border-radius:3px;font-size:11px;font-weight:600">%s</span>',
+		esc_attr( $bg ),
+		esc_attr( $color ),
+		esc_html( strtoupper( $status ) )
+	);
+}
+
+/**
+ * Return a two-cell table row with label and value.
+ *
+ * @param string $label Row label.
+ * @param mixed  $value Row value (arrays are rendered as a pre block).
+ * @param string $note  Optional explanatory note shown in muted text.
+ * @return string HTML tr.
+ */
+function p4wc_debug_row( string $label, $value, string $note = '' ): string {
+	if ( is_array( $value ) || is_object( $value ) ) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$val = '<pre style="margin:0">' . esc_html( var_export( $value, true ) ) . '</pre>';
+	} else {
+		$val = esc_html( (string) $value );
+	}
+	$n = $note ? ' <span style="color:#6c757d;font-size:11px">&mdash; ' . esc_html( $note ) . '</span>' : '';
+	return '<tr><td style="padding:5px 10px;color:#6c757d;white-space:nowrap;vertical-align:top">'
+		. esc_html( $label )
+		. '</td><td style="padding:5px 10px">'
+		. $val . $n
+		. '</td></tr>';
+}
+
+/**
+ * Return an h2 section heading.
+ *
+ * @param string $title Section title.
+ * @return string HTML h2.
+ */
+function p4wc_debug_section( string $title ): string {
+	return '<h2 style="margin:30px 0 8px;font-size:15px;border-bottom:2px solid #dee2e6;padding-bottom:6px;color:#343a40">'
+		. esc_html( $title )
+		. '</h2>';
+}
+
+$generated_at = current_time( 'Y-m-d H:i:s' ) . ' (server: ' . gmdate( 'Y-m-d H:i:s' ) . ' UTC)';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Pinterest for WooCommerce &mdash; Feed Debug</title>
+<style>
+*, *::before, *::after { box-sizing: border-box }
+body  { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; font-size:13px; color:#212529; background:#f8f9fa; margin:0; padding:20px }
+.wrap { max-width:1200px; margin:0 auto; background:#fff; border:1px solid #dee2e6; border-radius:6px; padding:24px }
+h1    { font-size:20px; margin:0 0 4px; color:#343a40 }
+.meta { color:#6c757d; font-size:12px; margin-bottom:20px }
+table { width:100%; border-collapse:collapse; margin-bottom:6px }
+table tr:nth-child(even) td { background:#f8f9fa }
+.as-table th { background:#343a40; color:#fff; padding:6px 10px; text-align:left; font-size:11px; font-weight:600; white-space:nowrap }
+.as-table td { padding:5px 10px; border-bottom:1px solid #dee2e6; vertical-align:top }
+.as-table tr:hover td { background:#f0f4ff }
+.warn { background:#fff3cd; border:1px solid #ffc107; border-radius:4px; padding:10px 14px; margin:8px 0; color:#856404 }
+.ok   { background:#d4edda; border:1px solid #28a745; border-radius:4px; padding:10px 14px; margin:8px 0; color:#155724 }
+.err  { background:#f8d7da; border:1px solid #dc3545; border-radius:4px; padding:10px 14px; margin:8px 0; color:#721c24 }
+pre   { font-size:11px; white-space:pre-wrap; word-break:break-all }
+.hook { font-size:11px; color:#495057 }
+.nodata { color:#6c757d; font-style:italic; padding:10px 0 }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Pinterest for WooCommerce &mdash; Feed Debug</h1>
+<p class="meta">
+	Generated: <?php echo esc_html( $generated_at ); ?>
+	&nbsp;|&nbsp;
+	User: <?php echo esc_html( wp_get_current_user()->user_login ); ?>
+</p>
+
+<?php
+// ── Section 1: System Info ────────────────────────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '1. System Info' );
+echo '<table>';
+foreach ( $system as $k => $v ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( $k, $v );
+}
+echo '</table>';
+
+// ── Section 2: Product Counts ─────────────────────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '2. Product Counts' );
+
+if ( $simple_count !== $feed_total ) {
+	echo '<div class="warn">'
+		. '&#9888; WC dashboard count (' . esc_html( number_format( $simple_count ) ) . ') differs from feed query total (' . esc_html( number_format( $feed_total ) ) . '). '
+		. 'The feed iterates more rows than the admin shows &mdash; check for extra published product posts (e.g. from incomplete imports or leftover variations).'
+		. '</div>';
+}
+
+echo '<table>';
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'WC dashboard count', number_format( $simple_count ), 'SELECT COUNT(*) WHERE post_type=product AND post_status=publish' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Feed query total rows', number_format( $feed_total ), 'same WHERE clause the feed iterates (products + variations)' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( '  -> published product posts', number_format( $product_posts ) );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( '  -> published variation posts', number_format( $variation_count ) );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Batches needed @ 100/batch', number_format( $batches_needed ) );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Recommended circuit-breaker filter', number_format( $recommended ), 'ceil(total/100) x 1.25 rounded to nearest 500' );
+echo '</table>';
+
+// ── Section 3: Feed Configuration & Cursor ────────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '3. Feed Configuration & Cursor' );
+
+$limit_ok = $active_limit >= $batches_needed;
+if ( $limit_ok ) {
+	echo '<div class="ok">'
+		. '&#10004; Circuit breaker limit (' . esc_html( number_format( $active_limit ) ) . ') is sufficient for ' . esc_html( number_format( $batches_needed ) ) . ' needed batches.'
+		. '</div>';
+} else {
+	echo '<div class="err">'
+		. '&#10008; Circuit breaker limit (' . esc_html( number_format( $active_limit ) ) . ') is TOO LOW &mdash; feed needs ' . esc_html( number_format( $batches_needed ) ) . ' batches. '
+		. 'Add: <code>add_filter( \'pinterest_for_woocommerce_max_feed_batches_per_cycle\', fn() =&gt; ' . esc_html( number_format( $recommended ) ) . ' );</code>'
+		. '</div>';
+}
+
+echo '<table>';
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Active circuit breaker limit', number_format( $active_limit ), 'pinterest_for_woocommerce_max_feed_batches_per_cycle filter' );
+
+if ( null !== $cursor_dedicated ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Cursor (dedicated option)', number_format( (int) $cursor_dedicated ), 'pinterest-for-woocommerce_feed_cursor - authoritative after plugin fix' );
+} else {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Cursor (dedicated option)', 'NOT SET', 'plugin fix not yet active - cursor stored in legacy shared option' );
+}
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Cursor (legacy shared option)', $cursor_legacy, 'feed_last_queued_item_id inside pinterest_for_woocommerce_data' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Cursor reset flag', null !== $reset_flag ? (int) $reset_flag : 'not set', 'set by workaround snippet when batch 1 is about to start' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Batch size override', null !== $batch_size_ovr ? $batch_size_ovr : 'not set (using default 100)', 'set during timeout retries; cleared after success' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Batch attempt', null !== $batch_attempt ? $batch_attempt : 'not set', 'retry counter within current batch; cleared after success' );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Feed dirty', $feed_dirty );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Feed registered (feed ID)', $feed_registered );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_row( 'Merchant ID', $merchant_id );
+echo '</table>';
+
+// ── Section 4: ProductFeedStatus ─────────────────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '4. ProductFeedStatus' );
+if ( empty( $feed_status ) ) {
+	echo '<p class="nodata">ProductFeedStatus unavailable.</p>';
+} else {
+	$written        = (int) ( $feed_status['product_count'] ?? 0 );
+	$wall_time_secs = (int) ( $feed_status['feed_generation_wall_time'] ?? 0 );
+	$wall_human     = $wall_time_secs > 0 ? gmdate( 'H:i:s', $wall_time_secs ) : ( -1 === $wall_time_secs ? 'failed' : '—' );
+
+	if ( false === $integrity_ok ) {
+		echo '<div class="err">'
+			. '&#10008; Content integrity: ' . esc_html( number_format( $written ) ) . ' entries written vs ' . esc_html( number_format( $feed_total ) ) . ' published products '
+			. '(' . esc_html( (string) round( $written / max( $feed_total, 1 ), 2 ) ) . 'x). '
+			. 'Ratio exceeds 1.5 &mdash; cursor was likely reset mid-cycle causing duplicates.'
+			. '</div>';
+	} elseif ( true === $integrity_ok ) {
+		echo '<div class="ok">'
+			. '&#10004; Content integrity: ' . esc_html( number_format( $written ) ) . ' entries for ' . esc_html( number_format( $feed_total ) ) . ' products '
+			. '(' . esc_html( (string) round( $written / max( $feed_total, 1 ), 2 ) ) . 'x).'
+			. '</div>';
+	}
+
+	echo '<table>';
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Status', $feed_status['status'] ?? '—' );
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Products written this cycle', number_format( $written ) );
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Recent product count (last completed)', number_format( (int) ( $feed_status['feed_generation_recent_product_count'] ?? 0 ) ) );
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo p4wc_debug_row( 'Last generation wall time', $wall_human );
+	if ( ! empty( $feed_status['error_message'] ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo p4wc_debug_row( 'Last error', $feed_status['error_message'] );
+	}
+	echo '</table>';
+}
+
+// ── Section 5: Action Scheduler (last 48 h) ───────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '5. Action Scheduler — Last 48 h (pinterest-for-woocommerce group)' );
+
+if ( empty( $as_actions ) ) {
+	echo '<p class="nodata">No actions found in the last 48 hours.</p>';
+} else {
+	$batch_hook = 'pinterest/jobs/generate_feed/chain_batch';
+	$start_hook = 'pinterest-for-woocommerce-start-feed-generation';
+
+	// Count completed batches since the most recent start-feed-generation run.
+	$last_start_ran    = null;
+	$completed_batches = 0;
+	foreach ( $as_actions as $row ) {
+		if ( $row->hook === $start_hook && 'complete' === $row->status && '0000-00-00 00:00:00' !== $row->last_attempt_gmt ) {
+			$last_start_ran = $last_start_ran ?? $row->last_attempt_gmt;
+		}
+	}
+	foreach ( $as_actions as $row ) {
+		if ( $row->hook === $batch_hook && 'complete' === $row->status ) {
+			if ( ! $last_start_ran || $row->scheduled_date_gmt >= $last_start_ran ) {
+				++$completed_batches;
+			}
+		}
+	}
+
+	if ( $completed_batches > (int) ( $batches_needed * 1.1 ) ) {
+		echo '<div class="warn">'
+			. '&#9888; ' . esc_html( number_format( $completed_batches ) ) . ' chain_batch actions completed since last start but only ' . esc_html( number_format( $batches_needed ) ) . ' expected. '
+			. 'Cursor may have been reset mid-cycle.'
+			. '</div>';
+	} elseif ( $completed_batches > 0 ) {
+		echo '<div class="ok">'
+			. '&#10004; ' . esc_html( number_format( $completed_batches ) ) . ' batches completed this cycle (expected &asymp; ' . esc_html( number_format( $batches_needed ) ) . ').'
+			. '</div>';
+	}
+
+	echo '<table class="as-table">';
+	echo '<tr><th>ID</th><th>Hook</th><th>Status</th><th>Batch #</th><th>Scheduled (UTC)</th><th>Last attempt (UTC)</th><th>Last log</th></tr>';
+	foreach ( $as_actions as $row ) {
+		$args         = json_decode( $row->args ?? '[]', true );
+		$batch_num    = ( is_array( $args ) && isset( $args[0] ) && is_int( $args[0] ) ) ? $args[0] : '—';
+		$short_hook   = str_replace( 'pinterest-for-woocommerce/', '', $row->hook );
+		$short_hook   = str_replace( 'pinterest-for-woocommerce', 'p4wc', $short_hook );
+		$last_attempt = ( $row->last_attempt_gmt && '0000-00-00 00:00:00' !== $row->last_attempt_gmt )
+			? $row->last_attempt_gmt : '—';
+		printf(
+			'<tr><td>%s</td><td class="hook">%s</td><td>%s</td><td style="text-align:right">%s</td><td style="white-space:nowrap">%s</td><td style="white-space:nowrap">%s</td><td><small>%s</small></td></tr>',
+			esc_html( $row->action_id ),
+			esc_html( $short_hook ),
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			p4wc_debug_badge( $row->status ),
+			esc_html( (string) $batch_num ),
+			esc_html( $row->scheduled_date_gmt ),
+			esc_html( $last_attempt ),
+			esc_html( mb_substr( $row->log_message ?? '', 0, 140 ) )
+		);
+	}
+	echo '</table>';
+	if ( 100 === count( $as_actions ) ) {
+		echo '<p class="nodata">Showing most recent 100 actions. Older entries truncated.</p>';
+	}
+}
+
+// ── Section 6: Diagnosis Summary ─────────────────────────────────────────────
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo p4wc_debug_section( '6. Diagnosis Summary' );
+
+$issues = array();
+if ( $active_limit < $batches_needed ) {
+	$issues[] = 'Circuit breaker limit too low &mdash; feed truncated after ' . number_format( $active_limit ) . ' batches; needs ' . number_format( $batches_needed ) . '. Apply the filter: <code>add_filter( \'pinterest_for_woocommerce_max_feed_batches_per_cycle\', fn() =&gt; ' . number_format( $recommended ) . ' );</code>';
+}
+if ( $simple_count !== $feed_total ) {
+	$issues[] = 'Product count mismatch: WC admin shows ' . number_format( $simple_count ) . ' but feed iterates ' . number_format( $feed_total ) . ' rows. Extra posts with post_type=product may exist in the database.';
+}
+if ( false === $integrity_ok ) {
+	$issues[] = 'Feed content integrity breach: written product count (' . number_format( (int) ( $feed_status['product_count'] ?? 0 ) ) . ') is more than 1.5x the published product count. Cursor was reset mid-cycle &mdash; duplicates were written to the feed.';
+}
+if ( null === $cursor_dedicated ) {
+	$issues[] = 'Dedicated cursor option not found. The cursor race-condition fix is not yet active on this site. Apply the workaround snippet or update the plugin.';
+}
+if ( ! empty( $feed_status['error_message'] ) ) {
+	$issues[] = 'Last feed error: ' . esc_html( $feed_status['error_message'] );
+}
+
+if ( empty( $issues ) ) {
+	echo '<div class="ok">&#10004; No issues detected. Feed configuration looks correct.</div>';
+} else {
+	foreach ( $issues as $issue ) {
+		echo '<div class="err">&#10008; ' . wp_kses( $issue, array( 'code' => array() ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+}
+?>
+
+</div><!-- .wrap -->
+</body>
+</html>

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -374,6 +374,7 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
+		// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		throw new \RuntimeException(
 			sprintf(
 				/* translators: 1: product entries written to feed, 2: published product count. */
@@ -385,6 +386,7 @@ class FeedGenerator extends AbstractChainedJob {
 				$expected
 			)
 		);
+		// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 	}
 
 	/**
@@ -402,6 +404,12 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	const FEED_INTEGRITY_MAX_RATIO = 1.1;
 
+	/**
+	 * Handle end of feed generation — verify integrity, rename temp files, update status.
+	 *
+	 * @return void
+	 * @throws \Throwable Re-throws any exception from the integrity check or file operations after logging.
+	 */
 	protected function handle_end() {
 		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
 		try {

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -421,6 +421,9 @@ class FeedGenerator extends AbstractChainedJob {
 		}
 		self::log( __( 'Feed generated successfully.', 'pinterest-for-woocommerce' ) );
 
+		// Feed completed cleanly — remove any circuit-breaker warning from the WC admin inbox.
+		FeedCircuitBreakerNote::delete_note();
+
 		// Check if feed is dirty and reschedule in necessary.
 		if ( $this->feed_is_dirty() ) {
 			$this->mark_feed_clean();

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -348,9 +348,61 @@ class FeedGenerator extends AbstractChainedJob {
 	 *
 	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
+	/**
+	 * Verify the number of product entries written this cycle is not significantly
+	 * greater than the published product count.
+	 *
+	 * The feed cursor lives in the shared `pinterest_for_woocommerce_data` option,
+	 * which is also written by FeedRegistration, Merchants, Feeds, and other classes
+	 * via a read-modify-write pattern.  If one of those writes lands while the cursor
+	 * has already advanced, it silently overwrites it with a stale value and the feed
+	 * chain re-traverses all products from the beginning — writing every product two,
+	 * three, or four times into the temp file without any error.  The circuit breaker
+	 * eventually fires, but by then the temp file already contains duplicates.
+	 *
+	 * This check is the last line of defence: if the written count exceeds the
+	 * published count by more than FEED_INTEGRITY_MAX_RATIO the temp files are
+	 * discarded and a fresh cycle is scheduled rather than publishing a corrupted feed.
+	 *
+	 * @throws \RuntimeException When duplicate entries are detected.
+	 */
+	private function assert_feed_content_integrity(): void {
+		$written  = (int) ( ProductFeedStatus::get()['product_count'] ?? 0 );
+		$expected = $this->count_published_products();
+
+		if ( $expected <= 0 || $written <= (int) ceil( $expected * self::FEED_INTEGRITY_MAX_RATIO ) ) {
+			return;
+		}
+
+		throw new \RuntimeException(
+			sprintf(
+				/* translators: 1: product entries written to feed, 2: published product count. */
+				__(
+					'Feed content integrity check failed: %1$d product entries were written but the catalog has only %2$d published products. The cursor was likely reset mid-cycle, causing duplicate entries. Discarding the temporary feed file — a fresh generation cycle will start automatically.',
+					'pinterest-for-woocommerce'
+				),
+				$written,
+				$expected
+			)
+		);
+	}
+
+	/**
+	 * Maximum ratio of feed entries written to published product count before
+	 * the feed is considered corrupted by cursor resets.
+	 *
+	 * 1.5 allows up to 50 % more entries than published products (accommodates
+	 * products added during generation) while reliably catching the ≥ 2× duplication
+	 * that occurs when the cursor is silently reset mid-cycle.
+	 *
+	 * @var float
+	 */
+	const FEED_INTEGRITY_MAX_RATIO = 1.5;
+
 	protected function handle_end() {
 		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );
 		try {
+			$this->assert_feed_content_integrity();
 			$this->feed_file_operations->add_footer_to_temporary_feed_files();
 			$this->feed_file_operations->rename_temporary_feed_files_to_final();
 			ProductFeedStatus::set(

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -374,19 +374,16 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
-		// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
-		throw new \RuntimeException(
-			sprintf(
-				/* translators: 1: product entries written to feed, 2: published product count. */
-				__(
-					'Feed content integrity check failed: %1$d product entries were written but the catalog has only %2$d published products. The cursor was likely reset mid-cycle, causing duplicate entries. Discarding the temporary feed file — a fresh generation cycle will start automatically.',
-					'pinterest-for-woocommerce'
-				),
-				$written,
-				$expected
-			)
+		$message = sprintf(
+			/* translators: 1: product entries written to feed, 2: published product count. */
+			__(
+				'Feed content integrity check failed: %1$d product entries were written but the catalog has only %2$d published products. The cursor was likely reset mid-cycle, causing duplicate entries. Discarding the temporary feed file — a fresh generation cycle will start automatically.',
+				'pinterest-for-woocommerce'
+			),
+			$written,
+			$expected
 		);
-		// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		throw new \RuntimeException( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -391,13 +391,16 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Maximum ratio of feed entries written to published product count before
 	 * the feed is considered corrupted by cursor resets.
 	 *
-	 * 1.5 allows up to 50 % more entries than published products (accommodates
-	 * products added during generation) while reliably catching the ≥ 2× duplication
-	 * that occurs when the cursor is silently reset mid-cycle.
+	 * 1.1 allows up to 10 % more entries than published products (accommodates
+	 * products added or published during generation) while catching the ≥ 1.29×
+	 * duplication observed in production when the cursor race condition fires.
+	 * The previous value of 1.5 was too loose — a 29 % over-count (133,500 entries
+	 * for a 103,708-product catalog) slipped through and the corrupted feed was
+	 * published to Pinterest.
 	 *
 	 * @var float
 	 */
-	const FEED_INTEGRITY_MAX_RATIO = 1.5;
+	const FEED_INTEGRITY_MAX_RATIO = 1.1;
 
 	protected function handle_end() {
 		self::log( __( 'Feed generation end. Moving files to the final destination.', 'pinterest-for-woocommerce' ) );

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -341,28 +341,17 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
-	 * Runs as the last step of the job.
-	 * Add XML footer to the feed files and copy the move the files from tmp to the final destination.
-	 *
-	 * @since 1.0.10
-	 *
-	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
-	 */
-	/**
 	 * Verify the number of product entries written this cycle is not significantly
 	 * greater than the published product count.
 	 *
-	 * The feed cursor lives in the shared `pinterest_for_woocommerce_data` option,
-	 * which is also written by FeedRegistration, Merchants, Feeds, and other classes
-	 * via a read-modify-write pattern.  If one of those writes lands while the cursor
-	 * has already advanced, it silently overwrites it with a stale value and the feed
-	 * chain re-traverses all products from the beginning — writing every product two,
-	 * three, or four times into the temp file without any error.  The circuit breaker
-	 * eventually fires, but by then the temp file already contains duplicates.
-	 *
-	 * This check is the last line of defence: if the written count exceeds the
-	 * published count by more than FEED_INTEGRITY_MAX_RATIO the temp files are
-	 * discarded and a fresh cycle is scheduled rather than publishing a corrupted feed.
+	 * The feed cursor is stored in the dedicated FEED_CURSOR_OPTION to avoid a
+	 * read-modify-write race with FeedRegistration, Merchants, Feeds, and other
+	 * classes that write the shared `pinterest_for_woocommerce_data` option. This
+	 * check is a second line of defence for sites still running an older cursor
+	 * implementation, or for any other cause of duplicate entries: if the written
+	 * count exceeds the published count by more than FEED_INTEGRITY_MAX_RATIO the
+	 * temp files are discarded and a fresh cycle is scheduled rather than
+	 * publishing a corrupted feed.
 	 *
 	 * @throws \RuntimeException When duplicate entries are detected.
 	 */

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -734,6 +734,25 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Dedicated option name for the feed cursor (last queued product ID).
+	 *
+	 * Stored as a standalone WordPress option — NOT inside the shared
+	 * `pinterest_for_woocommerce_data` array — to prevent concurrent
+	 * read-modify-write races with other classes (FeedRegistration, Merchants,
+	 * Feeds, etc.) that also call save_data() on that shared option.  Those
+	 * classes load the entire array, do external work (API calls), then write
+	 * the array back.  If the write happens after the feed chain committed a
+	 * new cursor value, the write silently overwrites the cursor with the stale
+	 * value read at the start, causing the chain to loop from the beginning.
+	 *
+	 * Using update_option() directly is atomic (a single SQL UPDATE) and
+	 * eliminates the race window entirely.
+	 *
+	 * @var string
+	 */
+	const FEED_CURSOR_OPTION = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '_feed_cursor';
+
+	/**
 	 * Returns last product id from the last batch of products fetched at the previous step.
 	 *
 	 * @param int $batch_number - Action Scheduler chain action batch number.
@@ -741,11 +760,12 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function get_last_batch_id( int $batch_number ): int {
 		if ( 1 === $batch_number ) {
-			// Reset last fetched ID if batch number equals to 1.
-			Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+			// Reset cursor at the start of each new generation cycle.
+			update_option( self::FEED_CURSOR_OPTION, 0, false );
+			return 0;
 		}
 		// Get last fetched ID to start from the next item after it.
-		return (int) Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		return (int) get_option( self::FEED_CURSOR_OPTION, 0 );
 	}
 
 	/**
@@ -755,7 +775,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return void
 	 */
 	protected function set_last_batch_id( int $id ): void {
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', $id );
+		update_option( self::FEED_CURSOR_OPTION, $id, false );
 	}
 
 	/**

--- a/src/Notes/FeedCircuitBreakerNote.php
+++ b/src/Notes/FeedCircuitBreakerNote.php
@@ -87,4 +87,22 @@ class FeedCircuitBreakerNote {
 			return;
 		}
 	}
+
+	/**
+	 * Delete the circuit-breaker note when the feed completes successfully.
+	 *
+	 * Called from FeedGenerator::handle_end() after the feed file has been
+	 * renamed to its final location. If the note is present it means the
+	 * merchant has already raised the filter high enough for the feed to
+	 * complete — the warning is no longer relevant.
+	 *
+	 * @return void
+	 */
+	public static function delete_note(): void {
+		try {
+			Notes::delete_notes_with_name( self::NOTE_NAME );
+		} catch ( NotesUnavailableException $e ) {
+			return;
+		}
+	}
 }

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -558,6 +558,65 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Content integrity guard — normal cases that must NOT throw.
+	 *
+	 * @dataProvider feed_integrity_pass_provider
+	 */
+	public function test_feed_content_integrity_passes( int $written, int $published ): void {
+		// Create exactly $published simple products so count_published_products() returns $published.
+		for ( $i = 0; $i < $published; $i++ ) {
+			WC_Helper_Product::create_simple_product();
+		}
+
+		ProductFeedStatus::set( array( 'product_count' => $written ) );
+
+		// handle_end_action must complete without throwing.
+		$this->feed_generator->handle_end_action( array() );
+		$this->assertTrue( true ); // reached without exception
+	}
+
+	public function feed_integrity_pass_provider(): array {
+		return array(
+			'exact match'                       => array( 3, 3 ),
+			'written less (filtered out stock)' => array( 2, 3 ),
+			'written at 1.0x'                   => array( 10, 10 ),
+			'written at 1.4x (under threshold)' => array( 14, 10 ),
+			'written at exactly 1.5x'           => array( 15, 10 ),
+			'empty catalog skips check'         => array( 0, 0 ),
+		);
+	}
+
+	public function test_feed_content_integrity_throws_when_written_count_exceeds_ratio(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Simulate the cursor-reset duplication: 4 full traversals of a 1-product catalog.
+		ProductFeedStatus::set( array( 'product_count' => 4 ) );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/Feed content integrity check failed/' );
+
+		$this->feed_generator->handle_end_action( array() );
+
+		$product->delete( true );
+	}
+
+	public function test_feed_content_integrity_throws_sets_status_to_error(): void {
+		WC_Helper_Product::create_simple_product();
+
+		// Simulate 3x duplication.
+		ProductFeedStatus::set( array( 'product_count' => 3 ) );
+
+		try {
+			$this->feed_generator->handle_end_action( array() );
+		} catch ( \RuntimeException $e ) {
+			$this->assertEquals( 'error', ProductFeedStatus::get()['status'] );
+			return;
+		}
+
+		$this->fail( 'Expected RuntimeException was not thrown.' );
+	}
+
 	public function test_while_feed_generator_is_in_progress_previous_wall_time_and_recent_product_count_are_not_overwritten() {
 		ProductFeedStatus::set(
 			array(
@@ -663,22 +722,22 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		// Create a product to fetch.
 		WC_Helper_Product::create_simple_product();
 
-		// Set initial cursor.
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+		// Set initial cursor via the dedicated option (cursor moved from shared data option).
+		update_option( FeedGenerator::FEED_CURSOR_OPTION, 0 );
 
 		// Fetch items - this should store pending cursor but not commit it yet.
 		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
 		$this->assertNotEmpty( $items );
 
 		// Cursor should still be at initial value (not advanced yet).
-		$cursor_before = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$cursor_before = (int) get_option( FeedGenerator::FEED_CURSOR_OPTION, 0 );
 		$this->assertEquals( 0, $cursor_before, 'Cursor should not advance before handle_batch_action completes' );
 
 		// Complete batch processing.
 		$this->feed_generator->handle_batch_action( 1, array() );
 
 		// Now cursor should be advanced.
-		$cursor_after = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$cursor_after = (int) get_option( FeedGenerator::FEED_CURSOR_OPTION, 0 );
 		$this->assertGreaterThan( $cursor_before, $cursor_after, 'Cursor should advance after successful batch completion' );
 	}
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -516,6 +516,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_time );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function test_feed_generator_end_clears_circuit_breaker_note_on_success(): void {
 		// Simulate a note left over from a previous circuit-breaker failure.
 		\Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote::add_note( 2000 );
@@ -573,6 +576,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * Content integrity guard — normal cases that must NOT throw.
 	 *
 	 * @dataProvider feed_integrity_pass_provider
+	 * @param int $written   Product entries written to the temp feed file.
+	 * @param int $published Published product count returned by the DB query.
+	 * @return void
 	 */
 	public function test_feed_content_integrity_passes( int $written, int $published ): void {
 		// Create exactly $published simple products so count_published_products() returns $published.
@@ -584,9 +590,12 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		// handle_end_action must complete without throwing.
 		$this->feed_generator->handle_end_action( array() );
-		$this->assertTrue( true ); // reached without exception
+		$this->assertTrue( true ); // Reached without exception.
 	}
 
+	/**
+	 * @return array<string, array{int, int}>
+	 */
 	public function feed_integrity_pass_provider(): array {
 		return array(
 			'exact match'                       => array( 3, 3 ),
@@ -598,6 +607,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	public function test_feed_content_integrity_throws_when_written_count_exceeds_ratio(): void {
 		WC_Helper_Product::create_simple_product();
 
@@ -610,6 +622,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->feed_generator->handle_end_action( array() );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function test_feed_content_integrity_throws_on_1_29x_ratio_matching_observed_production_bug(): void {
 		// Reproduce the exact production failure: 133,500 entries for 103,708 products = 1.29x.
 		// The previous 1.5x threshold silently passed this; the new 1.1x threshold must catch it.
@@ -626,6 +641,9 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->feed_generator->handle_end_action( array() );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function test_feed_content_integrity_throws_sets_status_to_error(): void {
 		WC_Helper_Product::create_simple_product();
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -581,14 +581,14 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 			'exact match'                       => array( 3, 3 ),
 			'written less (filtered out stock)' => array( 2, 3 ),
 			'written at 1.0x'                   => array( 10, 10 ),
-			'written at 1.4x (under threshold)' => array( 14, 10 ),
-			'written at exactly 1.5x'           => array( 15, 10 ),
+			'written at 1.05x (under threshold)' => array( 105, 100 ),
+			'written at exactly 1.1x'            => array( 110, 100 ),
 			'empty catalog skips check'         => array( 0, 0 ),
 		);
 	}
 
 	public function test_feed_content_integrity_throws_when_written_count_exceeds_ratio(): void {
-		$product = WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_simple_product();
 
 		// Simulate the cursor-reset duplication: 4 full traversals of a 1-product catalog.
 		ProductFeedStatus::set( array( 'product_count' => 4 ) );
@@ -597,8 +597,22 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->expectExceptionMessageMatches( '/Feed content integrity check failed/' );
 
 		$this->feed_generator->handle_end_action( array() );
+	}
 
-		$product->delete( true );
+	public function test_feed_content_integrity_throws_on_1_29x_ratio_matching_observed_production_bug(): void {
+		// Reproduce the exact production failure: 133,500 entries for 103,708 products = 1.29x.
+		// The previous 1.5x threshold silently passed this; the new 1.1x threshold must catch it.
+		for ( $i = 0; $i < 10; $i++ ) {
+			WC_Helper_Product::create_simple_product();
+		}
+
+		// 10 products published, 13 written = 1.3x (mirrors 103,708 → 133,500).
+		ProductFeedStatus::set( array( 'product_count' => 13 ) );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/Feed content integrity check failed/' );
+
+		$this->feed_generator->handle_end_action( array() );
 	}
 
 	public function test_feed_content_integrity_throws_sets_status_to_error(): void {

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -516,6 +516,17 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( $time_test_started, $feed_generation_wall_time );
 	}
 
+	public function test_feed_generator_end_clears_circuit_breaker_note_on_success(): void {
+		// Simulate a note left over from a previous circuit-breaker failure.
+		\Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote::add_note( 2000 );
+		$data_store = \Automattic\WooCommerce\Admin\Notes\Notes::load_data_store();
+		$this->assertCount( 1, $data_store->get_notes_with_name( \Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote::NOTE_NAME ), 'Pre-condition: note must exist before handle_end runs' );
+
+		$this->feed_generator->handle_end_action( array() );
+
+		$this->assertCount( 0, $data_store->get_notes_with_name( \Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote::NOTE_NAME ), 'Note should be deleted after a successful feed generation' );
+	}
+
 	public function test_feed_generator_end_sets_product_count_into_persistent_state_property() {
 		ProductFeedStatus::set(
 			array(

--- a/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
+++ b/tests/Unit/Notes/FeedCircuitBreakerNoteTest.php
@@ -100,6 +100,27 @@ class FeedCircuitBreakerNoteTest extends \WP_UnitTestCase {
 	/**
 	 * @return void
 	 */
+	public function test_delete_note_removes_existing_note(): void {
+		FeedCircuitBreakerNote::add_note( 2500 );
+		$this->assertCount( 1, Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) );
+
+		FeedCircuitBreakerNote::delete_note();
+
+		$this->assertCount( 0, Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_delete_note_is_safe_when_no_note_exists(): void {
+		// No note added — delete_note must not throw.
+		FeedCircuitBreakerNote::delete_note();
+		$this->assertCount( 0, Notes::load_data_store()->get_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME ) );
+	}
+
+	/**
+	 * @return void
+	 */
 	public function test_note_has_catalog_sync_and_dismiss_actions() {
 		FeedCircuitBreakerNote::add_note( 2500 );
 

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -26,6 +26,9 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_all_filters( 'woocommerce_tracker_data' );

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -26,6 +26,11 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'woocommerce_tracker_data' );
+	}
+
 	function test_settings_are_tracked_by_woo_tracker_if_opt_in() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
@@ -139,6 +144,6 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertTrue( count($tracks) === 0, "Track data should be empty whe OPT-OUT" );
+		$this->assertTrue( count( $tracks ) === 0, 'Track data should be empty whe OPT-OUT' );
 	}
 }

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -144,6 +144,6 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertTrue( count( $tracks ) === 0, 'Track data should be empty whe OPT-OUT' );
+		$this->assertTrue( count( $tracks ) === 0, 'Track data should be empty when opting out' );
 	}
 }

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -144,6 +144,6 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertTrue( count( $tracks ) === 0, 'Track data should be empty when opting out' );
+		$this->assertEmpty( $tracks, 'Track data should be empty when opting out' );
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1166 — these fixes were developed after that PR merged and contain the most critical production fixes:

- **Cursor race condition fix**: moves `feed_last_queued_item_id` from the shared `pinterest_for_woocommerce_data` option to a dedicated `pinterest-for-woocommerce_feed_cursor` option. The shared option is read-modify-written by multiple classes (FeedRegistration, Merchants, Feeds, etc.) creating a race window where `p4wc-handle-feed-registration` (firing every 10 min) reads the option with cursor=0 at feed start, makes Pinterest API calls, then writes back the stale cursor=0 — resetting the feed mid-cycle. This caused a 102,827-product store to exhaust 4,001 batches (expected: ~1,029) and hit the circuit breaker every cycle.
- **Feed content integrity guard**: `assert_feed_content_integrity()` in `handle_end()` compares written product count against published product count before renaming the temp feed file to final. Feeds with ratio > 1.1x (duplicates from a mid-cycle cursor reset) are rejected and rescheduled rather than published to Pinterest.
- **Circuit-breaker note auto-clear**: `FeedCircuitBreakerNote::delete_note()` is called after a successful feed generation so the WC inbox warning clears automatically when the issue is resolved.
- **Feed debug page** (`debug.php`): standalone support tool accessible via direct URL (`/wp-content/plugins/pinterest-for-woocommerce/debug.php`) by logged-in administrators. Not linked from any admin menu. Shows product count breakdown (simple/variable/variations), feed cursor state, Action Scheduler history, integrity ratio, and recommended circuit-breaker filter value — all without requiring the merchant to run SQL or install debug plugins.

## Test plan

- [ ] On a store with variable products: confirm feed generates cleanly, completing with all products (simple + variations) in the feed — not duplicates
- [ ] Confirm `pinterest-for-woocommerce_feed_cursor` option appears in `wp_options` during feed generation and advances correctly batch-by-batch
- [ ] Simulate a cursor reset: temporarily make `p4wc-handle-feed-registration` overwrite the cursor mid-run, confirm `assert_feed_content_integrity()` rejects the feed (error status, file not renamed to final)
- [ ] After fixing the circuit-breaker filter value and letting a feed complete, confirm the WC inbox note disappears automatically
- [ ] Visit `/wp-content/plugins/pinterest-for-woocommerce/debug.php` as an admin — confirm product breakdown (simple/variable parents/variations), cursor state, and AS action table all display correctly
- [ ] Visit the debug page as a non-admin — confirm 403
- [ ] Visit the debug page logged out — confirm redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)