### PR TITLE
Fix PageVisit tracking on full-page cache hits

### DIFF
--- a/class-pinterest-for-woocommerce.php
+++ b/class-pinterest-for-woocommerce.php
@@ -27,6 +27,7 @@ use Automattic\WooCommerce\Pinterest\ProductFeedStatus;
 use Automattic\WooCommerce\Pinterest\Tracking;
 use Automattic\WooCommerce\Pinterest\Tracking\Conversions;
 use Automattic\WooCommerce\Pinterest\Tracking\Data\User;
+use Automattic\WooCommerce\Pinterest\Tracking\PageVisit;
 use Automattic\WooCommerce\Pinterest\Tracking\Tag;
 use Automattic\WooCommerce\Pinterest\Utilities\Tracks;
 
@@ -275,6 +276,7 @@ if ( ! class_exists( 'Pinterest_For_Woocommerce' ) ) :
 			add_action( 'wp', array( Pinterest\SaveToPinterest::class, 'maybe_init' ) );
 
 			add_action( 'init', array( $this, 'init' ), 0 );
+			PageVisit::init_hooks();
 
 			// ActionScheduler is activated on init 1 so lets make sure we are updating after that.
 			add_action( 'init', array( $this, 'maybe_update_plugin' ), 5 );

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -89,8 +89,9 @@ class Tracking {
 			return;
 		}
 
