### PR TITLE
Fix Save to Pinterest button accessibility for screen readers

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -50,108 +50,28 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			} );
 	}
 
-	// Run initially in case Pinterest rendered on page load.
-	processWrappers();
+	// Pinterest renders its button asynchronously, so keep retrying for a short
+	// window instead of giving up after the first pass.
+	const POLL_INTERVAL = 2000; // 2 seconds.
+	const POLL_TIMEOUT  = 10000; // 10 seconds.
 
-	/**
-	 * Whether a mutation is related to our Save button wrappers/links.
-	 *
-	 * Pinterest often rewrites the <a> inside an existing wrapper (childList on
-	 * the wrapper) or inserts a ready-made link with data-pin-log already set
-	 * (no attribute mutation). Matching only newly added wrappers misses that.
-	 *
-	 * @param {MutationRecord} mutation Mutation to inspect.
-	 * @return {boolean} True when processWrappers should run.
-	 */
-	function isPinterestRelatedMutation( mutation ) {
-		if (
-			mutation.type === 'attributes' &&
-			mutation.attributeName === 'data-pin-log' &&
-			mutation.target &&
-			typeof mutation.target.closest === 'function' &&
-			mutation.target.closest(
-				'.pinterest-for-woocommerce-image-wrapper'
-			)
-		) {
-			return true;
-		}
+	const deadline = Date.now() + POLL_TIMEOUT;
 
-		if (
-			mutation.type !== 'childList' ||
-			mutation.addedNodes.length === 0
-		) {
-			return false;
-		}
-
-		// Pinterest rewrote nodes inside an existing wrapper.
-		if (
-			mutation.target &&
-			mutation.target.nodeType === 1 &&
-			typeof mutation.target.closest === 'function' &&
-			mutation.target.closest(
-				'.pinterest-for-woocommerce-image-wrapper'
-			)
-		) {
-			return true;
-		}
-
-		for ( const node of mutation.addedNodes ) {
-			if ( node.nodeType !== 1 ) {
-				continue;
-			}
-
-			if (
-				node.matches( '.pinterest-for-woocommerce-image-wrapper' ) ||
-				node.querySelector(
-					'.pinterest-for-woocommerce-image-wrapper'
-				) ||
-				node.matches( 'a[data-pin-do], a[data-pin-log]' ) ||
-				node.querySelector( 'a[data-pin-do], a[data-pin-log]' )
-			) {
-				return true;
-			}
-		}
-
-		return false;
+	function hasPendingWrappers() {
+		return (
+			document.querySelector(
+				'.pinterest-for-woocommerce-image-wrapper:not([data-sr-labeled])'
+			) !== null
+		);
 	}
 
-	let processScheduled = false;
+	( function poll() {
+		processWrappers();
 
-	function scheduleProcessWrappers() {
-		if ( processScheduled ) {
+		if ( ! hasPendingWrappers() || Date.now() >= deadline ) {
 			return;
 		}
 
-		processScheduled = true;
-
-		const run = () => {
-			processScheduled = false;
-			processWrappers();
-		};
-
-		// Defer briefly so DOM paint can complete; fall back when rAF is missing.
-		if ( typeof window.requestAnimationFrame === 'function' ) {
-			window.requestAnimationFrame( run );
-		} else {
-			window.setTimeout( run, 0 );
-		}
-	}
-
-	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
-	const observer = new window.MutationObserver( function ( mutations ) {
-		for ( const mutation of mutations ) {
-			if ( isPinterestRelatedMutation( mutation ) ) {
-				scheduleProcessWrappers();
-				break;
-			}
-		}
-	} );
-
-	// Observe child node additions and attribute changes across the document.
-	observer.observe( document.body, {
-		childList: true,
-		subtree: true,
-		attributes: true,
-		attributeFilter: [ 'data-pin-log' ],
-	} );
+		window.setTimeout( poll, POLL_INTERVAL );
+	} )();
 } );

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -148,6 +148,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 
 	// Observe child node additions and attribute changes across the document.
