### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -9,6 +9,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # v0.4.0
         with:

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   SetLabels:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Set Labels
         uses: woocommerce/grow/branch-label@actions-v1

--- a/.github/workflows/build-upload-zip.yml
+++ b/.github/workflows/build-upload-zip.yml
@@ -5,6 +5,7 @@ jobs:
   build_project:
         name: Build and upload
         runs-on: ubuntu-latest
+        timeout-minutes: 5
 
         steps:
 

--- a/.github/workflows/ci-cron-qit.yml
+++ b/.github/workflows/ci-cron-qit.yml
@@ -40,6 +40,7 @@ jobs:
         needs: qit-tests
         name: Handle success
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
@@ -53,6 +54,7 @@ jobs:
       needs: qit-tests
       name: Handle failure
       runs-on: ubuntu-latest
+      timeout-minutes: 5
       env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       steps:

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -42,6 +42,7 @@ jobs:
         needs: qit-tests
         name: Handle success
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
@@ -55,6 +56,7 @@ jobs:
         needs: qit-tests
         name: Handle cancellation
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:
@@ -68,6 +70,7 @@ jobs:
         needs: qit-tests
         name: Handle failure
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         steps:

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -26,6 +26,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -44,6 +45,7 @@ jobs:
   CSSLintingCheck:
     name: Lint CSS
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -25,6 +25,7 @@ jobs:
   UnitTests:
     name: JavaScript unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/manual-ci.yml
+++ b/.github/workflows/manual-ci.yml
@@ -117,6 +117,7 @@ jobs:
     needs: [qit-tests, e2e-tests, php-tests]
     name: Handle success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -130,6 +131,7 @@ jobs:
     needs: [qit-tests, e2e-tests, php-tests]
     name: Handle cancellation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -143,6 +145,7 @@ jobs:
     needs: [qit-tests, e2e-tests, php-tests]
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -25,6 +25,7 @@ jobs:
   UnitTests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"

--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -15,5 +15,6 @@ jobs:
   automerge_trunk:
     name: Automerge released trunk
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: woocommerce/grow/automerge-released-trunk@actions-v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,6 +25,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -20,6 +20,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -78,6 +78,7 @@ jobs:
 
         name: Run QIT Tests
         runs-on: ubuntu-latest
+        timeout-minutes: 35
         steps:
 
           - name: Install QIT via composer

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -14,6 +14,7 @@ jobs:
   php-tests:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"

--- a/.github/workflows/setup-env.yml
+++ b/.github/workflows/setup-env.yml
@@ -6,6 +6,7 @@ jobs:
   setup-node:
     name: Setup NodeJS and Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -31,6 +32,7 @@ jobs:
   setup-php:
     name: Setup PHP and Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `backlog-automation.yml` / `add-to-project` | no successful runs | no successful runs | 5 |
| `branch-labels.yml` / `SetLabels` | 0.1 min | 0.1 min | 5 |
| `build-upload-zip.yml` / `build_project` | 0.9 min | 1.0 min | 5 |
| `ci-cron-qit.yml` / `handle-success` | 0.1 min | 0.1 min | 5 |
| `ci-cron-qit.yml` / `handle-error` | never runs on success | never runs on success | 5 |
| `ci-merge.yml` / `handle-success` | 0.1 min | 0.1 min | 5 |
| `ci-merge.yml` / `handle-cancelled` | never runs on success | never runs on success | 5 |
| `ci-merge.yml` / `handle-error` | never runs on success | never runs on success | 5 |
| `js-css-linting.yml` / `JSLintingCheck` | 0.6 min | 0.7 min | 5 |
| `js-css-linting.yml` / `CSSLintingCheck` | 0.6 min | 0.7 min | 5 |
| `js-unit-tests.yml` / `UnitTests` | 0.9 min | 1.0 min | 5 |
| `manual-ci.yml` / `handle-success` | 0.1 min | 0.1 min | 5 |
| `manual-ci.yml` / `handle-cancelled` | never runs on success | never runs on success | 5 |
| `manual-ci.yml` / `handle-error` | never runs on success | never runs on success | 5 |
| `php-unit-tests.yml` / `UnitTests` | 1.0 min | 2.9 min | 5 |
| `post-release-automerge.yml` / `automerge_trunk` | 0.1 min | 0.1 min | 5 |
| `prepare-release.yml` / `PrepareRelease` | no runs in 30d (0.1 min in 2026-01) | no runs in 30d (0.2 min in 2026-01) | 5 |
| `run-e2e.yml` / `e2e-tests` | no runs in 30d (0.8 min in 2026-03) | no runs in 30d (0.8 min in 2026-03) | 5 |
| `run-qit.yml` / `qit-tests` | 5.1 min | 5.1 min (29.7 min for the full test set in 2026-03) | 35 |
| `run-unit-tests.yml` / `php-tests` | no runs in 30d (same steps as `php-unit-tests.yml`) | no runs in 30d (same steps as `php-unit-tests.yml`) | 5 |
| `setup-env.yml` / `setup-node` | 0.8 min | 0.8 min | 5 |
| `setup-env.yml` / `setup-php` | 0.3 min | 0.3 min | 5 |

The 12 jobs that call a reusable workflow with `uses:` are unchanged, since `timeout-minutes` is not valid on them. Their limits come from the called workflows above.

Part of TESTOPS-272