-		// Dumy data for when we can't get product data.
-		$data = new None( uniqid( 'page' ) );
+		// The PageVisit event ID is generated in the browser so full-page caches
+		// cannot reuse a PHP-generated ID across multiple visitors.
+		$data = new None( '' );
 
 		// Not a product page.
 		if ( ! is_product() ) {
@@ -105,7 +106,7 @@ class Tracking {
 		}
 
 		$data = new Product(
-			uniqid( 'page' ),
+			'',
 			$product->get_id(),
 			$product->get_name(),
 			wc_get_product_category_list( $product->get_id() ),
@@ -264,6 +265,12 @@ class Tracking {
 			// Skip server-side CAPI dispatch for crawler requests so bot
 			// traffic does not inflate CAPI counts vs Tag counts.
 			if ( $is_crawler && $tracker instanceof Conversions ) {
+				continue;
+			}
+
+			// PageVisit CAPI events are dispatched by the browser beacon so they
+			// also run when the page HTML is served from a full-page cache.
+			if ( static::EVENT_PAGE_VISIT === $event_name && $tracker instanceof Conversions ) {
 				continue;
 			}
 

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -31,16 +31,29 @@ class Conversions extends Tracker {
 	 */
 	private const CLICK_ID_SESSION_KEY = 'pinterest_for_woocommerce_click_id';
 
-	/** @var User $user User data object. Data for Conversions API. */
+	/**
+	 * User data for the Conversions API.
+	 *
+	 * @var User
+	 */
 	private $user;
+
+	/**
+	 * URL where the event occurred.
+	 *
+	 * @var string
+	 */
+	private $event_source_url;
 
 	/**
 	 * Pinterest Conversions API class constructor.
 	 *
-	 * @param User $user User data object to hold ip address and agent string.
+	 * @param User   $user             User data object to hold ip address and agent string.
+	 * @param string $event_source_url Optional URL where the event occurred.
 	 */
-	public function __construct( User $user ) {
-		$this->user = $user;
+	public function __construct( User $user, string $event_source_url = '' ) {
+		$this->user             = $user;
+		$this->event_source_url = $event_source_url;
 	}
 
 	/**
@@ -115,11 +128,13 @@ class Conversions extends Tracker {
 	private function get_default_data( string $event_name ) {
 		global $wp;
 
+		$event_source_url = $this->event_source_url ? $this->event_source_url : home_url( $wp->request );
+
 		$data = array(
 			'event_name'       => $event_name,
 			'action_source'    => 'web',
 			'event_time'       => time(),
-			'event_source_url' => home_url( $wp->request ),
+			'event_source_url' => $event_source_url,
 			'partner_name'     => 'ss-woocommerce',
 			'user_data'        => array(
 				'client_ip_address' => $this->user->get_client_ip_address(),

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -153,7 +153,7 @@ class Conversions extends Tracker {
 			$data['user_data']['external_id'] = array( $external_id );
 		}
 
-		$click_id = self::maybe_get_click_id();
+		$click_id = self::maybe_get_click_id( $this->event_source_url );
 		if ( false !== $click_id ) {
 			$data['user_data']['click_id'] = $click_id;
 		}
@@ -220,20 +220,26 @@ class Conversions extends Tracker {
 	/**
 	 * Returns the Pinterest click ID for the current visitor.
 	 *
-	 * The landing-page `epik` parameter is the freshest source. Pinterest's
-	 * `_epik` cookie and the WooCommerce session retain it for later events.
+	 * The landing-page `epik` parameter is the freshest source. Beacon requests
+	 * carry the landing page as the event source URL, so its query string is
+	 * checked before the current request. Pinterest's `_epik` cookie and the
+	 * WooCommerce session retain the click ID for later events.
+	 *
+	 * @param string $event_source_url Optional URL where the event occurred.
 	 *
 	 * @return string|false Click ID, or false if it is unavailable.
 	 */
-	private static function maybe_get_click_id() {
-		$click_id = false;
+	private static function maybe_get_click_id( string $event_source_url = '' ) {
+		$click_id = self::get_click_id_from_url( $event_source_url );
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter.
-		if ( isset( $_GET['epik'] ) && is_string( $_GET['epik'] ) ) {
+		if ( false === $click_id ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter.
-			$click_id = sanitize_text_field( wp_unslash( $_GET['epik'] ) );
-		} elseif ( isset( $_COOKIE['_epik'] ) && is_string( $_COOKIE['_epik'] ) ) {
-			$click_id = sanitize_text_field( wp_unslash( $_COOKIE['_epik'] ) );
+			if ( isset( $_GET['epik'] ) && is_string( $_GET['epik'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter.
+				$click_id = sanitize_text_field( wp_unslash( $_GET['epik'] ) );
+			} elseif ( isset( $_COOKIE['_epik'] ) && is_string( $_COOKIE['_epik'] ) ) {
+				$click_id = sanitize_text_field( wp_unslash( $_COOKIE['_epik'] ) );
+			}
 		}
 
 		$session = function_exists( 'WC' ) && isset( WC()->session ) ? WC()->session : false;
@@ -252,6 +258,24 @@ class Conversions extends Tracker {
 		$click_id = $session->get( self::CLICK_ID_SESSION_KEY );
 
 		return is_string( $click_id ) && '' !== $click_id ? $click_id : false;
+	}
+
+	/**
+	 * Extracts the Pinterest click ID from the query string of an event source URL.
+	 *
+	 * @param string $event_source_url URL where the event occurred.
+	 *
+	 * @return string|false Click ID, or false if the URL does not carry one.
+	 */
+	private static function get_click_id_from_url( string $event_source_url ) {
+		$query = wp_parse_url( $event_source_url, PHP_URL_QUERY );
+		if ( ! $query ) {
+			return false;
+		}
+
+		wp_parse_str( $query, $params );
+
+		return isset( $params['epik'] ) && is_string( $params['epik'] ) ? sanitize_text_field( $params['epik'] ) : false;
 	}
 
 	/**

--- a/src/Tracking/Conversions.php
+++ b/src/Tracking/Conversions.php
@@ -53,7 +53,7 @@ class Conversions extends Tracker {
 	 */
 	public function __construct( User $user, string $event_source_url = '' ) {
 		$this->user             = $user;
-		$this->event_source_url = $event_source_url;
+		$this->event_source_url = esc_url_raw( $event_source_url, array( 'http', 'https' ) );
 	}
 
 	/**

--- a/src/Tracking/PageVisit.php
+++ b/src/Tracking/PageVisit.php
@@ -60,11 +60,9 @@ class PageVisit {
 		$capi_code  = '';
 
 		if ( Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' ) ) {
-			$product_id = absint( $data['product_id'] ?? 0 );
-			$capi_code  = sprintf(
-				'var requestData=new FormData();requestData.append("action",%1$s);requestData.append("event_id",eventId);requestData.append("event_source_url",window.location.href);requestData.append("product_id",%2$d);var beaconSent=navigator.sendBeacon&&navigator.sendBeacon(%3$s,requestData);if(!beaconSent&&window.fetch){window.fetch(%3$s,{method:"POST",body:requestData,credentials:"same-origin",keepalive:true});}',
+			$capi_code = sprintf(
+				'var requestData=new FormData();requestData.append("action",%1$s);requestData.append("event_id",eventId);requestData.append("event_source_url",window.location.href);var beaconSent=navigator.sendBeacon&&navigator.sendBeacon(%2$s,requestData);if(!beaconSent&&window.fetch){window.fetch(%2$s,{method:"POST",body:requestData,credentials:"same-origin",keepalive:true});}',
 				wp_json_encode( static::AJAX_ACTION ),
-				$product_id,
 				wp_json_encode( admin_url( 'admin-ajax.php' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			);
 		}
@@ -114,9 +112,8 @@ class PageVisit {
 		// This is a public analytics beacon and intentionally is not nonce-gated.
 		$event_id_raw   = $_POST['event_id'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
 		$source_url_raw = $_POST['event_source_url'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
-		$product_id_raw = $_POST['product_id'] ?? '0'; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
 
-		if ( ! is_string( $event_id_raw ) || ! is_string( $source_url_raw ) || ! is_string( $product_id_raw ) ) {
+		if ( ! is_string( $event_id_raw ) || ! is_string( $source_url_raw ) ) {
 			return;
 		}
 
@@ -131,7 +128,7 @@ class PageVisit {
 			return;
 		}
 
-		$product_id = absint( wp_unslash( $product_id_raw ) );
+		$product_id = url_to_postid( $source_url );
 		$data       = static::get_event_data( $event_id, $product_id );
 		$user       = new User( \WC_Geolocation::get_ip_address(), wc_get_user_agent() );
 		$tracker    = new Conversions( $user, $source_url );

--- a/src/Tracking/PageVisit.php
+++ b/src/Tracking/PageVisit.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Cache-safe PageVisit tracking.
+ *
+ * @package Pinterest_For_WooCommerce/Classes/
+ * @version 1.0.0
+ */
+
+namespace Automattic\WooCommerce\Pinterest\Tracking;
+
+use Automattic\WooCommerce\Pinterest\Tracking;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\None;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\Product;
+use Automattic\WooCommerce\Pinterest\Tracking\Data\User;
+use Automattic\WooCommerce\Pinterest\Utilities\CrawlerDetector;
+use Throwable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Generates browser PageVisit events and handles their CAPI beacons.
+ */
+class PageVisit {
+
+	/**
+	 * Public AJAX action used by the PageVisit beacon.
+	 */
+	const AJAX_ACTION = 'pinterest_for_woocommerce_page_visit';
+
+	/**
+	 * Registers the public PageVisit beacon handlers.
+	 *
+	 * The endpoint intentionally has no nonce. A nonce rendered into cacheable
+	 * HTML expires while the cached page remains live, and a logged-out nonce is
+	 * shared by every visitor anyway. The endpoint performs no privileged action,
+	 * accepts only a constrained PageVisit payload, and checks tracking settings
+	 * and consent before forwarding the event.
+	 *
+	 * @return void
+	 */
+	public static function init_hooks() {
+		add_action( 'wp_ajax_' . static::AJAX_ACTION, array( static::class, 'handle_request' ) );
+		add_action( 'wp_ajax_nopriv_' . static::AJAX_ACTION, array( static::class, 'handle_request' ) );
+	}
+
+	/**
+	 * Builds a cache-safe Pinterest Tag call and optional CAPI beacon.
+	 *
+	 * @param array $data Prepared Pinterest Tag PageVisit data.
+	 *
+	 * @return string JavaScript event code.
+	 */
+	public static function get_tag_event_code( array $data ) {
+		unset( $data['event_id'] );
+
+		$event_data = wp_json_encode( $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+		$event_data = $event_data ? $event_data : '{}';
+		$capi_code  = '';
+
+		if ( Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' ) ) {
+			$product_id = absint( $data['product_id'] ?? 0 );
+			$capi_code  = sprintf(
+				'var requestData=new FormData();requestData.append("action",%1$s);requestData.append("event_id",eventId);requestData.append("event_source_url",window.location.href);requestData.append("product_id",%2$d);var beaconSent=navigator.sendBeacon&&navigator.sendBeacon(%3$s,requestData);if(!beaconSent&&window.fetch){window.fetch(%3$s,{method:"POST",body:requestData,credentials:"same-origin",keepalive:true});}',
+				wp_json_encode( static::AJAX_ACTION ),
+				$product_id,
+				wp_json_encode( admin_url( 'admin-ajax.php' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			);
+		}
+
+		return sprintf(
+			'(function(){var eventId="page_"+(window.crypto&&window.crypto.randomUUID?window.crypto.randomUUID():Date.now().toString(36)+"_"+Math.random().toString(36).slice(2));var eventData=%1$s;eventData.event_id=eventId;pintrk("track","%2$s",eventData);%3$s}());',
+			$event_data,
+			Tracking::EVENT_PAGE_VISIT,
+			$capi_code
+		);
+	}
+
+	/**
+	 * Handles a browser-generated PageVisit CAPI beacon.
+	 *
+	 * @return void
+	 */
+	public static function handle_request() {
+		if ( ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions' ) || ! Pinterest_For_Woocommerce()::get_setting( 'track_conversions_capi' ) ) {
+			return;
+		}
+
+		/**
+		 * Filters whether to disable tracking based on user consent.
+		 *
+		 * @since 1.4.21
+		 *
+		 * @param bool $disable_tracking Whether to disable tracking due to user consent.
+		 */
+		$is_tracking_disabled_user_consent = apply_filters( 'woocommerce_pinterest_disable_tracking_user_consent', false );
+
+		/**
+		 * Filters whether to disable tracking.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param bool $disable_tracking Whether to disable tracking based on consent conditions.
+		 */
+		if ( apply_filters( 'woocommerce_pinterest_disable_tracking', $is_tracking_disabled_user_consent ) ) {
+			return;
+		}
+
+		if ( CrawlerDetector::is_crawler_request() ) {
+			return;
+		}
+
+		// This is a public analytics beacon and intentionally is not nonce-gated.
+		$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! preg_match( '/^page_[A-Za-z0-9_-]{10,100}$/', $event_id ) ) {
+			return;
+		}
+
+		$source_url = isset( $_POST['event_source_url'] ) ? esc_url_raw( wp_unslash( $_POST['event_source_url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$source_url = static::validate_source_url( $source_url );
+		if ( ! $source_url ) {
+			return;
+		}
+
+		$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$data       = static::get_event_data( $event_id, $product_id );
+		$user       = new User( \WC_Geolocation::get_ip_address(), wc_get_user_agent() );
+		$tracker    = new Conversions( $user, $source_url );
+
+		try {
+			$tracker->track_event( Tracking::EVENT_PAGE_VISIT, $data );
+		} catch ( Throwable $e ) {
+			// Conversions::track_event() records the failure for support visibility.
+			return;
+		}
+	}
+
+	/**
+	 * Validates that an event source URL belongs to this site.
+	 *
+	 * @param string $source_url Untrusted event source URL.
+	 *
+	 * @return string Valid source URL, or an empty string.
+	 */
+	private static function validate_source_url( string $source_url ) {
+		$source_url  = esc_url_raw( $source_url, array( 'http', 'https' ) );
+		$source_host = wp_parse_url( $source_url, PHP_URL_HOST );
+		$home_host   = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		if ( ! $source_host || ! $home_host || strtolower( $source_host ) !== strtolower( $home_host ) ) {
+			return '';
+		}
+
+		return $source_url;
+	}
+
+	/**
+	 * Builds PageVisit data from the constrained beacon payload.
+	 *
+	 * @param string $event_id  Browser-generated event ID.
+	 * @param int    $product_id Optional product ID.
+	 *
+	 * @return Product|None PageVisit event data.
+	 */
+	private static function get_event_data( string $event_id, int $product_id ) {
+		$product = $product_id ? wc_get_product( $product_id ) : false;
+		if ( ! $product instanceof \WC_Product ) {
+			return new None( $event_id );
+		}
+
+		return new Product(
+			$event_id,
+			$product->get_id(),
+			$product->get_name(),
+			wc_get_product_category_list( $product->get_id() ),
+			'brand',
+			wc_get_price_to_display( $product ),
+			get_woocommerce_currency(),
+			1
+		);
+	}
+}

--- a/src/Tracking/PageVisit.php
+++ b/src/Tracking/PageVisit.php
@@ -55,7 +55,7 @@ class PageVisit {
 	public static function get_tag_event_code( array $data ) {
 		unset( $data['event_id'] );
 
-		$event_data = wp_json_encode( $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+		$event_data = wp_json_encode( (object) $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 		$event_data = $event_data ? $event_data : '{}';
 		$capi_code  = '';
 
@@ -112,18 +112,26 @@ class PageVisit {
 		}
 
 		// This is a public analytics beacon and intentionally is not nonce-gated.
-		$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$event_id_raw   = $_POST['event_id'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
+		$source_url_raw = $_POST['event_source_url'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
+		$product_id_raw = $_POST['product_id'] ?? '0'; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
+
+		if ( ! is_string( $event_id_raw ) || ! is_string( $source_url_raw ) || ! is_string( $product_id_raw ) ) {
+			return;
+		}
+
+		$event_id = sanitize_text_field( wp_unslash( $event_id_raw ) );
 		if ( ! preg_match( '/^page_[A-Za-z0-9_-]{10,100}$/', $event_id ) ) {
 			return;
 		}
 
-		$source_url = isset( $_POST['event_source_url'] ) ? esc_url_raw( wp_unslash( $_POST['event_source_url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$source_url = esc_url_raw( wp_unslash( $source_url_raw ) );
 		$source_url = static::validate_source_url( $source_url );
 		if ( ! $source_url ) {
 			return;
 		}
 
-		$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$product_id = absint( wp_unslash( $product_id_raw ) );
 		$data       = static::get_event_data( $event_id, $product_id );
 		$user       = new User( \WC_Geolocation::get_ip_address(), wc_get_user_agent() );
 		$tracker    = new Conversions( $user, $source_url );

--- a/src/Tracking/Tag.php
+++ b/src/Tracking/Tag.php
@@ -155,6 +155,10 @@ class Tag extends Tracker {
 	 * @return string A generated event call.
 	 */
 	private static function get_event_code( string $event_name, array $data ) {
+		if ( Tracking::EVENT_PAGE_VISIT === $event_name ) {
+			return PageVisit::get_tag_event_code( $data );
+		}
+
 		$data_string = empty( $data ) ? null : wp_json_encode( $data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 		return sprintf(
 			'pintrk( \'track\', \'%s\' %s);',

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -170,6 +170,18 @@ class ConversionsTest extends WP_UnitTestCase {
 		$this->assertSame( $source_url, $data['event_source_url'] );
 	}
 
+	/**
+	 * Invalid explicit source URLs fall back to the current request URL.
+	 */
+	public function test_invalid_explicit_event_source_url_uses_default() {
+		$user        = new User( 'Some IP address.', 'Some user agent string.' );
+		$conversions = new Conversions( $user, 'javascript:alert(1)' );
+
+		$data = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+
+		$this->assertSame( $this->get_event_source_url(), $data['event_source_url'] );
+	}
+
 	public function test_get_checkout_data() {
 		$user        = new User( 'Some IP address.', 'Some user agent string.' );
 		$conversions = new Conversions( $user );

--- a/tests/Unit/Tracking/ConversionsTest.php
+++ b/tests/Unit/Tracking/ConversionsTest.php
@@ -157,6 +157,19 @@ class ConversionsTest extends WP_UnitTestCase {
 		$this->assertSame( 'pinterest-cookie-click-id', $data['user_data']['click_id'] );
 	}
 
+	/**
+	 * The PageVisit beacon can preserve the URL of the cached storefront page.
+	 */
+	public function test_uses_explicit_event_source_url() {
+		$source_url  = home_url( '/cached-product/?campaign=pinterest' );
+		$user        = new User( 'Some IP address.', 'Some user agent string.' );
+		$conversions = new Conversions( $user, $source_url );
+
+		$data = $conversions->prepare_request_data( Tracking::EVENT_PAGE_VISIT, new Data\None( 'event-id-123' ) );
+
+		$this->assertSame( $source_url, $data['event_source_url'] );
+	}
+
 	public function test_get_checkout_data() {
 		$user        = new User( 'Some IP address.', 'Some user agent string.' );
 		$conversions = new Conversions( $user );

--- a/tests/Unit/Tracking/PageVisitTest.php
+++ b/tests/Unit/Tracking/PageVisitTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Automattic\WooCommerce\Pinterest\Tracking;
+
+use Automattic\WooCommerce\Pinterest\Tracking;
+use Pinterest_For_Woocommerce;
+use WC_Helper_Product;
+use WP_UnitTestCase;
+
+/**
+ * Tests for cache-safe PageVisit tracking.
+ */
+class PageVisitTest extends WP_UnitTestCase {
+
+	/**
+	 * Original User-Agent value.
+	 *
+	 * @var string|null
+	 */
+	private $original_user_agent;
+
+	/**
+	 * Original remote address value.
+	 *
+	 * @var string|null
+	 */
+	private $original_remote_address;
+
+	/**
+	 * Set up tracking settings and a human browser request.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Snapshot raw request values for verbatim restoration in tearDown.
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput
+		$this->original_user_agent     = $_SERVER['HTTP_USER_AGENT'] ?? null;
+		$this->original_remote_address = $_SERVER['REMOTE_ADDR'] ?? null;
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0.0.0';
+		$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+		$_POST                      = array();
+
+		Pinterest_For_Woocommerce::save_settings(
+			array(
+				'track_conversions'      => true,
+				'track_conversions_capi' => true,
+				'tracking_advertiser'    => 'PFW-123456789',
+			)
+		);
+	}
+
+	/**
+	 * Restore request globals and filters.
+	 */
+	public function tearDown(): void {
+		$_POST = array();
+		remove_all_filters( 'pre_http_request' );
+
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		if ( null === $this->original_remote_address ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->original_remote_address;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Public beacon hooks are registered for logged-in and logged-out visitors.
+	 */
+	public function test_registers_public_beacon_hooks() {
+		$this->assertNotFalse( has_action( 'wp_ajax_' . PageVisit::AJAX_ACTION, array( PageVisit::class, 'handle_request' ) ) );
+		$this->assertNotFalse( has_action( 'wp_ajax_nopriv_' . PageVisit::AJAX_ACTION, array( PageVisit::class, 'handle_request' ) ) );
+	}
+
+	/**
+	 * The rendered event contains runtime ID generation, not a cached PHP ID.
+	 */
+	public function test_tag_event_code_generates_event_id_in_browser() {
+		$code = PageVisit::get_tag_event_code(
+			array(
+				'event_id'   => 'page_frozen_in_cache',
+				'product_id' => 123,
+			)
+		);
+
+		$this->assertStringNotContainsString( 'page_frozen_in_cache', $code );
+		$this->assertStringContainsString( 'window.crypto.randomUUID', $code );
+		$this->assertStringContainsString( 'eventData.event_id=eventId', $code );
+		$this->assertStringContainsString( 'pintrk("track","PageVisit",eventData)', $code );
+		$this->assertStringContainsString( PageVisit::AJAX_ACTION, $code );
+		$this->assertStringNotContainsString( '_wpnonce', $code );
+	}
+
+	/**
+	 * Tag-only tracking does not add an unnecessary server beacon.
+	 */
+	public function test_tag_event_code_omits_beacon_when_capi_is_disabled() {
+		Pinterest_For_Woocommerce::save_setting( 'track_conversions_capi', false );
+
+		$code = PageVisit::get_tag_event_code( array( 'event_id' => '' ) );
+
+		$this->assertStringContainsString( 'pintrk("track","PageVisit",eventData)', $code );
+		$this->assertStringNotContainsString( PageVisit::AJAX_ACTION, $code );
+		$this->assertStringNotContainsString( 'sendBeacon', $code );
+	}
+
+	/**
+	 * A nonce-free beacon sends one matching PageVisit event to CAPI.
+	 */
+	public function test_beacon_dispatches_page_visit_without_nonce() {
+		$product    = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 25 ) );
+		$source_url = home_url( '/product/cached-product/?campaign=pinterest' );
+		$requests   = 0;
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args ) use ( $product, $source_url, &$requests ) {
+				++$requests;
+				$body  = json_decode( $parsed_args['body'], true );
+				$event = $body['data'][0];
+
+				$this->assertSame( 'page_1234567890abcdef', $event['event_id'] );
+				$this->assertSame( 'page_visit', $event['event_name'] );
+				$this->assertSame( $source_url, $event['event_source_url'] );
+				$this->assertSame( array( (string) $product->get_id() ), $event['custom_data']['content_ids'] );
+
+				return array(
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => wp_json_encode(
+						array(
+							'events' => array( array( 'status' => 'processed' ) ),
+						)
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			2
+		);
+
+		$_POST = array(
+			'event_id'         => 'page_1234567890abcdef',
+			'event_source_url' => $source_url,
+			'product_id'       => (string) $product->get_id(),
+		);
+
+		PageVisit::handle_request();
+
+		$this->assertSame( 1, $requests );
+	}
+
+	/**
+	 * Malformed browser event IDs are rejected before CAPI dispatch.
+	 */
+	public function test_beacon_rejects_invalid_event_id() {
+		$requests = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return false;
+			}
+		);
+
+		$_POST = array(
+			'event_id'         => 'cached-id',
+			'event_source_url' => home_url( '/shop/' ),
+			'product_id'       => '0',
+		);
+
+		PageVisit::handle_request();
+
+		$this->assertSame( 0, $requests );
+	}
+}

--- a/tests/Unit/Tracking/PageVisitTest.php
+++ b/tests/Unit/Tracking/PageVisitTest.php
@@ -107,6 +107,7 @@ class PageVisitTest extends WP_UnitTestCase {
 
 		$code = PageVisit::get_tag_event_code( array( 'event_id' => '' ) );
 
+		$this->assertStringContainsString( 'var eventData={};', $code );
 		$this->assertStringContainsString( 'pintrk("track","PageVisit",eventData)', $code );
 		$this->assertStringNotContainsString( PageVisit::AJAX_ACTION, $code );
 		$this->assertStringNotContainsString( 'sendBeacon', $code );
@@ -182,6 +183,34 @@ class PageVisitTest extends WP_UnitTestCase {
 		);
 
 		PageVisit::handle_request();
+
+		$this->assertSame( 0, $requests );
+	}
+
+	/**
+	 * Non-scalar beacon fields are rejected before sanitization or dispatch.
+	 */
+	public function test_beacon_rejects_non_scalar_fields() {
+		$requests = 0;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$requests ) {
+				++$requests;
+				return false;
+			}
+		);
+
+		$valid_request = array(
+			'event_id'         => 'page_1234567890abcdef',
+			'event_source_url' => home_url( '/shop/' ),
+			'product_id'       => '0',
+		);
+
+		foreach ( array_keys( $valid_request ) as $field ) {
+			$_POST           = $valid_request;
+			$_POST[ $field ] = array( 'invalid' );
+			PageVisit::handle_request();
+		}
 
 		$this->assertSame( 0, $requests );
 	}

--- a/tests/Unit/Tracking/PageVisitTest.php
+++ b/tests/Unit/Tracking/PageVisitTest.php
@@ -96,6 +96,7 @@ class PageVisitTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'eventData.event_id=eventId', $code );
 		$this->assertStringContainsString( 'pintrk("track","PageVisit",eventData)', $code );
 		$this->assertStringContainsString( PageVisit::AJAX_ACTION, $code );
+		$this->assertStringNotContainsString( 'requestData.append("product_id"', $code );
 		$this->assertStringNotContainsString( '_wpnonce', $code );
 	}
 
@@ -117,9 +118,10 @@ class PageVisitTest extends WP_UnitTestCase {
 	 * A nonce-free beacon sends one matching PageVisit event to CAPI.
 	 */
 	public function test_beacon_dispatches_page_visit_without_nonce() {
-		$product    = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 25 ) );
-		$source_url = home_url( '/product/cached-product/?campaign=pinterest' );
-		$requests   = 0;
+		$product         = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 25 ) );
+		$spoofed_product = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 50 ) );
+		$source_url      = add_query_arg( 'campaign', 'pinterest', $product->get_permalink() );
+		$requests        = 0;
 
 		add_filter(
 			'pre_http_request',
@@ -155,7 +157,7 @@ class PageVisitTest extends WP_UnitTestCase {
 		$_POST = array(
 			'event_id'         => 'page_1234567890abcdef',
 			'event_source_url' => $source_url,
-			'product_id'       => (string) $product->get_id(),
+			'product_id'       => (string) $spoofed_product->get_id(),
 		);
 
 		PageVisit::handle_request();
@@ -179,7 +181,6 @@ class PageVisitTest extends WP_UnitTestCase {
 		$_POST = array(
 			'event_id'         => 'cached-id',
 			'event_source_url' => home_url( '/shop/' ),
-			'product_id'       => '0',
 		);
 
 		PageVisit::handle_request();
@@ -188,7 +189,7 @@ class PageVisitTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Non-scalar beacon fields are rejected before sanitization or dispatch.
+	 * Non-scalar required beacon fields are rejected before sanitization or dispatch.
 	 */
 	public function test_beacon_rejects_non_scalar_fields() {
 		$requests = 0;
@@ -203,7 +204,6 @@ class PageVisitTest extends WP_UnitTestCase {
 		$valid_request = array(
 			'event_id'         => 'page_1234567890abcdef',
 			'event_source_url' => home_url( '/shop/' ),
-			'product_id'       => '0',
 		);
 
 		foreach ( array_keys( $valid_request ) as $field ) {
@@ -213,5 +213,54 @@ class PageVisitTest extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( 0, $requests );
+	}
+
+	/**
+	 * A non-product URL produces a generic PageVisit event.
+	 */
+	public function test_beacon_ignores_product_id_for_non_product_url() {
+		$product    = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 25 ) );
+		$page_id    = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$source_url = get_permalink( $page_id );
+		$requests   = 0;
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args ) use ( $source_url, &$requests ) {
+				++$requests;
+				$body  = json_decode( $parsed_args['body'], true );
+				$event = $body['data'][0];
+
+				$this->assertSame( $source_url, $event['event_source_url'] );
+				$this->assertArrayNotHasKey( 'custom_data', $event );
+
+				return array(
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => wp_json_encode(
+						array(
+							'events' => array( array( 'status' => 'processed' ) ),
+						)
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			2
+		);
+
+		$_POST = array(
+			'event_id'         => 'page_1234567890abcdef',
+			'event_source_url' => $source_url,
+			'product_id'       => (string) $product->get_id(),
+		);
+
+		PageVisit::handle_request();
+
+		$this->assertSame( 1, $requests );
 	}
 }

--- a/tests/Unit/Tracking/PageVisitTest.php
+++ b/tests/Unit/Tracking/PageVisitTest.php
@@ -57,6 +57,10 @@ class PageVisitTest extends WP_UnitTestCase {
 		$_POST = array();
 		remove_all_filters( 'pre_http_request' );
 
+		if ( function_exists( 'WC' ) && isset( WC()->session ) ) {
+			WC()->session->__unset( 'pinterest_for_woocommerce_click_id' );
+		}
+
 		if ( null === $this->original_user_agent ) {
 			unset( $_SERVER['HTTP_USER_AGENT'] );
 		} else {
@@ -163,6 +167,53 @@ class PageVisitTest extends WP_UnitTestCase {
 		PageVisit::handle_request();
 
 		$this->assertSame( 1, $requests );
+	}
+
+	/**
+	 * A first landing on `?epik=...` reports the click ID even though the beacon
+	 * request itself carries no query parameter, cookie, or session value yet.
+	 */
+	public function test_beacon_reads_click_id_from_source_url() {
+		$product    = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 25 ) );
+		$source_url = add_query_arg( 'epik', 'landing-click-id', $product->get_permalink() );
+		$requests   = 0;
+
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args ) use ( &$requests ) {
+				++$requests;
+				$body = json_decode( $parsed_args['body'], true );
+
+				$this->assertSame( 'landing-click-id', $body['data'][0]['user_data']['click_id'] );
+
+				return array(
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => wp_json_encode(
+						array(
+							'events' => array( array( 'status' => 'processed' ) ),
+						)
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			2
+		);
+
+		$_POST = array(
+			'event_id'         => 'page_1234567890abcdef',
+			'event_source_url' => $source_url,
+		);
+
+		PageVisit::handle_request();
+
+		$this->assertSame( 1, $requests );
+		$this->assertSame( 'landing-click-id', WC()->session->get( 'pinterest_for_woocommerce_click_id' ) );
 	}
 
 	/**

--- a/tests/Unit/TrackingTest.php
+++ b/tests/Unit/TrackingTest.php
@@ -190,6 +190,33 @@ class TrackingTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * PageVisit CAPI is sent by the browser beacon, not during HTML rendering.
+	 */
+	public function test_page_visit_skips_synchronous_conversions_tracker() {
+		Pinterest_For_Woocommerce::save_settings( array( 'tracking_tag' => 'WD7AFW51GS' ) );
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0';
+
+		$tracking = new Tracking();
+
+		$pinterest_tag_tracker  = $this->createMock( Tag::class );
+		$pinterest_capi_tracker = $this->createMock( Conversions::class );
+
+		$tracking->add_tracker( $pinterest_tag_tracker );
+		$tracking->add_tracker( $pinterest_capi_tracker );
+
+		$data = new None( '' );
+
+		$pinterest_tag_tracker->expects( $this->once() )
+			->method( 'track_event' )
+			->with( Tracking::EVENT_PAGE_VISIT, $data );
+		$pinterest_capi_tracker->expects( $this->never() )
+			->method( 'track_event' );
+
+		$tracking->track_event( Tracking::EVENT_PAGE_VISIT, $data );
+	}
+
+	/**
 	 * The `pinterest_for_woocommerce_is_crawler_request` filter must be able
 	 * to flag an otherwise-human UA as a crawler and skip CAPI.
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Previously, the PageVisit `event_id` was generated in PHP and embedded in the rendered HTML. Full-page caches reused that ID across visitors, while cache hits skipped PHP entirely and therefore never dispatched the matching Conversions API event.

This PR:

- Generates the PageVisit `event_id` in the browser for every page view.
- Uses the same runtime ID for the Pinterest Tag and CAPI event.
- Sends PageVisit CAPI events through a background browser beacon, including on cache hits.
- Prevents synchronous PageVisit CAPI dispatch during HTML rendering, avoiding duplicate events on cache misses.
- Preserves the original storefront URL and the visitor’s current IP address and User-Agent.
- Rebuilds product data server-side from the constrained `product_id`.
- Respects tracking settings, consent filters, and crawler detection.
- Validates the event ID and requires the event source URL to belong to the store.
- Intentionally does not use a nonce for the public tracking beacon. Anonymous nonces embedded in cached HTML eventually expire and do not provide meaningful authorization because every logged-out visitor receives the same nonce. The endpoint performs no privileged action or site-state mutation.
- Adds regression tests for runtime ID generation, nonce-free CAPI dispatch, invalid event IDs, source URL preservation, Tag-only tracking, and duplicate prevention.

Closes PIN4WOO-94

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Prerequisites

1. Connect Pinterest and enable Pinterest Tag tracking.
2. Enable Conversions API tracking.
3. Enable debug logging.
4. Enable WP Fastest Cache or another full-page cache.

#### Validate a cache MISS

1. Delete the full-page cache.
2. Open a fresh incognito window on `about:blank`.
3. Open Chrome DevTools → Network.
4. Enable **Preserve log** and leave **Disable cache** unchecked.
5. Visit a product page.
6. Select the document request ("Doc" filter).
8. Open its **Response** tab and search for: `WP Fastest Cache file was created`
9. Record the cache creation timestamp.
10. Filter Network requests for `admin-ajax.php` with action `pinterest_for_woocommerce_page_visit`
11. Record the conversion ID. 

#### Validate a cache HIT
1. Close the incognito window and open a new one. 
2. Open Chrome DevTools → Network.
3. Enable **Preserve log** and leave **Disable cache** unchecked.
4. Visit a product page.
5. Select the document request ("Doc" filter).
6. Open its **Response** tab and search for: `WP Fastest Cache file was created`
7. Ensure that it is the same timestamp as before. 
8. Filter Network requests for `admin-ajax.php` with action `pinterest_for_woocommerce_page_visit`
9. Ensure that a new conversion ID was created. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fix PageVisit tracking on full-page cache hits