+	// Body-level observation is required so newly inserted wrappers (AJAX
+	// product grids, etc.) are still detected; isPinterestRelatedMutation
+	// keeps processWrappers from running on unrelated DOM noise.
 	observer.observe( document.body, {
 		childList: true,
 		subtree: true,

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -53,7 +53,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	// Pinterest renders its button asynchronously, so keep retrying for a short
 	// window instead of giving up after the first pass.
 	const POLL_INTERVAL = 2000; // 2 seconds.
-	const POLL_TIMEOUT  = 10000; // 10 seconds.
+	const POLL_TIMEOUT = 10000; // 10 seconds.
 
 	const deadline = Date.now() + POLL_TIMEOUT;
 

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -53,30 +53,97 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	// Run initially in case Pinterest rendered on page load.
 	processWrappers();
 
-	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
-	const observer = new window.MutationObserver( function ( mutations ) {
-		let shouldProcess = false;
+	/**
+	 * Whether a mutation is related to our Save button wrappers/links.
+	 *
+	 * Pinterest often rewrites the <a> inside an existing wrapper (childList on
+	 * the wrapper) or inserts a ready-made link with data-pin-log already set
+	 * (no attribute mutation). Matching only newly added wrappers misses that.
+	 *
+	 * @param {MutationRecord} mutation Mutation to inspect.
+	 * @return {boolean} True when processWrappers should run.
+	 */
+	function isPinterestRelatedMutation( mutation ) {
+		if (
+			mutation.type === 'attributes' &&
+			mutation.attributeName === 'data-pin-log' &&
+			mutation.target &&
+			typeof mutation.target.closest === 'function' &&
+			mutation.target.closest(
+				'.pinterest-for-woocommerce-image-wrapper'
+			)
+		) {
+			return true;
+		}
 
-		for ( const mutation of mutations ) {
-			// Check for added DOM nodes or attribute changes made by Pinterest.
+		if (
+			mutation.type !== 'childList' ||
+			mutation.addedNodes.length === 0
+		) {
+			return false;
+		}
+
+		// Pinterest rewrote nodes inside an existing wrapper.
+		if (
+			mutation.target &&
+			mutation.target.nodeType === 1 &&
+			typeof mutation.target.closest === 'function' &&
+			mutation.target.closest(
+				'.pinterest-for-woocommerce-image-wrapper'
+			)
+		) {
+			return true;
+		}
+
+		for ( const node of mutation.addedNodes ) {
+			if ( node.nodeType !== 1 ) {
+				continue;
+			}
+
 			if (
-				mutation.type === 'childList' &&
-				mutation.addedNodes.length > 0
+				node.matches( '.pinterest-for-woocommerce-image-wrapper' ) ||
+				node.querySelector(
+					'.pinterest-for-woocommerce-image-wrapper'
+				) ||
+				node.matches( 'a[data-pin-do], a[data-pin-log]' ) ||
+				node.querySelector( 'a[data-pin-do], a[data-pin-log]' )
 			) {
-				shouldProcess = true;
-				break;
-			} else if (
-				mutation.type === 'attributes' &&
-				mutation.attributeName === 'data-pin-log'
-			) {
-				shouldProcess = true;
-				break;
+				return true;
 			}
 		}
 
-		if ( shouldProcess ) {
-			// Defer execution briefly to ensure DOM paint completes.
-			window.requestAnimationFrame( processWrappers );
+		return false;
+	}
+
+	let processScheduled = false;
+
+	function scheduleProcessWrappers() {
+		if ( processScheduled ) {
+			return;
+		}
+
+		processScheduled = true;
+
+		const run = () => {
+			processScheduled = false;
+			processWrappers();
+		};
+
+		// Defer briefly so DOM paint can complete; fall back when rAF is missing.
+		if ( typeof window.requestAnimationFrame === 'function' ) {
+			window.requestAnimationFrame( run );
+		} else {
+			window.setTimeout( run, 0 );
+		}
+	}
+
+	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
+	const observer = new window.MutationObserver( function ( mutations ) {
+		for ( const mutation of mutations ) {
+			if ( isPinterestRelatedMutation( mutation ) ) {
+				scheduleProcessWrappers();
+				break;
+			}
 		}
 	} );
 

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -50,28 +50,108 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			} );
 	}
 
-	// Pinterest renders its button asynchronously, so keep retrying for a short
-	// window instead of giving up after the first pass.
-	const POLL_INTERVAL = 2000; // 2 seconds.
-	const POLL_TIMEOUT  = 10000; // 10 seconds.
+	// Run initially in case Pinterest rendered on page load.
+	processWrappers();
 
-	const deadline = Date.now() + POLL_TIMEOUT;
+	/**
+	 * Whether a mutation is related to our Save button wrappers/links.
+	 *
+	 * Pinterest often rewrites the <a> inside an existing wrapper (childList on
+	 * the wrapper) or inserts a ready-made link with data-pin-log already set
+	 * (no attribute mutation). Matching only newly added wrappers misses that.
+	 *
+	 * @param {MutationRecord} mutation Mutation to inspect.
+	 * @return {boolean} True when processWrappers should run.
+	 */
+	function isPinterestRelatedMutation( mutation ) {
+		if (
+			mutation.type === 'attributes' &&
+			mutation.attributeName === 'data-pin-log' &&
+			mutation.target &&
+			typeof mutation.target.closest === 'function' &&
+			mutation.target.closest(
+				'.pinterest-for-woocommerce-image-wrapper'
+			)
+		) {
+			return true;
+		}
 
-	function hasPendingWrappers() {
-		return (
-			document.querySelector(
-				'.pinterest-for-woocommerce-image-wrapper:not([data-sr-labeled])'
-			) !== null
-		);
+		if (
+			mutation.type !== 'childList' ||
+			mutation.addedNodes.length === 0
+		) {
+			return false;
+		}
+
+		// Pinterest rewrote nodes inside an existing wrapper.
+		if (
+			mutation.target &&
+			mutation.target.nodeType === 1 &&
+			typeof mutation.target.closest === 'function' &&
+			mutation.target.closest(
+				'.pinterest-for-woocommerce-image-wrapper'
+			)
+		) {
+			return true;
+		}
+
+		for ( const node of mutation.addedNodes ) {
+			if ( node.nodeType !== 1 ) {
+				continue;
+			}
+
+			if (
+				node.matches( '.pinterest-for-woocommerce-image-wrapper' ) ||
+				node.querySelector(
+					'.pinterest-for-woocommerce-image-wrapper'
+				) ||
+				node.matches( 'a[data-pin-do], a[data-pin-log]' ) ||
+				node.querySelector( 'a[data-pin-do], a[data-pin-log]' )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
-	( function poll() {
-		processWrappers();
+	let processScheduled = false;
 
-		if ( ! hasPendingWrappers() || Date.now() >= deadline ) {
+	function scheduleProcessWrappers() {
+		if ( processScheduled ) {
 			return;
 		}
 
-		window.setTimeout( poll, POLL_INTERVAL );
-	} )();
+		processScheduled = true;
+
+		const run = () => {
+			processScheduled = false;
+			processWrappers();
+		};
+
+		// Defer briefly so DOM paint can complete; fall back when rAF is missing.
+		if ( typeof window.requestAnimationFrame === 'function' ) {
+			window.requestAnimationFrame( run );
+		} else {
+			window.setTimeout( run, 0 );
+		}
+	}
+
+	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
+	const observer = new window.MutationObserver( function ( mutations ) {
+		for ( const mutation of mutations ) {
+			if ( isPinterestRelatedMutation( mutation ) ) {
+				scheduleProcessWrappers();
+				break;
+			}
+		}
+	} );
+
+	// Observe child node additions and attribute changes across the document.
+	observer.observe( document.body, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: [ 'data-pin-log' ],
+	} );
 } );

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -22,3 +22,69 @@ window.addEventListener( 'load', function () {
 
 	checkForPinterestExtension();
 } );
+
+// eslint-disable-next-line @wordpress/no-global-event-listener
+document.addEventListener( 'DOMContentLoaded', function () {
+	function processWrappers() {
+		document
+			.querySelectorAll( '.pinterest-for-woocommerce-image-wrapper' )
+			.forEach( function ( wrapper ) {
+				// Skip if already processed.
+				if ( wrapper.dataset.srLabeled ) return;
+
+				const pinLink = wrapper.querySelector( 'a' );
+				const srSpan = wrapper.querySelector( '.screen-reader-text' );
+
+				// Check that both elements exist AND Pinterest has finished adding its attribute.
+				const isPinterestReady =
+					pinLink &&
+					pinLink.getAttribute( 'data-pin-log' ) === 'button_pinit';
+
+				if ( isPinterestReady && srSpan ) {
+					// Move the span inside the processed <a> tag.
+					pinLink.appendChild( srSpan );
+
+					// Mark as processed so it only runs once.
+					wrapper.dataset.srLabeled = 'true';
+				}
+			} );
+	}
+
+	// Run initially in case Pinterest rendered on page load.
+	processWrappers();
+
+	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
+	const observer = new window.MutationObserver( function ( mutations ) {
+		let shouldProcess = false;
+
+		for ( const mutation of mutations ) {
+			// Check for added DOM nodes or attribute changes made by Pinterest.
+			if (
+				mutation.type === 'childList' &&
+				mutation.addedNodes.length > 0
+			) {
+				shouldProcess = true;
+				break;
+			} else if (
+				mutation.type === 'attributes' &&
+				mutation.attributeName === 'data-pin-log'
+			) {
+				shouldProcess = true;
+				break;
+			}
+		}
+
+		if ( shouldProcess ) {
+			// Defer execution briefly to ensure DOM paint completes.
+			window.requestAnimationFrame( processWrappers );
+		}
+	} );
+
+	// Observe child node additions and attribute changes across the document.
+	observer.observe( document.body, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: [ 'data-pin-log' ],
+	} );
+} );

--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -53,7 +53,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	// Pinterest renders its button asynchronously, so keep retrying for a short
 	// window instead of giving up after the first pass.
 	const POLL_INTERVAL = 2000; // 2 seconds.
-	const POLL_TIMEOUT = 10000; // 10 seconds.
+	const POLL_TIMEOUT  = 10000; // 10 seconds.
 
 	const deadline = Date.now() + POLL_TIMEOUT;
 

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -85,7 +85,8 @@ class SaveToPinterest {
 		 * Image used is the one explicitly set in the media attribute.
 		 */
 		return sprintf(
-			'<div class="pinterest-for-woocommerce-image-wrapper"><a data-pin-do="buttonPin" href="%s"></a></div>',
+			'<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">%s</span><a data-pin-do="buttonPin" href="%s"></a></div>',
+			esc_html__( 'Save to Pinterest (opens in a new tab)', 'pinterest-for-woocommerce' ),
 			esc_url(
 				add_query_arg(
 					$attributes,

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -66,8 +66,13 @@ class SaveToPinterest {
 	 */
 	public static function render_pin( $post_id, $post_thumbnail_id = '' ) {
 
+		$product_name = get_the_title();
+
+		/* translators: %s: product name */
+		$screen_reader_text = sprintf( __( '%s to Pinterest (opens in a new window)', 'pinterest-for-woocommerce' ), $product_name );
+
 		$attributes = array(
-			'description' => esc_html( get_the_title() ),
+			'description' => esc_html( $product_name ),
 			'url'         => esc_url( get_the_permalink() ),
 		);
 
@@ -86,7 +91,7 @@ class SaveToPinterest {
 		 */
 		return sprintf(
 			'<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">%s</span><a data-pin-do="buttonPin" href="%s"></a></div>',
-			esc_html__( 'Save to Pinterest (opens in a new tab)', 'pinterest-for-woocommerce' ),
+			esc_html( $screen_reader_text ),
 			esc_url(
 				add_query_arg(
 					$attributes,

--- a/src/SaveToPinterest.php
+++ b/src/SaveToPinterest.php
@@ -66,14 +66,14 @@ class SaveToPinterest {
 	 */
 	public static function render_pin( $post_id, $post_thumbnail_id = '' ) {
 
-		$product_name = get_the_title();
+		$product_name = get_the_title( $post_id );
 
 		/* translators: %s: product name */
 		$screen_reader_text = sprintf( __( '%s to Pinterest (opens in a new window)', 'pinterest-for-woocommerce' ), $product_name );
 
 		$attributes = array(
 			'description' => esc_html( $product_name ),
-			'url'         => esc_url( get_the_permalink() ),
+			'url'         => esc_url( get_the_permalink( $post_id ) ),
 		);
 
 		$post_thumbnail_id = empty( $post_thumbnail_id ) ? get_post_thumbnail_id( $post_id ) : $post_thumbnail_id;

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -26,6 +26,9 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_all_filters( 'woocommerce_tracker_data' );

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -26,6 +26,11 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'woocommerce_tracker_data' );
+	}
+
 	function test_settings_are_tracked_by_woo_tracker_if_opt_in() {
 		Pinterest_For_Woocommerce::save_settings( self::$default_settings );
 
@@ -139,6 +144,6 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertTrue( count($tracks) === 0, "Track data should be empty whe OPT-OUT" );
+		$this->assertEmpty( $tracks, 'Track data should be empty when opting out' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/WOOA11Y-245/a11y-links-open-new-window-or-tab-wooext-255, https://linear.app/a8c/issue/WOOA11Y-244/a11y-text-doesnt-describe-link-purpose-wooext-254

The Save to Pinterest button is rendered as an empty `<a>` that Pinterest’s widget then transforms. That leaves an unlabelled link for assistive tech.

This PR:

- Adds a `.screen-reader-text` span with “`(Product Name)` to Pinterest (opens in a new window)” next to the pin markup in `SaveToPinterest::render_pin()`
- Moves that span into the processed `<a>` once Pinterest has finished (`data-pin-log="button_pinit"`), via a `MutationObserver`
- Fixes ESLint issues (`window.MutationObserver` / `window.requestAnimationFrame`, and the existing global event-listener disable pattern)

> [!NOTE]
> https://worm-of-tyrannosauruses.jurassic.ninja/wp-admin
> demo / zaBTt3EEa1mXvaRn9NET

> [!CAUTION]
> Temporary workaround only — the root cause must be fixed on Pinterest’s side.

### Screen Recording:

https://github.com/user-attachments/assets/75a8488f-666c-445e-8f88-37fe76e549d9

### Detailed test instructions:

1. Open a shop/product page with the Save button visible; confirm the pin button still appears and works on hover.
3. Tab to a product card; confirm the Save button becomes visible on keyboard focus.
4. In DevTools, after Pinterest loads, confirm the `.screen-reader-text` span is inside the pin `<a>` (not only a sibling of it).
5. With a screen reader (or Accessibility tree), confirm the link announces something like “`(Product Name)` to Pinterest (opens in a new window)”.
6. Confirm the button still hides when the Pinterest browser extension is detected.
7. Run `npm run lint:js` and confirm no errors on `pinterest-for-woocommerce-save-button.js`.

### Changelog entry

> Fix - Add accessible screen reader label to the Save to Pinterest button.