### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v1
+        uses: woocommerce/grow/branch-label@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v1
+        uses: woocommerce/grow/eslint-annotation@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --format ./eslintFormatter.cjs
@@ -49,12 +49,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v1
+        uses: woocommerce/grow/stylelint-annotation@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare PHP ${{ matrix.php }}
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           php-version: ${{ matrix.php }}
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -38,12 +38,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           php-version: "${{ matrix.php }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
+        uses: woocommerce/grow/prepare-mysql@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
 
       - name: Install WP tests
         shell: bash

--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -16,4 +16,4 @@ jobs:
     name: Automerge released trunk
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/automerge-released-trunk@actions-v1
+      - uses: woocommerce/grow/automerge-released-trunk@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        uses: woocommerce/grow/prepare-extension-release@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
         with:
           php-version: "${{ matrix.php }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
+        uses: woocommerce/grow/prepare-mysql@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
 
       - name: Install WP tests
         shell: bash


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce intends to enforce an organization-wide requirement that GitHub Actions references use full-length commit SHAs. This pins 13 external Action references across 8 workflow files while retaining each original version or branch in a trailing comment.

Immutable pins reduce supply-chain compromise risk by preventing a moved or compromised mutable tag or branch from silently changing executed workflow code. Local actions and reusable workflows are unchanged.

### Checks:

- [x] New application tests are not applicable.
- [x] Configuration verification completed successfully.
- [x] Checked for an existing pull request for this branch.

### Detailed test instructions:

1. Re-run the Action-reference check and confirm zero unpinned external references.
2. Parse the changed YAML files.
3. Run `git diff --check` and confirm only `uses:` references changed.

### Changelog entry

> None — workflow-only configuration.
