### PR TITLE
Fix scheduled sale pricing in product feeds

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -42,6 +42,7 @@ class ProductsXmlFeed {
 		'g:availability',
 		'g:price',
 		'sale_price',
+		'sale_price_effective_date',
 		'g:mpn',
 		'g:brand',
 		'g:tax',
@@ -516,6 +517,9 @@ class ProductsXmlFeed {
 	 * @return string
 	 */
 	private static function get_property_sale_price( $product, $property ) {
+		if ( ! $product->is_on_sale() ) {
+			return;
+		}
 
 		if ( ! $product->get_parent_id() && method_exists( $product, 'get_variation_sale_price' ) ) {
 			$regular_price = $product->get_variation_regular_price( 'min', true );
@@ -537,6 +541,32 @@ class ProductsXmlFeed {
 		}
 
 		return '<' . $property . '>' . wc_format_decimal( $price, self::get_currency_decimals() ) . get_woocommerce_currency() . '</' . $property . '>';
+	}
+
+	/**
+	 * Returns the effective date interval for an active scheduled sale.
+	 *
+	 * @param WC_Product $product  The product.
+	 * @param string     $property The name of the property.
+	 *
+	 * @return string
+	 */
+	private static function get_property_sale_price_effective_date( $product, $property ) {
+		if ( ! $product->is_on_sale() ) {
+			return;
+		}
+
+		$start_date = $product->get_date_on_sale_from();
+		$end_date   = $product->get_date_on_sale_to();
+
+		if ( ! $start_date || ! $end_date ) {
+			return;
+		}
+
+		$start_date = gmdate( 'Y-m-d\TH:i:s\Z', $start_date->getTimestamp() );
+		$end_date   = gmdate( 'Y-m-d\TH:i:s\Z', $end_date->getTimestamp() );
+
+		return '<' . $property . '>' . $start_date . '/' . $end_date . '</' . $property . '>';
 	}
 
 	/**

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -763,6 +763,9 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( '<sale_price>', ProductsXmlFeed::get_xml_item( $product, 'US' ) );
 
 		$product->set_date_on_sale_from( time() - WEEK_IN_SECONDS );
+		$product->set_date_on_sale_to( null );
+		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $sale_price_method( $product ) );
+
 		$product->set_date_on_sale_to( time() - DAY_IN_SECONDS );
 		$this->assertEquals( '', $sale_price_method( $product ) );
 

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -790,8 +790,14 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 		$this->assertEquals( '', $sale_price_method( $variation ) );
 
 		$variation->set_date_on_sale_from( time() - WEEK_IN_SECONDS );
-		$variation->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
+		$variation->set_date_on_sale_to( null );
+		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $sale_price_method( $variation ) );
+		$this->assertEquals( '', $effective_date_method( $variation ) );
 
+		$variation->set_date_on_sale_to( time() - DAY_IN_SECONDS );
+		$this->assertEquals( '', $sale_price_method( $variation ) );
+
+		$variation->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
 		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $sale_price_method( $variation ) );
 
 		$start_date = gmdate( 'Y-m-d\TH:i:s\Z', $variation->get_date_on_sale_from()->getTimestamp() );

--- a/tests/Unit/FeedXMLGenerationTest.php
+++ b/tests/Unit/FeedXMLGenerationTest.php
@@ -748,6 +748,95 @@ class Pinterest_Test_Feed extends WC_Unit_Test_Case {
 	/**
 	 * @group feed
 	 */
+	public function testScheduledSalePriceXML() {
+		$sale_price_method = $this->getProductsXmlFeedAttributeMethod( 'sale_price' );
+		$product           = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 15,
+				'sale_price'    => 5,
+			)
+		);
+
+		$product->set_date_on_sale_from( time() + WEEK_IN_SECONDS );
+		$this->assertEquals( '', $sale_price_method( $product ) );
+		$this->assertStringNotContainsString( '<sale_price>', ProductsXmlFeed::get_xml_item( $product, 'US' ) );
+
+		$product->set_date_on_sale_from( time() - WEEK_IN_SECONDS );
+		$product->set_date_on_sale_to( time() - DAY_IN_SECONDS );
+		$this->assertEquals( '', $sale_price_method( $product ) );
+
+		$product->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
+		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $sale_price_method( $product ) );
+	}
+
+	/**
+	 * @group feed
+	 */
+	public function testScheduledVariationSalePriceXML() {
+		$sale_price_method     = $this->getProductsXmlFeedAttributeMethod( 'sale_price' );
+		$effective_date_method = $this->getProductsXmlFeedAttributeMethod( 'sale_price_effective_date' );
+		$product               = new WC_Product_Variable();
+		$variable_product      = WC_Helper_Product::create_variation_product( $product );
+		$variation             = wc_get_product( $variable_product->get_children()[0] );
+
+		$variation->set_regular_price( 15 );
+		$variation->set_sale_price( 5 );
+		$variation->set_date_on_sale_from( time() + WEEK_IN_SECONDS );
+
+		$this->assertEquals( '', $sale_price_method( $variation ) );
+
+		$variation->set_date_on_sale_from( time() - WEEK_IN_SECONDS );
+		$variation->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
+
+		$this->assertEquals( '<sale_price>5.00USD</sale_price>', $sale_price_method( $variation ) );
+
+		$start_date = gmdate( 'Y-m-d\TH:i:s\Z', $variation->get_date_on_sale_from()->getTimestamp() );
+		$end_date   = gmdate( 'Y-m-d\TH:i:s\Z', $variation->get_date_on_sale_to()->getTimestamp() );
+		$expected   = '<sale_price_effective_date>' . $start_date . '/' . $end_date . '</sale_price_effective_date>';
+
+		$this->assertEquals( $expected, $effective_date_method( $variation ) );
+	}
+
+	/**
+	 * @group feed
+	 */
+	public function testPropertySalePriceEffectiveDateXML() {
+		$effective_date_method = $this->getProductsXmlFeedAttributeMethod( 'sale_price_effective_date' );
+		$product               = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => 15,
+				'sale_price'    => 5,
+			)
+		);
+
+		$this->assertEquals( '', $effective_date_method( $product ) );
+
+		$product->set_date_on_sale_from( time() + DAY_IN_SECONDS );
+		$product->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
+		$this->assertEquals( '', $effective_date_method( $product ) );
+
+		$product->set_date_on_sale_from( time() - WEEK_IN_SECONDS );
+		$product->set_date_on_sale_to( null );
+		$this->assertEquals( '', $effective_date_method( $product ) );
+
+		$product->set_date_on_sale_to( time() - DAY_IN_SECONDS );
+		$this->assertEquals( '', $effective_date_method( $product ) );
+
+		$product->set_date_on_sale_to( time() + WEEK_IN_SECONDS );
+
+		$start_date = gmdate( 'Y-m-d\TH:i:s\Z', $product->get_date_on_sale_from()->getTimestamp() );
+		$end_date   = gmdate( 'Y-m-d\TH:i:s\Z', $product->get_date_on_sale_to()->getTimestamp() );
+		$expected   = '<sale_price_effective_date>' . $start_date . '/' . $end_date . '</sale_price_effective_date>';
+
+		$this->assertEquals( $expected, $effective_date_method( $product ) );
+		$this->assertStringContainsString( $expected, ProductsXmlFeed::get_xml_item( $product, 'US' ) );
+	}
+
+	/**
+	 * @group feed
+	 */
 	public function testPropertyPriceVariableProductXML() {
 		$price_method      = $this->getProductsXmlFeedAttributeMethod( 'g:price' );
 		$product           = new WC_Product_Variable();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR prevents future and expired scheduled sale prices from being exported as active `sale_price` values. To detect sale price schedule, it uses WooCommerce’s schedule-aware `is_on_sale()` state for simple products and variations.

Moreover, it adds a `sale_price_effective_date` for active sales with defined start and end dates in UTC ISO 8601 format, as described in [Pinterest documentation](https://help.pinterest.com/en/business/article/before-you-get-started-with-catalogs).
 
Finally, it adds regression coverage for future, active, expired, partial, and variation sale schedules.

Closes PIN4WOO-92


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a Simple Product with a Sale price.
2. Save it.
3. Go to Marketing > Pinterest and wait for a new XML file to be generated. run `wp action-scheduler run --group=pinterest-for-woocommerce --force` to run the AS actions to generate the feed.
4. Ensure that the product shows up with a `<sale_price>` in the XML. 
5. Re-edit the product and set a sale date in the future. 
6. Ensure that the product shows up without a `<sale_price>` in the XML.
7. Re-edit the product and set a sale date that covers the present date.
8. Ensure that the product shows up with a `<sale_price>` in the XML, and with a `<sale_price_effective_date>`.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fixed scheduled sale pricing in product feeds.
