### PR TITLE
Prevent overlapping feed generation runs from corrupting the product feed

### DIFF
--- a/src/FeedFileOperations.php
+++ b/src/FeedFileOperations.php
@@ -71,6 +71,22 @@ class FeedFileOperations {
 	}
 
 	/**
+	 * Delete the temporary feed files.
+	 *
+	 * Used when a generation cycle fails or is aborted, so partial feeds do not
+	 * accumulate on disk.
+	 *
+	 * @since x.x.x
+	 */
+	public function delete_temporary_feed_files(): void {
+		foreach ( $this->configurations->get_configurations() as $config ) {
+			if ( isset( $config['tmp_file'] ) && file_exists( $config['tmp_file'] ) ) {
+				wp_delete_file( $config['tmp_file'] );
+			}
+		}
+	}
+
+	/**
 	 * Check if we have a feed file on the disk.
 	 *
 	 * @since 1.2.9

--- a/src/FeedFileOperations.php
+++ b/src/FeedFileOperations.php
@@ -72,11 +72,9 @@ class FeedFileOperations {
 
 	/**
 	 * Delete the temporary feed files.
+	 * Used when a generation cycle fails or is aborted, so partial feeds do not accumulate on disk.
 	 *
-	 * Used when a generation cycle fails or is aborted, so partial feeds do not
-	 * accumulate on disk.
-	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 */
 	public function delete_temporary_feed_files(): void {
 		foreach ( $this->configurations->get_configurations() as $config ) {

--- a/src/FeedFileOperations.php
+++ b/src/FeedFileOperations.php
@@ -74,7 +74,7 @@ class FeedFileOperations {
 	 * Delete the temporary feed files.
 	 * Used when a generation cycle fails or is aborted, so partial feeds do not accumulate on disk.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 */
 	public function delete_temporary_feed_files(): void {
 		foreach ( $this->configurations->get_configurations() as $config ) {

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -53,10 +53,20 @@ class FeedGenerator extends AbstractChainedJob {
 	const OPTION_FEED_DIRTY = 'pinterest_for_woocommerce_feed_dirty';
 
 	/**
+	 * The option used as an atomic lock while a generation cycle is started.
+	 */
+	const OPTION_START_LOCK = 'pinterest_for_woocommerce_feed_generation_start_lock';
+
+	/**
 	 * How soon (in seconds) an already pending start action must fire for
 	 * mark_feed_dirty() to skip scheduling another immediate start.
 	 */
 	const START_DEBOUNCE_WINDOW = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Maximum lifetime for a start lock left behind by an interrupted request.
+	 */
+	const START_LOCK_TTL = 5 * MINUTE_IN_SECONDS;
 
 	/**
 	 * The time in seconds to wait after a failed feed generation attempt,
@@ -380,23 +390,34 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	public function handle_start_action( array $args ) {
-		if ( $this->is_current_cycle_alive() ) {
+		$start_lock = $this->acquire_start_lock();
+		if ( '' === $start_lock ) {
 			update_option( self::OPTION_FEED_DIRTY, 1, false );
-			self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
+			self::log( __( 'Another feed generation start is in progress. Marked the feed dirty to regenerate afterward.', 'pinterest-for-woocommerce' ) );
 			return;
 		}
 
-		// Mint the new cycle before truncating the temporary files: from this moment
-		// any still-scheduled action from an older cycle self-terminates.
-		$cycle_id = wp_generate_uuid4();
-		update_option( self::OPTION_CYCLE_ID, $cycle_id, false );
-		$args[ self::ARG_CYCLE_ID ] = $cycle_id;
+		try {
+			if ( $this->is_current_cycle_alive() ) {
+				update_option( self::OPTION_FEED_DIRTY, 1, false );
+				self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
+				return;
+			}
 
-		/* translators: feed generation cycle ID */
-		self::log( sprintf( __( 'Starting feed generation cycle `%s`.', 'pinterest-for-woocommerce' ), $cycle_id ) );
+			// Mint the new cycle before truncating the temporary files: from this moment
+			// any still-scheduled action from an older cycle self-terminates.
+			$cycle_id = wp_generate_uuid4();
+			update_option( self::OPTION_CYCLE_ID, $cycle_id, false );
+			$args[ self::ARG_CYCLE_ID ] = $cycle_id;
 
-		$this->handle_start();
-		$this->queue_batch( 1, $args );
+			/* translators: feed generation cycle ID */
+			self::log( sprintf( __( 'Starting feed generation cycle `%s`.', 'pinterest-for-woocommerce' ), $cycle_id ) );
+
+			$this->handle_start();
+			$this->queue_batch( 1, $args );
+		} finally {
+			$this->release_start_lock( $start_lock );
+		}
 	}
 
 	/**
@@ -836,6 +857,7 @@ class FeedGenerator extends AbstractChainedJob {
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		delete_option( self::OPTION_CYCLE_ID );
 		delete_option( self::OPTION_FEED_DIRTY );
+		delete_option( self::OPTION_START_LOCK );
 	}
 
 	/**
@@ -951,6 +973,81 @@ class FeedGenerator extends AbstractChainedJob {
 	protected function is_stale_cycle( array $args ): bool {
 		$cycle_id = (string) ( $args[ self::ARG_CYCLE_ID ] ?? '' );
 		return $cycle_id !== $this->get_current_cycle_id();
+	}
+
+	/**
+	 * Acquire the atomic lock that serializes generation-cycle starts.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Lock value owned by this request, or an empty string when another request owns it.
+	 */
+	protected function acquire_start_lock(): string {
+		global $wpdb;
+
+		$lock_value = ( time() + self::START_LOCK_TTL ) . ':' . wp_generate_uuid4();
+		$inserted   = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$wpdb->options} ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )",
+				self::OPTION_START_LOCK,
+				$lock_value
+			)
+		);
+		if ( 1 === $inserted ) {
+			return $lock_value;
+		}
+
+		$existing_lock = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				self::OPTION_START_LOCK
+			)
+		);
+		$expires_at    = (int) strstr( (string) $existing_lock, ':', true );
+		if ( $expires_at > time() ) {
+			return '';
+		}
+
+		$deleted = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+				self::OPTION_START_LOCK,
+				$existing_lock
+			)
+		);
+		if ( 1 !== $deleted ) {
+			return '';
+		}
+
+		$inserted = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$wpdb->options} ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )",
+				self::OPTION_START_LOCK,
+				$lock_value
+			)
+		);
+
+		return 1 === $inserted ? $lock_value : '';
+	}
+
+	/**
+	 * Release a generation-cycle start lock only when this request still owns it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $lock_value Lock value returned by acquire_start_lock().
+	 * @return void
+	 */
+	protected function release_start_lock( string $lock_value ): void {
+		global $wpdb;
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+				self::OPTION_START_LOCK,
+				$lock_value
+			)
+		);
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -42,20 +42,13 @@ class FeedGenerator extends AbstractChainedJob {
 
 	/**
 	 * The option storing the ID of the current (authoritative) generation cycle.
-	 *
-	 * Deliberately a dedicated option rather than a key inside the shared plugin
-	 * data option: the shared option is rewritten wholesale by concurrent
-	 * processes, which could clobber the cycle ID with a stale copy.
+	 * Dedicated option: concurrent whole-array writes to the shared plugin data option would clobber it.
 	 */
 	const OPTION_CYCLE_ID = 'pinterest_for_woocommerce_feed_generation_cycle_id';
 
 	/**
 	 * The option storing the feed dirty flag.
-	 *
-	 * Deliberately a dedicated option: the flag is written from product-edit
-	 * requests whose options caches may be stale — writing it through the shared
-	 * plugin data option would rewrite that whole array and clobber concurrent
-	 * writes (most importantly the feed cursor) with stale copies.
+	 * Dedicated option: written on every product edit, so it must not rewrite the shared plugin data option.
 	 */
 	const OPTION_FEED_DIRTY = 'pinterest_for_woocommerce_feed_dirty';
 
@@ -193,7 +186,6 @@ class FeedGenerator extends AbstractChainedJob {
 
 		// Do not resurrect a superseded cycle, and do not let its timeout shrink the
 		// current cycle's batch size throttling state.
-		$this->refresh_data_option_cache();
 		$job_args = ( isset( $args[1] ) && is_array( $args[1] ) ) ? $args[1] : array();
 		if ( $this->is_stale_cycle( $job_args ) ) {
 			self::log(
@@ -371,24 +363,16 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Handles the job chain start action.
 	 *
-	 * Overrides the framework handler to enforce a hard cap of one active generation
-	 * cycle. If the current cycle still has live (pending or in-progress) chain
-	 * actions, the start is skipped and the feed is marked dirty instead — the active
-	 * cycle picks the flag up in handle_end() and triggers the regeneration. Only when
-	 * the current cycle is dead or absent does the start mint a new cycle ID and take
-	 * over. The ID is stamped into the job args and propagates through every action in
-	 * the chain, so any still-scheduled action from an older cycle aborts instead of
-	 * writing to the feed files or the shared cursor.
+	 * Enforces at most one active generation cycle: defers (marking the feed dirty) while the current
+	 * cycle is alive, otherwise mints a new cycle ID that propagates through the whole new chain.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 *
 	 * @param array $args The args for the job.
 	 *
 	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	public function handle_start_action( array $args ) {
-		$this->refresh_data_option_cache();
-
 		if ( $this->is_current_cycle_alive() ) {
 			update_option( self::OPTION_FEED_DIRTY, 1, false );
 			self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
@@ -419,8 +403,6 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to issue possible when creating an empty feed temp file and populating the header.
 	 */
 	public function handle_batch_action( int $batch_number, array $args ) {
-		$this->refresh_data_option_cache();
-
 		if ( $this->is_stale_cycle( $args ) ) {
 			// A newer cycle owns the feed files and the shared cursor. Abort quietly:
 			// no processing, no successor action, no throttling state changes.
@@ -447,19 +429,16 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Handles the job chain end action.
 	 *
-	 * Overrides the framework handler to validate the cycle ID: a stale chain end
-	 * must not publish (rename) the temporary file that now belongs to the cycle
-	 * which superseded it, nor mark the feed as generated.
+	 * A chain end from a superseded cycle must not publish (rename) the temporary file that now
+	 * belongs to the newer cycle, nor mark the feed as generated.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 *
 	 * @param array $args The args for the job.
 	 *
 	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
 	public function handle_end_action( array $args ) {
-		$this->refresh_data_option_cache();
-
 		if ( $this->is_stale_cycle( $args ) ) {
 			self::log( __( 'Feed Generator end action belongs to a superseded generation cycle. Skipping.', 'pinterest-for-woocommerce' ) );
 			return;
@@ -891,6 +870,9 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Returns last product id from the last batch of products fetched at the previous step.
 	 *
+	 * Read directly from the database: the previous batch may have committed the cursor from another
+	 * process, and that write is invisible to this request's options caches.
+	 *
 	 * @param int $batch_number - Action Scheduler chain action batch number.
 	 * @return int
 	 */
@@ -898,9 +880,20 @@ class FeedGenerator extends AbstractChainedJob {
 		if ( 1 === $batch_number ) {
 			// Reset last fetched ID if batch number equals to 1.
 			Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+			return 0;
 		}
-		// Get last fetched ID to start from the next item after it.
-		return (int) Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+
+		global $wpdb;
+
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				PINTEREST_FOR_WOOCOMMERCE_DATA_NAME
+			)
+		);
+		$settings = maybe_unserialize( $value );
+
+		return (int) ( is_array( $settings ) ? ( $settings['feed_last_queued_item_id'] ?? 0 ) : 0 );
 	}
 
 	/**
@@ -916,12 +909,10 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Returns the ID of the current (authoritative) feed generation cycle.
 	 *
-	 * Reads straight from the database, bypassing both the plugin's runtime settings
-	 * cache and the WordPress options caches: Action Scheduler processes many chain
-	 * actions inside a single long-lived request, and a concurrent request may have
-	 * superseded the cycle after this request's caches were primed.
+	 * Read directly from the database: a long-lived Action Scheduler request must see a supersession
+	 * committed by a concurrent request, which its request-local options caches would hide.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 *
 	 * @return string Current cycle ID, or an empty string if no cycle has been started yet.
 	 */
@@ -939,34 +930,12 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
-	 * Drops the request-local caches for the plugin options so the next read fetches
-	 * fresh values from the database.
-	 *
-	 * Chain actions are processed by long-lived Action Scheduler runner requests
-	 * whose options caches were primed when the request started. Values written by
-	 * concurrent requests (the shared feed cursor, throttling state, the dirty flag)
-	 * are invisible to those caches, so every chain handler refreshes them before
-	 * acting — otherwise a stale snapshot could be read back and written out again.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return void
-	 */
-	protected function refresh_data_option_cache(): void {
-		wp_cache_delete( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME, 'options' );
-		wp_cache_delete( 'alloptions', 'options' );
-		// Re-prime the plugin's static settings cache from the now-fresh options.
-		Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id', true );
-	}
-
-	/**
 	 * Checks whether the given job args belong to a superseded generation cycle.
 	 *
-	 * Args without a cycle ID (scheduled by previous plugin versions) are considered
-	 * current as long as no cycle ID has ever been minted, which keeps in-flight
-	 * chains running across a plugin upgrade.
+	 * Args without a cycle ID are current as long as no cycle ID has ever been minted, which keeps
+	 * chains scheduled by previous plugin versions running across an upgrade.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 *
 	 * @param array $args The args for the job.
 	 *
@@ -980,12 +949,10 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Checks whether the current generation cycle still has live scheduled actions.
 	 *
-	 * A cycle is alive when a pending or in-progress chain batch or chain end action
-	 * carries the current cycle ID. Chain start actions never carry a cycle ID — the
-	 * ID is minted when the start action executes — so queued starts are gated by
-	 * this same check when they run.
+	 * Alive means a pending or in-progress chain batch/end action carries the current cycle ID.
+	 * Queued chain starts never carry an ID — they are gated by this same check when they run.
 	 *
-	 * @since x.x.x
+	 * @since 1.4.28
 	 *
 	 * @return bool
 	 */

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -388,7 +388,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Enforces at most one active generation cycle: defers (marking the feed dirty) while the current
 	 * cycle is alive, otherwise mints a new cycle ID that propagates through the whole new chain.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 *
 	 * @param array $args The args for the job.
 	 *
@@ -465,7 +465,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * A chain end from a superseded cycle must not publish (rename) the temporary file that now
 	 * belongs to the newer cycle, nor mark the feed as generated.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 *
 	 * @param array $args The args for the job.
 	 *
@@ -950,7 +950,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Read directly from the database: a long-lived Action Scheduler request must see a supersession
 	 * committed by a concurrent request, which its request-local options caches would hide.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 *
 	 * @return string Current cycle ID, or an empty string if no cycle has been started yet.
 	 */
@@ -965,7 +965,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Args without a cycle ID are current as long as no cycle ID has ever been minted, which keeps
 	 * chains scheduled by previous plugin versions running across an upgrade.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 *
 	 * @param array $args The args for the job.
 	 *
@@ -1073,7 +1073,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * Alive means a pending or in-progress chain batch/end action carries the current cycle ID.
 	 * Queued chain starts never carry an ID — they are gated by this same check when they run.
 	 *
-	 * @since 1.4.28
+	 * @since x.x.x
 	 *
 	 * @return bool
 	 */

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -50,6 +50,16 @@ class FeedGenerator extends AbstractChainedJob {
 	const OPTION_CYCLE_ID = 'pinterest_for_woocommerce_feed_generation_cycle_id';
 
 	/**
+	 * The option storing the feed dirty flag.
+	 *
+	 * Deliberately a dedicated option: the flag is written from product-edit
+	 * requests whose options caches may be stale — writing it through the shared
+	 * plugin data option would rewrite that whole array and clobber concurrent
+	 * writes (most importantly the feed cursor) with stale copies.
+	 */
+	const OPTION_FEED_DIRTY = 'pinterest_for_woocommerce_feed_dirty';
+
+	/**
 	 * How soon (in seconds) an already pending start action must fire for
 	 * mark_feed_dirty() to skip scheduling another immediate start.
 	 */
@@ -380,7 +390,7 @@ class FeedGenerator extends AbstractChainedJob {
 		$this->refresh_data_option_cache();
 
 		if ( $this->is_current_cycle_alive() ) {
-			Pinterest_For_Woocommerce::save_data( 'feed_dirty', true );
+			update_option( self::OPTION_FEED_DIRTY, 1, false );
 			self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
 			return;
 		}
@@ -670,7 +680,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @since 1.0.10
 	 */
 	public function mark_feed_dirty(): void {
-		Pinterest_For_Woocommerce()::save_data( 'feed_dirty', true );
+		update_option( self::OPTION_FEED_DIRTY, 1, false );
 		self::log( 'Feed is dirty.' );
 
 		if ( $this->is_running() ) {
@@ -697,17 +707,29 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @since 1.0.10
 	 */
 	public function mark_feed_clean(): void {
-		Pinterest_For_Woocommerce()::save_data( 'feed_dirty', false );
+		update_option( self::OPTION_FEED_DIRTY, 0, false );
 	}
 
 	/**
 	 * Check if feed is dirty.
 	 *
+	 * Reads straight from the database: the flag may have been set by a concurrent
+	 * request after this request's options caches were primed.
+	 *
 	 * @since 1.0.10
 	 * @return bool Indicates if feed is dirty or not.
 	 */
 	public function feed_is_dirty(): bool {
-		return (bool) Pinterest_For_Woocommerce()::get_data( 'feed_dirty' );
+		global $wpdb;
+
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				self::OPTION_FEED_DIRTY
+			)
+		);
+
+		return (bool) $value;
 	}
 
 	/**
@@ -827,6 +849,7 @@ class FeedGenerator extends AbstractChainedJob {
 		}
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		delete_option( self::OPTION_CYCLE_ID );
+		delete_option( self::OPTION_FEED_DIRTY );
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -298,6 +298,13 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
+		$args     = $action->get_args();
+		$job_args = ( isset( $args[1] ) && is_array( $args[1] ) ) ? $args[1] : array();
+		if ( $this->is_stale_cycle( $job_args ) ) {
+			self::log( __( 'Feed Generator action from a superseded generation cycle failed. Ignoring the stale failure.', 'pinterest-for-woocommerce' ) );
+			return;
+		}
+
 		$this->handle_error( $throwable, $hook );
 	}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -732,16 +732,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return bool Indicates if feed is dirty or not.
 	 */
 	public function feed_is_dirty(): bool {
-		global $wpdb;
-
-		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				self::OPTION_FEED_DIRTY
-			)
-		);
-
-		return (bool) $value;
+		return (bool) $this->get_uncached_option_value( self::OPTION_FEED_DIRTY );
 	}
 
 	/**
@@ -918,26 +909,14 @@ class FeedGenerator extends AbstractChainedJob {
 			return 0;
 		}
 
-		global $wpdb;
-
-		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				self::OPTION_CURSOR
-			)
-		);
+		$value = $this->get_uncached_option_value( self::OPTION_CURSOR );
 		if ( null !== $value ) {
 			return (int) $value;
 		}
 
 		// Lazily migrate the legacy shared-option cursor so an in-flight chain from an
 		// older plugin version resumes from its last committed product ID.
-		$legacy_value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				PINTEREST_FOR_WOOCOMMERCE_DATA_NAME
-			)
-		);
+		$legacy_value = $this->get_uncached_option_value( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
 		$legacy_data  = maybe_unserialize( $legacy_value );
 		$cursor       = (int) ( is_array( $legacy_data ) ? ( $legacy_data['feed_last_queued_item_id'] ?? 0 ) : 0 );
 		$this->set_last_batch_id( $cursor );
@@ -976,15 +955,7 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return string Current cycle ID, or an empty string if no cycle has been started yet.
 	 */
 	protected function get_current_cycle_id(): string {
-		global $wpdb;
-
-		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				self::OPTION_CYCLE_ID
-			)
-		);
-
+		$value = $this->get_uncached_option_value( self::OPTION_CYCLE_ID );
 		return is_string( $value ) ? $value : '';
 	}
 
@@ -1027,12 +998,7 @@ class FeedGenerator extends AbstractChainedJob {
 			return $lock_value;
 		}
 
-		$existing_lock = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				self::OPTION_START_LOCK
-			)
-		);
+		$existing_lock = $this->get_uncached_option_value( self::OPTION_START_LOCK );
 		$expires_at    = (int) strstr( (string) $existing_lock, ':', true );
 		if ( $expires_at > time() ) {
 			return '';
@@ -1078,6 +1044,27 @@ class FeedGenerator extends AbstractChainedJob {
 				$lock_value
 			)
 		);
+	}
+
+	/**
+	 * Read an option directly from the database, bypassing request and persistent caches.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $option_name Option name.
+	 * @return string|null Stored option value, or null when the option does not exist.
+	 */
+	private function get_uncached_option_value( string $option_name ): ?string {
+		global $wpdb;
+
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				$option_name
+			)
+		);
+
+		return is_string( $value ) ? $value : null;
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -47,6 +47,11 @@ class FeedGenerator extends AbstractChainedJob {
 	const OPTION_CYCLE_ID = 'pinterest_for_woocommerce_feed_generation_cycle_id';
 
 	/**
+	 * The option storing the last product ID queued by feed generation.
+	 */
+	const OPTION_CURSOR = 'pinterest_for_woocommerce_feed_last_queued_item_id';
+
+	/**
 	 * The option storing the feed dirty flag.
 	 * Dedicated option: written on every product edit, so it must not rewrite the shared plugin data option.
 	 */
@@ -856,6 +861,7 @@ class FeedGenerator extends AbstractChainedJob {
 		}
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 		delete_option( self::OPTION_CYCLE_ID );
+		delete_option( self::OPTION_CURSOR );
 		delete_option( self::OPTION_FEED_DIRTY );
 		delete_option( self::OPTION_START_LOCK );
 	}
@@ -908,7 +914,7 @@ class FeedGenerator extends AbstractChainedJob {
 	protected function get_last_batch_id( int $batch_number ): int {
 		if ( 1 === $batch_number ) {
 			// Reset last fetched ID if batch number equals to 1.
-			Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+			$this->set_last_batch_id( 0 );
 			return 0;
 		}
 
@@ -917,12 +923,26 @@ class FeedGenerator extends AbstractChainedJob {
 		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				self::OPTION_CURSOR
+			)
+		);
+		if ( null !== $value ) {
+			return (int) $value;
+		}
+
+		// Lazily migrate the legacy shared-option cursor so an in-flight chain from an
+		// older plugin version resumes from its last committed product ID.
+		$legacy_value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
 				PINTEREST_FOR_WOOCOMMERCE_DATA_NAME
 			)
 		);
-		$settings = maybe_unserialize( $value );
+		$legacy_data  = maybe_unserialize( $legacy_value );
+		$cursor       = (int) ( is_array( $legacy_data ) ? ( $legacy_data['feed_last_queued_item_id'] ?? 0 ) : 0 );
+		$this->set_last_batch_id( $cursor );
 
-		return (int) ( is_array( $settings ) ? ( $settings['feed_last_queued_item_id'] ?? 0 ) : 0 );
+		return $cursor;
 	}
 
 	/**
@@ -932,7 +952,17 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @return void
 	 */
 	protected function set_last_batch_id( int $id ): void {
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', $id );
+		global $wpdb;
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"INSERT INTO {$wpdb->options} ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )
+				ON DUPLICATE KEY UPDATE option_value = %s, autoload = 'no'",
+				self::OPTION_CURSOR,
+				(string) $id,
+				(string) $id
+			)
+		);
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -1102,27 +1102,38 @@ class FeedGenerator extends AbstractChainedJob {
 		);
 
 		foreach ( $hooks as $hook ) {
-			$actions = (array) $this->action_scheduler->search(
-				array(
-					'hook'     => $hook,
-					'status'   => array( ActionSchedulerInterface::STATUS_PENDING, ActionSchedulerInterface::STATUS_RUNNING ),
-					'per_page' => 50,
-				),
-				OBJECT,
-				PINTEREST_FOR_WOOCOMMERCE_PREFIX
-			);
+			$per_page = 50;
+			$offset   = 0;
 
-			foreach ( $actions as $action ) {
-				if ( ! $action instanceof ActionScheduler_Action ) {
-					continue;
+			do {
+				$actions = (array) $this->action_scheduler->search(
+					array(
+						'hook'     => $hook,
+						'status'   => array( ActionSchedulerInterface::STATUS_PENDING, ActionSchedulerInterface::STATUS_RUNNING ),
+						'per_page' => $per_page,
+						'offset'   => $offset,
+						'orderby'  => 'date',
+						'order'    => 'DESC',
+					),
+					OBJECT,
+					PINTEREST_FOR_WOOCOMMERCE_PREFIX
+				);
+
+				foreach ( $actions as $action ) {
+					if ( ! $action instanceof ActionScheduler_Action ) {
+						continue;
+					}
+					$action_args = $action->get_args();
+					// Chain batch action args are [ batch_number, job_args ]; chain end args are [ job_args ].
+					$job_args = end( $action_args );
+					if ( is_array( $job_args ) && (string) ( $job_args[ self::ARG_CYCLE_ID ] ?? '' ) === $cycle_id ) {
+						return true;
+					}
 				}
-				$action_args = $action->get_args();
-				// Chain batch action args are [ batch_number, job_args ]; chain end args are [ job_args ].
-				$job_args = end( $action_args );
-				if ( is_array( $job_args ) && (string) ( $job_args[ self::ARG_CYCLE_ID ] ?? '' ) === $cycle_id ) {
-					return true;
-				}
-			}
+
+				$action_count = count( $actions );
+				$offset      += $per_page;
+			} while ( $action_count === $per_page );
 		}
 
 		return false;

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\Pinterest\Exception\FeedFileOperationsException;
 use Automattic\WooCommerce\Pinterest\Notes\FeedCircuitBreakerNote;
 use Automattic\WooCommerce\Pinterest\Utilities\ProductFeedLogger;
 use ActionScheduler;
+use ActionScheduler_Action;
 use Exception;
 use Pinterest_For_Woocommerce;
 use Throwable;
@@ -33,6 +34,22 @@ class FeedGenerator extends AbstractChainedJob {
 	use ProductFeedLogger;
 
 	const ACTION_START_FEED_GENERATOR = PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-start-feed-generation';
+
+	/**
+	 * The job args key carrying the generation cycle ID through the action chain.
+	 */
+	const ARG_CYCLE_ID = 'cycle_id';
+
+	/**
+	 * The data key storing the ID of the current (authoritative) generation cycle.
+	 */
+	const DATA_CYCLE_ID = 'feed_generation_cycle_id';
+
+	/**
+	 * How soon (in seconds) an already pending start action must fire for
+	 * mark_feed_dirty() to skip scheduling another immediate start.
+	 */
+	const START_DEBOUNCE_WINDOW = 5 * MINUTE_IN_SECONDS;
 
 	/**
 	 * The time in seconds to wait after a failed feed generation attempt,
@@ -157,6 +174,23 @@ class FeedGenerator extends AbstractChainedJob {
 
 		// If not Pinterest Feed Generator action - ignore.
 		if ( $hook !== $this->get_action_full_name( self::CHAIN_BATCH ) ) {
+			return;
+		}
+
+		// Do not resurrect a superseded cycle, and do not let its timeout shrink the
+		// current cycle's batch size throttling state.
+		$job_args = ( isset( $args[1] ) && is_array( $args[1] ) ) ? $args[1] : array();
+		if ( $this->is_stale_cycle( $job_args ) ) {
+			self::log(
+				sprintf(
+					// Translators: Action Scheduler hook name.
+					__(
+						'Feed Generator `%s` Action from a superseded generation cycle timed out. Not rescheduling.',
+						'pinterest-for-woocommerce'
+					),
+					$hook
+				)
+			);
 			return;
 		}
 
@@ -320,6 +354,44 @@ class FeedGenerator extends AbstractChainedJob {
 	}
 
 	/**
+	 * Handles the job chain start action.
+	 *
+	 * Overrides the framework handler to enforce a hard cap of one active generation
+	 * cycle. If the current cycle still has live (pending or in-progress) chain
+	 * actions, the start is skipped and the feed is marked dirty instead — the active
+	 * cycle picks the flag up in handle_end() and triggers the regeneration. Only when
+	 * the current cycle is dead or absent does the start mint a new cycle ID and take
+	 * over. The ID is stamped into the job args and propagates through every action in
+	 * the chain, so any still-scheduled action from an older cycle aborts instead of
+	 * writing to the feed files or the shared cursor.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $args The args for the job.
+	 *
+	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
+	 */
+	public function handle_start_action( array $args ) {
+		if ( $this->is_current_cycle_alive() ) {
+			Pinterest_For_Woocommerce::save_data( 'feed_dirty', true );
+			self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
+			return;
+		}
+
+		// Mint the new cycle before truncating the temporary files: from this moment
+		// any still-scheduled action from an older cycle self-terminates.
+		$cycle_id = wp_generate_uuid4();
+		Pinterest_For_Woocommerce::save_data( self::DATA_CYCLE_ID, $cycle_id );
+		$args[ self::ARG_CYCLE_ID ] = $cycle_id;
+
+		/* translators: feed generation cycle ID */
+		self::log( sprintf( __( 'Starting feed generation cycle `%s`.', 'pinterest-for-woocommerce' ), $cycle_id ) );
+
+		$this->handle_start();
+		$this->queue_batch( 1, $args );
+	}
+
+	/**
 	 * Handle processing a chain batch.
 	 *
 	 * @since 1.2.14
@@ -330,6 +402,19 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to issue possible when creating an empty feed temp file and populating the header.
 	 */
 	public function handle_batch_action( int $batch_number, array $args ) {
+		if ( $this->is_stale_cycle( $args ) ) {
+			// A newer cycle owns the feed files and the shared cursor. Abort quietly:
+			// no processing, no successor action, no throttling state changes.
+			self::log(
+				sprintf(
+					// Translators: batch number.
+					__( 'Feed Generator batch #%d belongs to a superseded generation cycle. Skipping.', 'pinterest-for-woocommerce' ),
+					$batch_number
+				)
+			);
+			return;
+		}
+
 		// Reset pending cursor to prevent stale values from previous failed batches.
 		$this->pending_last_batch_id = null;
 
@@ -338,6 +423,28 @@ class FeedGenerator extends AbstractChainedJob {
 		// Reset number of products per batch and action retries counter on success.
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_size' );
 		Pinterest_For_Woocommerce::remove_data( 'feed_product_batch_attempt' );
+	}
+
+	/**
+	 * Handles the job chain end action.
+	 *
+	 * Overrides the framework handler to validate the cycle ID: a stale chain end
+	 * must not publish (rename) the temporary file that now belongs to the cycle
+	 * which superseded it, nor mark the feed as generated.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $args The args for the job.
+	 *
+	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
+	 */
+	public function handle_end_action( array $args ) {
+		if ( $this->is_stale_cycle( $args ) ) {
+			self::log( __( 'Feed Generator end action belongs to a superseded generation cycle. Skipping.', 'pinterest-for-woocommerce' ) );
+			return;
+		}
+
+		parent::handle_end_action( $args );
 	}
 
 	/**
@@ -560,6 +667,15 @@ class FeedGenerator extends AbstractChainedJob {
 			return;
 		}
 
+		// Debounce: if a start action is running right now or already pending to fire
+		// soon, do not reschedule it. The check is time-aware because the recurring
+		// daily start action is effectively always pending (next occurrence within a
+		// day) — only a start due within the debounce window counts as "queued".
+		$next_start = as_next_scheduled_action( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		if ( true === $next_start || ( is_numeric( $next_start ) && (int) $next_start <= time() + self::START_DEBOUNCE_WINDOW ) ) {
+			return;
+		}
+
 		// Start new feed generation cycle now.
 		$this->schedule_next_generator_start( time() );
 	}
@@ -621,6 +737,10 @@ class FeedGenerator extends AbstractChainedJob {
 			)
 		);
 		ProductFeedStatus::mark_feed_file_generation_as_failed();
+
+		// Remove the temporary feed files so failed or aborted cycles do not leave
+		// potentially huge partial feeds on disk. Any retry regenerates from scratch.
+		$this->feed_file_operations->delete_temporary_feed_files();
 
 		if ( $this->is_circuit_breaker_exception( $th ) ) {
 			// Use a live product count rather than the batch-run status cache — the batch
@@ -756,6 +876,89 @@ class FeedGenerator extends AbstractChainedJob {
 	 */
 	protected function set_last_batch_id( int $id ): void {
 		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', $id );
+	}
+
+	/**
+	 * Returns the ID of the current (authoritative) feed generation cycle.
+	 *
+	 * Always reads a fresh value: Action Scheduler may process many chain actions in
+	 * a single long-lived request while a concurrent request supersedes the cycle, so
+	 * the runtime settings cache cannot be trusted here.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Current cycle ID, or an empty string if no cycle has been started yet.
+	 */
+	protected function get_current_cycle_id(): string {
+		return (string) ( Pinterest_For_Woocommerce::get_data( self::DATA_CYCLE_ID, true ) ?? '' );
+	}
+
+	/**
+	 * Checks whether the given job args belong to a superseded generation cycle.
+	 *
+	 * Args without a cycle ID (scheduled by previous plugin versions) are considered
+	 * current as long as no cycle ID has ever been minted, which keeps in-flight
+	 * chains running across a plugin upgrade.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $args The args for the job.
+	 *
+	 * @return bool
+	 */
+	protected function is_stale_cycle( array $args ): bool {
+		$cycle_id = (string) ( $args[ self::ARG_CYCLE_ID ] ?? '' );
+		return $cycle_id !== $this->get_current_cycle_id();
+	}
+
+	/**
+	 * Checks whether the current generation cycle still has live scheduled actions.
+	 *
+	 * A cycle is alive when a pending or in-progress chain batch or chain end action
+	 * carries the current cycle ID. Chain start actions never carry a cycle ID — the
+	 * ID is minted when the start action executes — so queued starts are gated by
+	 * this same check when they run.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	protected function is_current_cycle_alive(): bool {
+		$cycle_id = $this->get_current_cycle_id();
+		if ( '' === $cycle_id ) {
+			return false;
+		}
+
+		$hooks = array(
+			$this->get_action_full_name( self::CHAIN_BATCH ),
+			$this->get_action_full_name( self::CHAIN_END ),
+		);
+
+		foreach ( $hooks as $hook ) {
+			$actions = (array) $this->action_scheduler->search(
+				array(
+					'hook'     => $hook,
+					'status'   => array( ActionSchedulerInterface::STATUS_PENDING, ActionSchedulerInterface::STATUS_RUNNING ),
+					'per_page' => 50,
+				),
+				OBJECT,
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
+			);
+
+			foreach ( $actions as $action ) {
+				if ( ! $action instanceof ActionScheduler_Action ) {
+					continue;
+				}
+				$action_args = $action->get_args();
+				// Chain batch action args are [ batch_number, job_args ]; chain end args are [ job_args ].
+				$job_args = end( $action_args );
+				if ( is_array( $job_args ) && (string) ( $job_args[ self::ARG_CYCLE_ID ] ?? '' ) === $cycle_id ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -41,9 +41,13 @@ class FeedGenerator extends AbstractChainedJob {
 	const ARG_CYCLE_ID = 'cycle_id';
 
 	/**
-	 * The data key storing the ID of the current (authoritative) generation cycle.
+	 * The option storing the ID of the current (authoritative) generation cycle.
+	 *
+	 * Deliberately a dedicated option rather than a key inside the shared plugin
+	 * data option: the shared option is rewritten wholesale by concurrent
+	 * processes, which could clobber the cycle ID with a stale copy.
 	 */
-	const DATA_CYCLE_ID = 'feed_generation_cycle_id';
+	const OPTION_CYCLE_ID = 'pinterest_for_woocommerce_feed_generation_cycle_id';
 
 	/**
 	 * How soon (in seconds) an already pending start action must fire for
@@ -179,6 +183,7 @@ class FeedGenerator extends AbstractChainedJob {
 
 		// Do not resurrect a superseded cycle, and do not let its timeout shrink the
 		// current cycle's batch size throttling state.
+		$this->refresh_data_option_cache();
 		$job_args = ( isset( $args[1] ) && is_array( $args[1] ) ) ? $args[1] : array();
 		if ( $this->is_stale_cycle( $job_args ) ) {
 			self::log(
@@ -372,6 +377,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to creating an empty feed temp file and populating the header possible issues.
 	 */
 	public function handle_start_action( array $args ) {
+		$this->refresh_data_option_cache();
+
 		if ( $this->is_current_cycle_alive() ) {
 			Pinterest_For_Woocommerce::save_data( 'feed_dirty', true );
 			self::log( __( 'Feed generation is already running. Marked the feed dirty to regenerate when the current cycle finishes.', 'pinterest-for-woocommerce' ) );
@@ -381,7 +388,7 @@ class FeedGenerator extends AbstractChainedJob {
 		// Mint the new cycle before truncating the temporary files: from this moment
 		// any still-scheduled action from an older cycle self-terminates.
 		$cycle_id = wp_generate_uuid4();
-		Pinterest_For_Woocommerce::save_data( self::DATA_CYCLE_ID, $cycle_id );
+		update_option( self::OPTION_CYCLE_ID, $cycle_id, false );
 		$args[ self::ARG_CYCLE_ID ] = $cycle_id;
 
 		/* translators: feed generation cycle ID */
@@ -402,6 +409,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to issue possible when creating an empty feed temp file and populating the header.
 	 */
 	public function handle_batch_action( int $batch_number, array $args ) {
+		$this->refresh_data_option_cache();
+
 		if ( $this->is_stale_cycle( $args ) ) {
 			// A newer cycle owns the feed files and the shared cursor. Abort quietly:
 			// no processing, no successor action, no throttling state changes.
@@ -439,6 +448,8 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @throws Throwable Related to adding the footer or renaming the files possible issues.
 	 */
 	public function handle_end_action( array $args ) {
+		$this->refresh_data_option_cache();
+
 		if ( $this->is_stale_cycle( $args ) ) {
 			self::log( __( 'Feed Generator end action belongs to a superseded generation cycle. Skipping.', 'pinterest-for-woocommerce' ) );
 			return;
@@ -815,6 +826,7 @@ class FeedGenerator extends AbstractChainedJob {
 			}
 		}
 		as_unschedule_all_actions( self::ACTION_START_FEED_GENERATOR, array(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
+		delete_option( self::OPTION_CYCLE_ID );
 	}
 
 	/**
@@ -881,16 +893,47 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Returns the ID of the current (authoritative) feed generation cycle.
 	 *
-	 * Always reads a fresh value: Action Scheduler may process many chain actions in
-	 * a single long-lived request while a concurrent request supersedes the cycle, so
-	 * the runtime settings cache cannot be trusted here.
+	 * Reads straight from the database, bypassing both the plugin's runtime settings
+	 * cache and the WordPress options caches: Action Scheduler processes many chain
+	 * actions inside a single long-lived request, and a concurrent request may have
+	 * superseded the cycle after this request's caches were primed.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return string Current cycle ID, or an empty string if no cycle has been started yet.
 	 */
 	protected function get_current_cycle_id(): string {
-		return (string) ( Pinterest_For_Woocommerce::get_data( self::DATA_CYCLE_ID, true ) ?? '' );
+		global $wpdb;
+
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				self::OPTION_CYCLE_ID
+			)
+		);
+
+		return is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * Drops the request-local caches for the plugin options so the next read fetches
+	 * fresh values from the database.
+	 *
+	 * Chain actions are processed by long-lived Action Scheduler runner requests
+	 * whose options caches were primed when the request started. Values written by
+	 * concurrent requests (the shared feed cursor, throttling state, the dirty flag)
+	 * are invisible to those caches, so every chain handler refreshes them before
+	 * acting — otherwise a stale snapshot could be read back and written out again.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	protected function refresh_data_option_cache(): void {
+		wp_cache_delete( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME, 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+		// Re-prime the plugin's static settings cache from the now-fresh options.
+		Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id', true );
 	}
 
 	/**

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1203,6 +1203,46 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Liveness detection must continue past a full first page of stale actions.
+	 *
+	 * @return void
+	 */
+	public function test_start_action_pages_through_all_actions_when_checking_liveness() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
+		update_option( FeedGenerator::OPTION_FEED_DIRTY, 0, false );
+
+		$stale_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'stale-cycle' ) )
+		);
+		$live_action  = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 3, array( FeedGenerator::ARG_CYCLE_ID => 'live-cycle' ) )
+		);
+		$offsets      = array();
+
+		$this->action_scheduler
+			->expects( $this->exactly( 2 ) )
+			->method( 'search' )
+			->willReturnCallback(
+				function ( $args ) use ( $stale_action, $live_action, &$offsets ) {
+					$offsets[] = $args['offset'];
+					return 0 === $args['offset'] ? array_fill( 0, 50, $stale_action ) : array( $live_action );
+				}
+			);
+
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'prepare_temporary_files' );
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$this->assertSame( array( 0, 50 ), $offsets );
+		$this->assertTrue( $this->feed_generator->feed_is_dirty() );
+		$this->assertEquals( 'live-cycle', get_option( FeedGenerator::OPTION_CYCLE_ID ) );
+	}
+
+	/**
 	 * A concurrent start must not inspect liveness or truncate files while another start owns the lock.
 	 *
 	 * @return void

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -991,6 +991,261 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The start action must mint a new cycle ID, persist it as the current cycle and
+	 * stamp it into the args of the first queued batch so it propagates down the chain.
+	 *
+	 * @return void
+	 */
+	public function test_handle_start_action_mints_cycle_id_and_stamps_it_into_batch_args() {
+		$captured_args = null;
+		$this->action_scheduler
+			->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				'pinterest/jobs/generate_feed/chain_batch',
+				$this->callback(
+					function ( $args ) use ( &$captured_args ) {
+						$captured_args = $args;
+						return true;
+					}
+				),
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
+			);
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$current_cycle_id = Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID );
+		$this->assertNotEmpty( $current_cycle_id, 'A cycle ID must be persisted as the current cycle.' );
+		$this->assertSame( 1, $captured_args[0], 'The first queued batch must be batch #1.' );
+		$this->assertSame(
+			$current_cycle_id,
+			$captured_args[1][ FeedGenerator::ARG_CYCLE_ID ] ?? null,
+			'The queued batch args must carry the current cycle ID.'
+		);
+	}
+
+	/**
+	 * A batch action carrying a superseded cycle ID must abort quietly: no processing,
+	 * no successor action, no cursor reset and no throttling state changes.
+	 *
+	 * @return void
+	 */
+	public function test_stale_batch_action_aborts_without_touching_cursor_or_throttling_state() {
+		WC_Helper_Product::create_simple_product();
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 42 );
+		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', 50 );
+		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_attempt', 2 );
+
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'write_buffers_to_temp_files' );
+
+		$this->feed_generator->handle_batch_action( 1, array( FeedGenerator::ARG_CYCLE_ID => 'superseded-cycle' ) );
+
+		// Batch #1 normally resets the cursor to 0 — a stale batch must not.
+		$this->assertEquals( 42, Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' ) );
+		$this->assertEquals( 50, Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
+		$this->assertEquals( 2, Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
+	}
+
+	/**
+	 * A batch action carrying the current cycle ID must process normally and propagate
+	 * the cycle ID to the next queued batch.
+	 *
+	 * @return void
+	 */
+	public function test_current_cycle_batch_action_proceeds_and_propagates_cycle_id() {
+		WC_Helper_Product::create_simple_product();
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+
+		$this->action_scheduler
+			->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				'pinterest/jobs/generate_feed/chain_batch',
+				array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'current-cycle' ) ),
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
+			);
+
+		$this->feed_generator->handle_batch_action( 1, array( FeedGenerator::ARG_CYCLE_ID => 'current-cycle' ) );
+	}
+
+	/**
+	 * A chain end action carrying a superseded cycle ID must not rename the temporary
+	 * file to final nor mark the feed as generated.
+	 *
+	 * @return void
+	 */
+	public function test_stale_end_action_does_not_publish_feed() {
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		ProductFeedStatus::set( array( 'status' => 'in_progress' ) );
+
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'add_footer_to_temporary_feed_files' );
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'rename_temporary_feed_files_to_final' );
+
+		$this->feed_generator->handle_end_action( array( FeedGenerator::ARG_CYCLE_ID => 'superseded-cycle' ) );
+
+		$this->assertNotEquals( 'generated', ProductFeedStatus::get()['status'] );
+	}
+
+	/**
+	 * A chain end action carrying the current cycle ID must publish the feed normally.
+	 *
+	 * @return void
+	 */
+	public function test_current_cycle_end_action_publishes_feed() {
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+
+		$this->feed_file_operations
+			->expects( $this->once() )
+			->method( 'rename_temporary_feed_files_to_final' );
+
+		$this->feed_generator->handle_end_action( array( FeedGenerator::ARG_CYCLE_ID => 'current-cycle' ) );
+
+		$this->assertEquals( 'generated', ProductFeedStatus::get()['status'] );
+	}
+
+	/**
+	 * While the current cycle still has live chain actions, a start action must not
+	 * mint a new cycle nor truncate the temporary files — it must set the dirty flag
+	 * so the active cycle triggers the regeneration when it finishes.
+	 *
+	 * @return void
+	 */
+	public function test_start_action_defers_to_live_current_cycle() {
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'live-cycle' );
+		Pinterest_For_Woocommerce::save_data( 'feed_dirty', false );
+
+		$live_batch_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'live-cycle' ) )
+		);
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturn( array( $live_batch_action ) );
+
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'prepare_temporary_files' );
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$this->assertTrue( (bool) Pinterest_For_Woocommerce::get_data( 'feed_dirty' ) );
+		$this->assertEquals( 'live-cycle', Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID ) );
+	}
+
+	/**
+	 * When the current cycle has no live chain actions left (a dead run), a start
+	 * action must supersede it: mint a new cycle ID and begin a fresh chain.
+	 *
+	 * @return void
+	 */
+	public function test_start_action_supersedes_dead_cycle() {
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'dead-cycle' );
+
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturn( array() );
+
+		$this->feed_file_operations
+			->expects( $this->once() )
+			->method( 'prepare_temporary_files' );
+
+		$captured_args = null;
+		$this->action_scheduler
+			->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with(
+				'pinterest/jobs/generate_feed/chain_batch',
+				$this->callback(
+					function ( $args ) use ( &$captured_args ) {
+						$captured_args = $args;
+						return true;
+					}
+				),
+				PINTEREST_FOR_WOOCOMMERCE_PREFIX
+			);
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$new_cycle_id = Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID );
+		$this->assertNotEquals( 'dead-cycle', $new_cycle_id, 'A dead cycle must be superseded by a new cycle ID.' );
+		$this->assertSame( $new_cycle_id, $captured_args[1][ FeedGenerator::ARG_CYCLE_ID ] ?? null );
+	}
+
+	/**
+	 * A timed out batch from a superseded cycle must not be rescheduled and must not
+	 * shrink the current cycle's batch size throttling state.
+	 *
+	 * @return void
+	 */
+	public function test_handle_unexpected_shutdown_ignores_stale_cycle_timeouts() {
+		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+
+		$action_id = as_schedule_single_action(
+			gmdate( 'U' ) - 1,
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 1, array( FeedGenerator::ARG_CYCLE_ID => 'superseded-cycle' ) ),
+			'pinterest-for-woocommerce'
+		);
+
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+
+		$error = array(
+			'type'    => E_ERROR,
+			'message' => 'Maximum execution time',
+		);
+		$this->feed_generator->handle_unexpected_shutdown( $action_id, $error );
+
+		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
+		$this->assertNull( Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
+	}
+
+	/**
+	 * handle_error() must remove the temporary feed files for generic errors.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_with_generic_exception_deletes_temporary_feed_files() {
+		$this->feed_file_operations
+			->expects( $this->once() )
+			->method( 'delete_temporary_feed_files' );
+
+		$this->invoke_protected( $this->feed_generator, 'handle_error', array( new Exception( 'transient error' ), 'chain_batch' ) );
+	}
+
+	/**
+	 * handle_error() must remove the temporary feed files on the circuit breaker path
+	 * too — it deliberately schedules no retry, so nothing else would clean up.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_with_circuit_breaker_exception_deletes_temporary_feed_files() {
+		$this->feed_file_operations
+			->expects( $this->once() )
+			->method( 'delete_temporary_feed_files' );
+
+		$this->invoke_protected(
+			$this->feed_generator,
+			'handle_error',
+			array( new FeedCircuitBreakerException( 'limit reached' ), 'chain_batch' )
+		);
+	}
+
+	/**
 	 * Action Scheduler's queue runner catches the original Throwable and re-throws a generic
 	 * Exception, exposing the original only via getPrevious(). handle_error must still detect
 	 * the circuit breaker through the exception chain — to add the note and skip the retry.

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1014,7 +1014,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_start_action( array() );
 
-		$current_cycle_id = Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID );
+		$current_cycle_id = get_option( FeedGenerator::OPTION_CYCLE_ID );
 		$this->assertNotEmpty( $current_cycle_id, 'A cycle ID must be persisted as the current cycle.' );
 		$this->assertSame( 1, $captured_args[0], 'The first queued batch must be batch #1.' );
 		$this->assertSame(
@@ -1032,7 +1032,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function test_stale_batch_action_aborts_without_touching_cursor_or_throttling_state() {
 		WC_Helper_Product::create_simple_product();
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
 		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 42 );
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', 50 );
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_attempt', 2 );
@@ -1060,7 +1060,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function test_current_cycle_batch_action_proceeds_and_propagates_cycle_id() {
 		WC_Helper_Product::create_simple_product();
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
 
 		$this->action_scheduler
 			->expects( $this->once() )
@@ -1081,7 +1081,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_stale_end_action_does_not_publish_feed() {
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
 		ProductFeedStatus::set( array( 'status' => 'in_progress' ) );
 
 		$this->feed_file_operations
@@ -1102,7 +1102,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_current_cycle_end_action_publishes_feed() {
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
 
 		$this->feed_file_operations
 			->expects( $this->once() )
@@ -1121,7 +1121,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_start_action_defers_to_live_current_cycle() {
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'live-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
 		Pinterest_For_Woocommerce::save_data( 'feed_dirty', false );
 
 		$live_batch_action = new ActionScheduler_Action(
@@ -1142,7 +1142,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->feed_generator->handle_start_action( array() );
 
 		$this->assertTrue( (bool) Pinterest_For_Woocommerce::get_data( 'feed_dirty' ) );
-		$this->assertEquals( 'live-cycle', Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID ) );
+		$this->assertEquals( 'live-cycle', get_option( FeedGenerator::OPTION_CYCLE_ID ) );
 	}
 
 	/**
@@ -1152,7 +1152,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_start_action_supersedes_dead_cycle() {
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'dead-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'dead-cycle', false );
 
 		$this->action_scheduler
 			->method( 'search' )
@@ -1179,7 +1179,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_start_action( array() );
 
-		$new_cycle_id = Pinterest_For_Woocommerce::get_data( FeedGenerator::DATA_CYCLE_ID );
+		$new_cycle_id = get_option( FeedGenerator::OPTION_CYCLE_ID );
 		$this->assertNotEquals( 'dead-cycle', $new_cycle_id, 'A dead cycle must be superseded by a new cycle ID.' );
 		$this->assertSame( $new_cycle_id, $captured_args[1][ FeedGenerator::ARG_CYCLE_ID ] ?? null );
 	}
@@ -1191,7 +1191,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_handle_unexpected_shutdown_ignores_stale_cycle_timeouts() {
-		Pinterest_For_Woocommerce::save_data( FeedGenerator::DATA_CYCLE_ID, 'current-cycle' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
 
 		$action_id = as_schedule_single_action(
 			gmdate( 'U' ) - 1,

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1122,7 +1122,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function test_start_action_defers_to_live_current_cycle() {
 		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
-		Pinterest_For_Woocommerce::save_data( 'feed_dirty', false );
+		update_option( FeedGenerator::OPTION_FEED_DIRTY, 0, false );
 
 		$live_batch_action = new ActionScheduler_Action(
 			'pinterest/jobs/generate_feed/chain_batch',
@@ -1141,7 +1141,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->feed_generator->handle_start_action( array() );
 
-		$this->assertTrue( (bool) Pinterest_For_Woocommerce::get_data( 'feed_dirty' ) );
+		$this->assertTrue( $this->feed_generator->feed_is_dirty() );
 		$this->assertEquals( 'live-cycle', get_option( FeedGenerator::OPTION_CYCLE_ID ) );
 	}
 

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -132,6 +132,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function tearDown(): void {
 		as_unschedule_all_actions( 'pinterest/jobs/generate_feed/chain_batch', null, 'pinterest-for-woocommerce' );
 		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', null, 'pinterest-for-woocommerce' );
+		delete_option( FeedGenerator::OPTION_CURSOR );
 		delete_option( FeedGenerator::OPTION_START_LOCK );
 		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		parent::tearDown();
@@ -642,7 +643,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 */
 	public function test_circuit_breaker_stops_processing_at_max_batches() {
 		$product = WC_Helper_Product::create_simple_product();
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+		$this->invoke_protected( $this->feed_generator, 'set_last_batch_id', array( 0 ) );
 		// Large batch size so the single product falls inside the boundary batch's query.
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', 10000 );
 
@@ -690,22 +691,52 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		WC_Helper_Product::create_simple_product();
 
 		// Set initial cursor.
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 0 );
+		$this->invoke_protected( $this->feed_generator, 'set_last_batch_id', array( 0 ) );
 
 		// Fetch items - this should store pending cursor but not commit it yet.
 		$items = $this->invoke_protected( $this->feed_generator, 'get_items_for_batch', array( 1, array() ) );
 		$this->assertNotEmpty( $items );
 
 		// Cursor should still be at initial value (not advanced yet).
