### PR TITLE
Fix AEM configuration for auto-created tags

### DIFF
--- a/src/API/APIV5.php
+++ b/src/API/APIV5.php
@@ -178,6 +178,7 @@ class APIV5 extends Base {
 	 *              @type ?bool $aem_ge_enabled     Whether Automatic Enhanced Match gender is enabled.
 	 *              @type ?bool $aem_db_enabled     Whether Automatic Enhanced Match birthdate is enabled.
 	 *              @type ?bool $aem_loc_enabled    Whether Automatic Enhanced Match location is enabled.
+	 *              @type ?bool $aem_external_id_enabled Whether Automatic Enhanced Match external ID is enabled.
 	 *          }
 	 *      }
 	 * }
@@ -221,6 +222,7 @@ class APIV5 extends Base {
 	 *          @type bool    $aem_ge_enabled      Whether Automatic Enhanced Match gender is enabled.
 	 *          @type bool    $aem_db_enabled      Whether Automatic Enhanced Match birthdate is enabled.
 	 *          @type bool    $aem_loc_enabled     Whether Automatic Enhanced Match location is enabled.
+	 *          @type bool    $aem_external_id_enabled Whether Automatic Enhanced Match external ID is enabled.
 	 *      }
 	 * }
 	 * @throws PinterestApiException Throws 500 exception in case of unexpected error.
@@ -259,6 +261,7 @@ class APIV5 extends Base {
 	 *          @type ?bool $aem_ge_enabled     Whether Automatic Enhanced Match gender is enabled.
 	 *          @type ?bool $aem_db_enabled     Whether Automatic Enhanced Match birthdate is enabled.
 	 *          @type ?bool $aem_loc_enabled    Whether Automatic Enhanced Match location is enabled.
+	 *          @type ?bool $aem_external_id_enabled Whether Automatic Enhanced Match external ID is enabled.
 	 *      }
 	 * }
 	 * @throws PinterestApiException|Exception Throws 500 exception.
@@ -269,14 +272,15 @@ class APIV5 extends Base {
 			"ad_accounts/{$ad_account_id}/conversion_tags",
 			'POST',
 			array(
-				'name'             => $tag_name,
-				'aem_enabled'      => true,
-				'md_frequency'     => 1,
-				'aem_fnln_enabled' => true,
-				'aem_ph_enabled'   => true,
-				'aem_ge_enabled'   => true,
-				'aem_db_enabled'   => true,
-				'ae_loc_enabled'   => true,
+				'name'                    => $tag_name,
+				'aem_enabled'             => true,
+				'md_frequency'            => 1,
+				'aem_fnln_enabled'        => true,
+				'aem_ph_enabled'          => true,
+				'aem_ge_enabled'          => true,
+				'aem_db_enabled'          => true,
+				'aem_loc_enabled'         => true,
+				'aem_external_id_enabled' => true,
 			)
 		);
 	}

