### PR TITLE
Fix keyboard accessibility of the Pinterest Save button on product images

### DIFF
--- a/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
+++ b/assets/source/sass/frontend/pinterest-for-woocommerce-pins.scss
@@ -4,17 +4,19 @@
 	top: 10px;
 	z-index: 50;
 	opacity: 0;
-	visibility: hidden;
+	pointer-events: none;
 
 	@media (hover: none) {
 		opacity: 1;
-		visibility: visible;
+		pointer-events: auto;
 	}
 
 	.product:hover > &,
-	.wc-block-grid__product:hover > & {
+	.wc-block-grid__product:hover > &,
+	.product:focus-within > &,
+	.wc-block-grid__product:focus-within > & {
 		opacity: 1;
-		visibility: visible;
+		pointer-events: auto;
 
 		a {
 			text-decoration: none;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/WOOA11Y-256/a11y-element-is-not-keyboard-operable-in-div-with-visibilityhidden, https://linear.app/a8c/issue/WOOA11Y-242/a11y-element-is-not-keyboard-operable-span-instead-of-button-wooext

The Pinterest Save button sits in `.pinterest-for-woocommerce-image-wrapper`, which used `visibility: hidden` until hover. That kept the link out of keyboard focus and made it unusable without a mouse (and harder for screen reader users).

This change:
- Replaces `visibility: hidden` / `visible` with `pointer-events: none` / `auto` so the control stays in the accessibility/focus tree while still avoiding accidental clicks when visually hidden.
- Adds `:focus-within` alongside `:hover` so the Save button becomes visible and interactive when reached via keyboard.

Touch devices without hover are unchanged (`@media (hover: none)` still shows the button).

> [!NOTE]
> https://resident-tern-saxophone.jurassic.ninja/wp-admin
> demo / 3u7ef3oCX0ZpDYrcRCN7


### Screen Recording:

#### Shop page
https://github.com/user-attachments/assets/61bc7328-685c-4e96-83a6-22e3d264af2a

#### Product page
https://github.com/user-attachments/assets/5ffeacd9-bec6-4714-965d-9b5a2c7b1814

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Pull the latest changes for this branch.
2. Build assets: `npm run build`.
3. Open a product page, e.g. https://resident-tern-saxophone.jurassic.ninja/product/blouse/
4. Use `Tab` to move focus until the `Save` button is selected.
5. Confirm the Save button:
   - Can receive keyboard focus
   - Becomes visible when focused (via `:focus-within`)
6. Open a Shop page, e.g. https://resident-tern-saxophone.jurassic.ninja/shop/
7. Confirm point number 4 and 5

### Changelog entry

> Fix - Make the Pinterest Save button reachable and usable with keyboard navigation by removing `visibility: hidden` from the image wrapper on shop and product page.