### PR TITLE
Release/1.4.28 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Pinterest for WooCommerce Changelog ***
 
+= 1.4.28 - 2026-08-14 =
+* Tweak - WC 11.1 compatibility.
+
 = 1.4.27 - 2026-06-01 =
 * Add - WooCommerce product_brand to Pinterest feed as `g:brand`.
 * Fix - Align Pinterest checkout value with discounted merchandise line totals.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinterest-for-woocommerce",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pinterest-for-woocommerce",
   "title": "Pinterest for WooCommerce",
   "description": "Pinterest for WooCommerce",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "main": "gulpfile.js",
   "repository": {
     "type": "git",

--- a/pinterest-for-woocommerce.php
+++ b/pinterest-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Pinterest for WooCommerce
  * Plugin URI:        https://woocommerce.com/products/pinterest-for-woocommerce/
  * Description:       Grow your business on Pinterest! Use this official plugin to allow shoppers to Pin products while browsing your store, track conversions, and advertise on Pinterest.
- * Version:           1.4.27
+ * Version:           1.4.28
  * Author:            WooCommerce
  * Author URI:        https://woocommerce.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@
  * Requires PHP: 7.4
  *
  * WC requires at least: 7.0
- * WC tested up to: 10.8
+ * WC tested up to: 11.1
  */
 
 /**
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'PINTEREST_FOR_WOOCOMMERCE_PLUGIN_FILE', __FILE__ );
-define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.27' ); // WRCS: DEFINED_VERSION.
+define( 'PINTEREST_FOR_WOOCOMMERCE_VERSION', '1.4.28' ); // WRCS: DEFINED_VERSION.
 
 // HPOS compatibility declaration.
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 1.4.28 - 2026-08-14 =
+* Tweak - WC 11.1 compatibility.
+
 = 1.4.27 - 2026-06-01 =
 * Add - WooCommerce product_brand to Pinterest feed as `g:brand`.
 * Fix - Align Pinterest checkout value with discounted merchandise line totals.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pinterest, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.4.27
+Stable tag: 1.4.28
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tests/Unit/TrackerSnapshotTest.php
+++ b/tests/Unit/TrackerSnapshotTest.php
@@ -139,6 +139,12 @@ class TrackerSnapshotTest extends \WP_UnitTestCase {
 		TrackerSnapshot::maybe_init();
 		$tracks = apply_filters( 'woocommerce_tracker_data', [] );
 
-		$this->assertTrue( count($tracks) === 0, "Track data should be empty whe OPT-OUT" );
+		// WooCommerce core hooks its own data into this filter unconditionally (the opt-out
+		// gating happens before core invokes the filter), so only assert that this plugin
+		// added nothing rather than expecting the filter result to be completely empty.
+		$this->assertFalse(
+			isset( $tracks['extensions'][ PINTEREST_FOR_WOOCOMMERCE_TRACKER_PREFIX ] ),
+			'Pinterest data should not be tracked when tracking is opted out'
+		);
 	}
 }


### PR DESCRIPTION
This PR merges the changes from [release v1.4.28](https://github.com/woocommerce/pinterest-for-woocommerce/releases/tag/1.4.28) back into `develop`.