--- a/tests/Unit/Api/APIV5Test.php
+++ b/tests/Unit/Api/APIV5Test.php
@@ -31,6 +31,23 @@ class APIV5Test extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			function ( $response, $parsed_args, $url ) {
+				$this->assertSame( 'https://api.pinterest.com/v5/ad_accounts/aai-1234567890/conversion_tags', $url );
+				$this->assertSame( 'POST', $parsed_args['method'] );
+				$this->assertSame(
+					array(
+						'name'                    => 'Some tag name 42',
+						'aem_enabled'             => true,
+						'md_frequency'            => 1,
+						'aem_fnln_enabled'        => true,
+						'aem_ph_enabled'          => true,
+						'aem_ge_enabled'          => true,
+						'aem_db_enabled'          => true,
+						'aem_loc_enabled'         => true,
+						'aem_external_id_enabled' => true,
+					),
+					json_decode( $parsed_args['body'], true )
+				);
+
 				return array(
 					'headers' => array(
 						'content-type' => 'application/json',
@@ -45,13 +62,14 @@ class APIV5Test extends WP_UnitTestCase {
 							'status'             => 'ACTIVE',
 							'version'            => 'v1',
 							'configs' => array(
-								'aem_enabled'      => true,
-								'md_frequency'     => 1,
-								'aem_fnln_enabled' => true,
-								'aem_ph_enabled'   => true,
-								'aem_ge_enabled'   => true,
-								'aem_db_enabled'   => true,
-								'ae_loc_enabled'   => true,
+								'aem_enabled'             => true,
+								'md_frequency'            => 1,
+								'aem_fnln_enabled'        => true,
+								'aem_ph_enabled'          => true,
+								'aem_ge_enabled'          => true,
+								'aem_db_enabled'          => true,
+								'aem_loc_enabled'         => true,
+								'aem_external_id_enabled' => true,
 							),
 						)
 					),
@@ -77,13 +95,14 @@ class APIV5Test extends WP_UnitTestCase {
 		// Check if enhanced match is enabled.
 		$this->assertEquals(
 			array(
-				'aem_enabled'      => true,
-				'md_frequency'     => 1,
-				'aem_fnln_enabled' => true,
-				'aem_ph_enabled'   => true,
-				'aem_ge_enabled'   => true,
-				'aem_db_enabled'   => true,
-				'ae_loc_enabled'   => true,
+				'aem_enabled'             => true,
+				'md_frequency'            => 1,
+				'aem_fnln_enabled'        => true,
+				'aem_ph_enabled'          => true,
+				'aem_ge_enabled'          => true,
+				'aem_db_enabled'          => true,
+				'aem_loc_enabled'         => true,
+				'aem_external_id_enabled' => true,
 			),
 			$output['configs']
 		);

--- a/tests/Unit/Api/TagsTest.php
+++ b/tests/Unit/Api/TagsTest.php
@@ -217,6 +217,26 @@ class TagsTest extends WP_Test_REST_TestCase {
 
 				// 2. POST new tag.
 				if ( 'POST' === $parsed_args['method'] ) {
+					$this->assertSame( 'https://api.pinterest.com/v5/ad_accounts/ai-123456789/conversion_tags', $url );
+
+					$request_body = json_decode( $parsed_args['body'], true );
+					$this->assertArrayHasKey( 'name', $request_body );
+					unset( $request_body['name'] );
+
+					$this->assertSame(
+						array(
+							'aem_enabled'             => true,
+							'md_frequency'            => 1,
+							'aem_fnln_enabled'        => true,
+							'aem_ph_enabled'          => true,
+							'aem_ge_enabled'          => true,
+							'aem_db_enabled'          => true,
+							'aem_loc_enabled'         => true,
+							'aem_external_id_enabled' => true,
+						),
+						$request_body
+					);
+
 					$body = array(
 						'ad_account_id'         => 'ai-123456789',
 						'code_snippet'          => '<!-- Pinterest Tag New -->',
@@ -227,13 +247,14 @@ class TagsTest extends WP_Test_REST_TestCase {
 						'status'                => 'ACTIVE',
 						'version'               => 2,
 						'configs'               => array(
-							'aem_enabled' => false,
-							'md_frequency' => 1,
-							'aem_fnln_enabled' => false,
-							'aem_ph_enabled' => false,
-							'aem_ge_enabled' => false,
-							'aem_db_enabled' => false,
-							'aem_loc_enabled' => false,
+							'aem_enabled'             => true,
+							'md_frequency'            => 1,
+							'aem_fnln_enabled'        => true,
+							'aem_ph_enabled'          => true,
+							'aem_ge_enabled'          => true,
+							'aem_db_enabled'          => true,
+							'aem_loc_enabled'         => true,
+							'aem_external_id_enabled' => true,
 						),
 					);
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1206 

Fix the Automatic Enhanced Match configuration sent when Pinterest for WooCommerce automatically creates a conversion tag.

This PR:

- Adds `aem_external_id_enabled` to enable External ID matching.
- Corrects `ae_loc_enabled` to the documented `aem_loc_enabled` field.
- Updates the conversion-tag response documentation.
- Adds regression coverage that verifies the outgoing tag-creation request and the REST onboarding flow.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. On a new store, install Pinterest for Woo from this branch.
2. Connect Pinterest and select to create a new account/tag combination, if you already have an account.
3. Once connection is completed and a new tag is created, go to the Tag Manager at: `https://ads.pinterest.com/advertiser/<ADS_ID>/conversions/tag/`.
4. Edit the tag and confirm that all the options are enabled.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>  Fix - Fixed AEM configuration for auto-created tags
