### PR TITLE
Add external and click IDs to Pinterest Tag and CAPI events

### DIFF
--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -222,7 +222,7 @@ class Conversions extends Tracker {
 		}
 
 		$session = function_exists( 'WC' ) && isset( WC()->session ) ? WC()->session : false;
-		if ( ! empty( $click_id ) ) {
+		if ( false !== $click_id && '' !== $click_id ) {
 			if ( $session ) {
 				$session->set( self::CLICK_ID_SESSION_KEY, $click_id );
 			}

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -24,6 +24,13 @@ use Throwable;
  */
 class Conversions extends Tracker {
 
+	/**
+	 * Session key used to persist the Pinterest click ID.
+	 *
+	 * @var string
+	 */
+	private const CLICK_ID_SESSION_KEY = 'pinterest_for_woocommerce_click_id';
+
 	/** @var User $user User data object. Data for Conversions API. */
 	private $user;
 
@@ -126,6 +133,16 @@ class Conversions extends Tracker {
 			$data['user_data']['em'] = array( $email );
 		}
 
+		$external_id = self::maybe_get_hashed_customer_external_id();
+		if ( false !== $external_id ) {
+			$data['user_data']['external_id'] = array( $external_id );
+		}
+
+		$click_id = self::maybe_get_click_id();
+		if ( false !== $click_id ) {
+			$data['user_data']['click_id'] = $click_id;
+		}
+
 		return $data;
 	}
 
@@ -183,6 +200,43 @@ class Conversions extends Tracker {
 			$user_email       = $session_customer ? $session_customer['email'] : '';
 		}
 		return $user_email ? hash( 'sha256', $user_email ) : false;
+	}
+
+	/**
+	 * Returns the Pinterest click ID for the current visitor.
+	 *
+	 * The landing-page `epik` parameter is the freshest source. Pinterest's
+	 * `_epik` cookie and the WooCommerce session retain it for later events.
+	 *
+	 * @return string|false Click ID, or false if it is unavailable.
+	 */
+	private static function maybe_get_click_id() {
+		$click_id = false;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter.
+		if ( isset( $_GET['epik'] ) && is_string( $_GET['epik'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter.
+			$click_id = sanitize_text_field( wp_unslash( $_GET['epik'] ) );
+		} elseif ( isset( $_COOKIE['_epik'] ) && is_string( $_COOKIE['_epik'] ) ) {
+			$click_id = sanitize_text_field( wp_unslash( $_COOKIE['_epik'] ) );
+		}
+
+		$session = function_exists( 'WC' ) && isset( WC()->session ) ? WC()->session : false;
+		if ( ! empty( $click_id ) ) {
+			if ( $session ) {
+				$session->set( self::CLICK_ID_SESSION_KEY, $click_id );
+			}
+
+			return $click_id;
+		}
+
+		if ( ! $session ) {
+			return false;
+		}
+
+		$click_id = $session->get( self::CLICK_ID_SESSION_KEY );
+
+		return is_string( $click_id ) && '' !== $click_id ? $click_id : false;
 	}
 
 	/**

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Tag extends Tracker {
 
-	private const TAG_ID_SLUG       = '%%TAG_ID%%';
-	private const HASHED_EMAIL_SLUG = '%%HASHED_EMAIL%%';
+	private const TAG_ID_SLUG    = '%%TAG_ID%%';
+	private const USER_DATA_SLUG = '%%USER_DATA%%';
 
 	/**
 	 * The base tracking snippet.
@@ -33,15 +33,7 @@ class Tag extends Tracker {
 	 *
 	 * @var string
 	 */
-	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
-
-	/**
-	 * The base tracking snippet with Enchanced match support.
-	 * Documentation: https://help.pinterest.com/en/business/article/enhanced-match
-	 *
-	 * @var string
-	 */
-	private static $base_tag_em = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', '" . self::TAG_ID_SLUG . "', { em: '" . self::HASHED_EMAIL_SLUG . "', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
+	private static $base_tag = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', '" . self::TAG_ID_SLUG . "', " . self::USER_DATA_SLUG . " );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n";
 
 	/**
 	 * The noscript base tracking snippet.
@@ -100,15 +92,25 @@ class Tag extends Tracker {
 	 */
 	public function print_script() {
 		$active_tag = Pinterest_For_Woocommerce()::get_setting( 'tracking_tag' );
-		$email      = Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' )
-			? static::maybe_get_hashed_customer_email()
-			: '';
+		$user_data  = array( 'np' => 'woocommerce' );
 
-		$script = ! empty( $email ) ? self::$base_tag_em : self::$base_tag;
+		if ( Pinterest_For_Woocommerce()::get_setting( 'enhanced_match_support' ) ) {
+			$email       = static::maybe_get_hashed_customer_email();
+			$external_id = static::maybe_get_hashed_customer_external_id();
+
+			if ( ! empty( $email ) ) {
+				$user_data['em'] = $email;
+			}
+
+			if ( false !== $external_id ) {
+				$user_data['external_id'] = $external_id;
+			}
+		}
+
 		$script = str_replace(
-			array( self::TAG_ID_SLUG, self::HASHED_EMAIL_SLUG ),
-			array( sanitize_key( $active_tag ), $email ),
-			$script
+			array( self::TAG_ID_SLUG, self::USER_DATA_SLUG ),
+			array( sanitize_key( $active_tag ), wp_json_encode( $user_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
+			self::$base_tag
 		);
 		//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $script;

--- a/src/Tracking/Tracker.php
+++ b/src/Tracking/Tracker.php
@@ -50,6 +50,19 @@ abstract class Tracker {
 	}
 
 	/**
+	 * Returns a hashed external identifier for the logged-in customer.
+	 *
+	 * @return string|false Hashed customer ID, or false for guests.
+	 */
+	protected static function maybe_get_hashed_customer_external_id() {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		return hash( 'sha256', (string) get_current_user_id() );
+	}
+
+	/**
 	 * Tracks the event.
 	 *
 	 * @since 1.4.0

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -10,10 +10,15 @@ use WP_UnitTestCase;
 class ConversionsTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
-		parent::tearDown();
-
 		remove_all_filters( 'pre_http_request' );
 		wp_set_current_user( 0 );
+		unset( $_GET['epik'], $_COOKIE['_epik'] );
+
+		if ( function_exists( 'WC' ) && isset( WC()->session ) ) {
+			WC()->session->__unset( 'pinterest_for_woocommerce_click_id' );
+		}
+
+		parent::tearDown();
 	}
 
 	public function test_conversions_track_page_visit_event() {
@@ -90,9 +95,9 @@ class ConversionsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that hashed email is merged into default user data.
+	 * Tests that hashed customer identifiers are merged into default user data.
 	 */
-	public function test_default_data_keeps_ip_user_agent_with_logged_in_email() {
+	public function test_default_data_keeps_ip_user_agent_with_logged_in_customer_identifiers() {
 		$user_id = self::factory()->user->create(
 			array(
 				'user_email' => 'customer@example.com',
@@ -110,9 +115,46 @@ class ConversionsTest extends WP_UnitTestCase {
 				'client_ip_address' => 'Some IP address.',
 				'client_user_agent' => 'Some user agent string.',
 				'em'                => array( hash( 'sha256', 'customer@example.com' ) ),
+				'external_id'       => array( hash( 'sha256', (string) $user_id ) ),
 			),
 			$data['user_data']
 		);
+	}
+
+	/**
+	 * Tests that the click ID is captured from the landing URL and persisted.
+	 *
+	 * @return void
+	 */
+	public function test_default_data_uses_and_persists_epik_query_parameter() {
+		$_GET['epik'] = 'pinterest-click-id';
+
+		$user        = new User( 'Some IP address.', 'Some user agent string.' );
+		$conversions = new Conversions( $user );
+		$data        = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+
+		$this->assertSame( 'pinterest-click-id', $data['user_data']['click_id'] );
+		$this->assertSame( 'pinterest-click-id', WC()->session->get( 'pinterest_for_woocommerce_click_id' ) );
+
+		unset( $_GET['epik'] );
+		$data = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-456' ) );
+
+		$this->assertSame( 'pinterest-click-id', $data['user_data']['click_id'] );
+	}
+
+	/**
+	 * Tests that the Pinterest tag cookie supplies the click ID.
+	 *
+	 * @return void
+	 */
+	public function test_default_data_uses_epik_cookie() {
+		$_COOKIE['_epik'] = 'pinterest-cookie-click-id';
+
+		$user        = new User( 'Some IP address.', 'Some user agent string.' );
+		$conversions = new Conversions( $user );
+		$data        = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+
+		$this->assertSame( 'pinterest-cookie-click-id', $data['user_data']['click_id'] );
 	}
 
 	public function test_get_checkout_data() {

--- a/tests/Unit/Tracking/TagTest.php
+++ b/tests/Unit/Tracking/TagTest.php
@@ -28,6 +28,7 @@ class TagTest extends \WP_UnitTestCase {
 
 	public function test_print_script_prints_tag() {
 		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'YU9AOV86F', 'enhanced_match_support' => false ) );
+		wp_set_current_user( $this->factory->user->create() );
 
 		$tag = new Tag();
 
@@ -36,7 +37,7 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', { np: \"woocommerce\" } );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'yu9aov86f', {\"np\":\"woocommerce\"} );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 
@@ -53,7 +54,14 @@ class TagTest extends \WP_UnitTestCase {
 		$script = ob_get_contents();
 		ob_end_clean();
 
-		$expected = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n pintrk('load', 'ju9rag86q', { em: '122dc8b4cb47fa7179db75f0c04b28dd', np: \"woocommerce\" });\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
+		$expected_user_data = wp_json_encode(
+			array(
+				'np'          => 'woocommerce',
+				'em'          => '122dc8b4cb47fa7179db75f0c04b28dd',
+				'external_id' => hash( 'sha256', (string) $user_id ),
+			)
+		);
+		$expected           = "<!-- Pinterest Pixel Base Code -->\n<script type=\"text/javascript\">\n  !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version=\"3.0\";var t=document.createElement(\"script\");t.async=!0,t.src=e;var r=document.getElementsByTagName(\"script\")[0];r.parentNode.insertBefore(t,r)}}(\"https://s.pinimg.com/ct/core.js\");\n\n  pintrk('load', 'ju9rag86q', {$expected_user_data} );\n  pintrk('page');\n</script>\n<!-- End Pinterest Pixel Base Code -->\n<script id=\"pinterest-tag-placeholder\"></script>";
 		$this->assertEquals( $expected, $script );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR adds the missing `external_id` and `click_id` identifiers to Pinterest tracking to improve event matching and attribution.

**External ID**
For logged-in customers, the WordPress user ID is hashed using SHA-256 and included as:
- A string in the Pinterest Tag `pintrk( 'load', ... )` data when Enhanced Match is enabled.
- An array in CAPI `user_data.external_id`, as required by Pinterest’s API schema.

**Click ID**

CAPI now reads the Pinterest click identifier from:
1. The current landing-page `epik` query parameter.
2. The Pinterest `_epik` cookie.
3. The previously persisted WooCommerce session value.

The click ID is stored in the WooCommerce session so subsequent events retain attribution after the epik parameter disappears from the URL.

Resources:
- https://developers.pinterest.com/docs/track-conversions/track-conversions-in-the-api/
- https://developers.pinterest.com/docs/track-conversions/pinterest-tag/

Closes PIN4WOO-93

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect a WooCommerce test site to Pinterest.
2. Enable: Track conversions, Conversions API, Enhanced Match support and Debug Logging.
3. Log in as a customer and visit a product page.
4. Open WooCommerce → Status → Logs and select the `pinterest-for-woocommerce-conversions` log.
5. Confirm that CAPI `user_data.external_id` contains an array with the SHA-256 hash of the WordPress user ID.
6. View the page source and confirm that the Tag’s `pintrk( 'load', ... )` data contains the same hash as a string.
7. Open a fresh incognito window and visit: `https://example.com/product/example/?epik=pin4woo-test-click-123`.
8. Confirm that the PageVisit CAPI payload contains: `"click_id": "pin4woo-test-click-123"`.
9. Remove `epik` from the URL in the same browser session and trigger another event.
10. Confirm that the same `click_id` remains present through WooCommerce session persistence.
11. Log out and confirm that `external_id` is omitted.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Include external and Pinterest click identifiers in Tag and Conversions API events to improve event matching and attribution.