-		$cursor_before = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$cursor_before = $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) );
 		$this->assertEquals( 0, $cursor_before, 'Cursor should not advance before handle_batch_action completes' );
 
 		// Complete batch processing.
 		$this->feed_generator->handle_batch_action( 1, array() );
 
 		// Now cursor should be advanced.
-		$cursor_after = Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' );
+		$cursor_after = $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) );
 		$this->assertGreaterThan( $cursor_before, $cursor_after, 'Cursor should advance after successful batch completion' );
+	}
+
+	/**
+	 * Cursor writes must not rewrite unrelated values in the shared plugin data option.
+	 *
+	 * @return void
+	 */
+	public function test_cursor_write_uses_a_dedicated_option() {
+		Pinterest_For_Woocommerce::save_data( 'unrelated_value', 'preserved' );
+		$shared_data_before = get_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME );
+
+		$this->invoke_protected( $this->feed_generator, 'set_last_batch_id', array( 321 ) );
+
+		$this->assertSame( $shared_data_before, get_option( PINTEREST_FOR_WOOCOMMERCE_DATA_NAME ) );
+		$this->assertSame( 321, $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) ) );
+	}
+
+	/**
+	 * An in-flight legacy chain must migrate its shared-option cursor without rewinding.
+	 *
+	 * @return void
+	 */
+	public function test_cursor_is_lazily_migrated_from_the_shared_option() {
+		delete_option( FeedGenerator::OPTION_CURSOR );
+		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 73 );
+
+		$this->assertSame( 73, $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) ) );
+
+		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 12 );
+		$this->assertSame( 73, $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) ) );
 	}
 
 	/**
@@ -1059,7 +1090,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function test_stale_batch_action_aborts_without_touching_cursor_or_throttling_state() {
 		WC_Helper_Product::create_simple_product();
 		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
-		Pinterest_For_Woocommerce::save_data( 'feed_last_queued_item_id', 42 );
+		$this->invoke_protected( $this->feed_generator, 'set_last_batch_id', array( 42 ) );
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_size', 50 );
 		Pinterest_For_Woocommerce::save_data( 'feed_product_batch_attempt', 2 );
 
@@ -1073,7 +1104,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->feed_generator->handle_batch_action( 1, array( FeedGenerator::ARG_CYCLE_ID => 'superseded-cycle' ) );
 
 		// Batch #1 normally resets the cursor to 0 — a stale batch must not.
-		$this->assertEquals( 42, Pinterest_For_Woocommerce::get_data( 'feed_last_queued_item_id' ) );
+		$this->assertEquals( 42, $this->invoke_protected( $this->feed_generator, 'get_last_batch_id', array( 2 ) ) );
 		$this->assertEquals( 50, Pinterest_For_Woocommerce::get_data( 'feed_product_batch_size' ) );
 		$this->assertEquals( 2, Pinterest_For_Woocommerce::get_data( 'feed_product_batch_attempt' ) );
 	}

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -381,6 +381,31 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A failure from a superseded cycle must not delete the current cycle's files or change its status.
+	 *
+	 * @return void
+	 */
+	public function test_handle_failed_execution_ignores_stale_cycle_failures() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'current-cycle', false );
+		ProductFeedStatus::set( array( 'status' => 'in_progress' ) );
+
+		$action_id = as_schedule_single_action(
+			gmdate( 'U' ) - 1,
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 1, array( FeedGenerator::ARG_CYCLE_ID => 'superseded-cycle' ) ),
+			'pinterest-for-woocommerce'
+		);
+
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'delete_temporary_feed_files' );
+
+		$this->feed_generator->handle_failed_execution( $action_id, new Exception( 'Stale cycle failure.' ) );
+
+		$this->assertEquals( 'in_progress', ProductFeedStatus::get()['status'] );
+	}
+
+	/**
 	 * Tests that the feed generator reschedules itself when the feed file operations fail with exception.
 	 *
 	 * @return void

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -132,6 +132,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function tearDown(): void {
 		as_unschedule_all_actions( 'pinterest/jobs/generate_feed/chain_batch', null, 'pinterest-for-woocommerce' );
 		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', null, 'pinterest-for-woocommerce' );
+		delete_option( FeedGenerator::OPTION_START_LOCK );
 		Notes::delete_notes_with_name( FeedCircuitBreakerNote::NOTE_NAME );
 		parent::tearDown();
 	}
@@ -1168,6 +1169,36 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 
 		$this->assertTrue( $this->feed_generator->feed_is_dirty() );
 		$this->assertEquals( 'live-cycle', get_option( FeedGenerator::OPTION_CYCLE_ID ) );
+	}
+
+	/**
+	 * A concurrent start must not inspect liveness or truncate files while another start owns the lock.
+	 *
+	 * @return void
+	 */
+	public function test_start_action_defers_while_another_start_holds_the_lock() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'existing-cycle', false );
+		update_option( FeedGenerator::OPTION_FEED_DIRTY, 0, false );
+		update_option(
+			FeedGenerator::OPTION_START_LOCK,
+			( time() + FeedGenerator::START_LOCK_TTL ) . ':other-request',
+			false
+		);
+
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'search' );
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+		$this->feed_file_operations
+			->expects( $this->never() )
+			->method( 'prepare_temporary_files' );
+
+		$this->feed_generator->handle_start_action( array() );
+
+		$this->assertTrue( $this->feed_generator->feed_is_dirty() );
+		$this->assertEquals( 'existing-cycle', get_option( FeedGenerator::OPTION_CYCLE_ID ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes PIN4WOO-88 (follow-up to PIN4WOO-87 / #1166).

## Problem

Feed generation is a chained Action Scheduler job in which every chain action shares one cursor (`feed_last_queued_item_id`). Two generation runs can overlap because:

1. The framework's `is_running()` only sees its own `chain_start`/`chain_batch` hooks — the plugin's daily `pinterest-for-woocommerce-start-feed-generation` action is invisible to it, so after any dead run every product edit immediately schedules a new start.
2. After a batch dies with a timeout fatal, Action Scheduler marks it failed *before* firing `action_scheduler_unexpected_shutdown`; until the plugin reschedules the retry there are zero pending/in-progress chain actions, so the "already running" guard in `handle_start_action()` passes for a concurrently claimed start.

An overlapping run's batch #1 resets the shared cursor to 0, so runs rewind each other. On 1.4.27 this produces duplicate items in the feed, truncated feeds silently renamed to final and marked `generated`, and false "maximum batch limit of 1000 reached" circuit-breaker trips (see the wp.org thread "XML Feed Generation never ends" — a ~37k-item store capped at exactly 100,000 items).

## Fix

**1. Cycle identity.** When a start action executes, it mints a cycle ID (`wp_generate_uuid4()`), persists it as the current cycle and stamps it into the job args, which the framework propagates verbatim through the whole chain (`chain_start → chain_batch → … → chain_end`). Every chain handler validates its args' cycle ID against the current one and, when stale, aborts quietly — no processing, no successor action, no error status, no touching the cursor or the batch-size throttling state; just a log line. A stale `chain_end` in particular does **not** rename the tmp file nor set status `generated`. The timeout-retry path (`handle_unexpected_shutdown`) also skips stale actions, so a retry from a superseded cycle neither runs nor shrinks the current cycle's batch size.

Two cache-correctness details proved essential under load (the first stress run failed without them):

- The cycle ID lives in a **dedicated option** (`pinterest_for_woocommerce_feed_generation_cycle_id`), not inside the shared `pinterest_for_woocommerce_data` array — the shared array is rewritten wholesale by concurrent processes and would clobber the ID with a stale copy. It is **read with a direct `$wpdb` query**: Action Scheduler runners are long-lived requests whose `alloptions` cache predates a concurrent supersession, so `get_option()` (and the plugin's `get_data( …, $force )`, which only bypasses the plugin's static cache) would keep serving each process its own cycle as "current".
- The **feed cursor read** (`get_last_batch_id()`) also goes **directly to the database**: the previous batch may have committed the cursor from another process, and that write is invisible to the current request's options caches — a stale read here re-fetches already-written products and duplicates them.
- The **feed dirty flag also moved to a dedicated option** (`pinterest_for_woocommerce_feed_dirty`). `mark_feed_dirty()` runs on every product edit in requests whose options caches are stale; saving the flag through the shared data option rewrote the whole array from that stale snapshot and could rewind the feed cursor mid-generation (reproduced in the second stress run: one edit rolled the cursor back 700 IDs and ~540KB of items were appended twice). With a dedicated option, product edits never touch the shared array at all.

**2. Hard concurrency cap of one active cycle.** `handle_start_action()` first checks whether the current cycle is still genuinely alive — i.e. a pending or in-progress `chain_batch`/`chain_end` action carries the *current* cycle ID. If alive, the start does not begin a new cycle (and does not truncate the tmp file): it sets the dirty flag and returns, so the active run finishes and `handle_end()` triggers a single follow-up regeneration that coalesces all edits made in the meantime. Only when the current cycle is dead or absent does a start mint a new ID and take over. `mark_feed_dirty()` additionally debounces the scheduling side with a time-aware check (a start pending within the next 5 minutes suppresses rescheduling — the naive check would always be truthy because the daily recurring start is effectively always pending). Layering: the debounce is best-effort de-noising, the liveness check stops needless takeovers of a healthy run, and if a start still slips through the post-timeout blind window, part 1's supersession guarantees the old cycle's actions abort on their next execution — under every path at most one cycle actually writes.

**3. Hygiene.** `handle_error()` now deletes the `-tmp.xml` files (new `FeedFileOperations::delete_temporary_feed_files()`), including on the circuit-breaker path which deliberately schedules no retry, so failed/aborted cycles no longer leave multi-hundred-MB partials on disk.

## Updates since the original description (post-review, Aug 18-19)

- **Start serialization is now a real lock.** Cycle starts take an atomic lock in a dedicated option (`pinterest_for_woocommerce_feed_generation_start_lock`) before minting a cycle ID, so two concurrently claimed start actions can no longer both pass the liveness check. A start that cannot take the lock defers, same as deferring to a live cycle.
- **The feed cursor moved to its own option** (`pinterest_for_woocommerce_feed_last_queued_item_id`), out of the shared plugin data array, for the same clobbering reason as the cycle ID and dirty flag. The value is lazily migrated from the shared option on first read, so upgrades need no migration step.
- **The liveness check pages through all scheduled feed actions** instead of inspecting only the first page, so a live cycle cannot be missed behind a page of stale actions.

## Known limitations

- A batch already mid-execution at the moment a new cycle truncates the tmp file can still append its buffer once before it next validates; the residue is bounded to a single batch and is corrected by the next full regeneration.
- Actions scheduled by previous plugin versions carry no cycle ID. They keep running as long as no cycle ID has ever been minted (upgrade compatibility); after the first post-upgrade start they are treated as stale and abort, and the feed is refreshed by that same run.
- In the rare case where a stale pending batch keeps `is_running()` truthy after the current cycle already completed, a product edit only sets the dirty flag and regeneration waits for the next daily start.

## Testing instructions

Unit tests: `vendor/bin/phpunit --filter FeedGeneratorTest` (15 new tests covering cycle-ID propagation, stale batch/end aborts, start deferral vs. takeover, the start lock, cursor option and lazy migration, liveness pagination, stale timeout handling, and tmp cleanup).

Stress repro (wp-env, ~2k products + ~5.2k variations, harness that injects timeout fatals and widens the post-fatal race window — available as a ready-to-use plugin with a wp-admin control page: https://gist.github.com/louwie17/76292fe79b85de637298d331e2f53043 ):

Test with `develop` & this branch to see the difference.
1. Arm `pint_repro_timeout_every=10` and `pint_repro_widen_window=3`.
2. Run 3 parallel web-context Action Scheduler runner loops (`admin-ajax.php?action=pint_repro_run`) while editing a product every ~2 s for ~6 minutes; then disarm and let a clean cycle finish.
3. Before this fix: cursor regressions and a truncated final feed appear within minutes. With this fix: the trace shows no cursor regressions outside legitimate new-cycle starts, stale actions abort with "superseded generation cycle" log lines, and the final feed returns to the healthy size with no duplicate `<g:id>` entries.

### Changelog entry

> Fix - Prevent overlapping feed generation runs from corrupting the product feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dsb33QpwXpKeQe17c65ZEo

