### PR TITLE
Adds `aria-haspopup="dialog"` to the Pinterest "Save" button

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -44,6 +44,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					// Move the span inside the processed <a> tag.
 					pinLink.appendChild( srSpan );
 
+					// Add aria-haspopup to <a> tag.
+					pinLink.setAttribute( 'aria-haspopup', 'dialog' );
+
 					// Mark as processed so it only runs once.
 					wrapper.dataset.srLabeled = 'true';
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/WOOA11Y-243/a11y-button-triggering-modal-missing-aria-haspopup-wooext-253

Adds `aria-haspopup="dialog"` to the Pinterest "Save" button to properly announce to screen reader users that activating the link opens an overlay/dialog window.

> [!IMPORTANT]
> **Note on aria-controls:** `aria-controls` was intentionally omitted because Pinterest generates its modal inside a dynamic third-party iframe at runtime. Referencing an element ID that does not exist prior to click violates W3C ARIA specs and causes WCAG validation failures.

> [!NOTE]
> https://worm-of-tyrannosauruses.jurassic.ninja/wp-admin
> demo / zaBTt3EEa1mXvaRn9NET

### Screenshots:

<img width="1686" height="720" alt="Screenshot 2026-07-22 at 4 50 41 PM" src="https://github.com/user-attachments/assets/e668e593-34b3-4862-8fde-1bf44044815e" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open a shop/product page with the Save button visible; confirm the pin button still appears and works on hover.
2. Tab to a product card; confirm the Save button becomes visible on keyboard focus.
3. In DevTools, confirm the `aria-haspopup="dialog"` is present in <a> tag.
4. With a screen reader (or Accessibility tree), confirm the link announces something like “dialogue pop-up”.
<img width="692" height="198" alt="Screenshot 2026-07-22 at 4 56 58 PM" src="https://github.com/user-attachments/assets/699cca2c-797a-41b4-a216-1cda71222bd1" />



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Accessibility: Added `aria-haspopup="dialog"` attribute to the Pinterest image button to properly announce to screen reader users that activating the button opens a modal window.
