### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -9,4 +9,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/branch-label@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -9,4 +9,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/branch-label@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
 
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
 
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare PHP ${{ matrix.php }}
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: ${{ matrix.php }}
 

--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare PHP ${{ matrix.php }}
-        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: ${{ matrix.php }}
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: "${{ matrix.php }}"
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: "${{ matrix.php }}"
 

--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: woocommerce/grow/automerge-released-trunk@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+      - uses: woocommerce/grow/automerge-released-trunk@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3

--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: woocommerce/grow/automerge-released-trunk@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+      - uses: woocommerce/grow/automerge-released-trunk@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-extension-release@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-extension-release@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@f1a6c217ba3b49c18029ebe7761f7be4abe992d7 # actions-v1
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           php-version: "${{ matrix.php }}"
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           php-version: "${{ matrix.php }}"
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Tracking: PIN4WOO-101

- Updates the affected parent actions or reusable workflows to immutable commits whose own remote action dependencies are pinned to full-length SHAs.
- Keeps human-readable version comments beside the SHAs.

This is part of the WooCommerce organization audit for transitive GitHub Action pinning. Shared Grow actions are pinned to the published [actions-v3.0.5 release](https://github.com/woocommerce/grow/releases/tag/actions-v3.0.5) build commit `b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa`. The action trees used here are identical to the reviewed test build from woocommerce/grow#265.

### Detailed test instructions

1. Inspect the changed `uses:` references and confirm every remote action ref is a 40-character commit SHA.
2. Confirm the adjacent comments identify the intended version or upstream pinning PR.
3. Let the affected workflows run through this PR's hosted checks.

Validation already completed:

- Parsed every GitHub workflow and composite action in this repository as YAML.
- Ran `git diff --check`.
- Verified the replacement parent commits resolve through their canonical GitHub repositories.
- Verified their nested remote action dependencies are pinned to full-length SHAs.

### Documentation

- [x] No documentation changes are required.

### Changelog entry

> Dev - Pin GitHub Actions and their nested dependencies to immutable commit SHAs.

**left by Biff (AI agent) on behalf of Darren*

