### PR TITLE
Fix Pinterest Save button not showing up after pagination or filtering

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.js
@@ -25,6 +25,22 @@ window.addEventListener( 'load', function () {
 
 // eslint-disable-next-line @wordpress/no-global-event-listener
 document.addEventListener( 'DOMContentLoaded', function () {
+	// Placeholder markup that pinit.js has not turned into a button yet.
+	const UNBUILT_PIN_SELECTOR =
+		'.pinterest-for-woocommerce-image-wrapper a[data-pin-do]:not([data-pin-log])';
+
+	// pinit.js is loaded async, so it can land after a placeholder appears.
+	const BUILD_RETRY_DELAY = 400;
+	const BUILD_MAX_RETRIES = 5;
+
+	// Class prefix pinit.js writes into the stylesheet it injects at runtime.
+	const PIN_STYLE_PATTERN = /_button_pin/;
+
+	// The router disables stylesheets while it renders, so restore over a
+	// short window rather than a single pass that could land too early.
+	const STYLE_RESTORE_PASSES = 4;
+	const STYLE_RESTORE_DELAY = 200;
+
 	function processWrappers() {
 		document
 			.querySelectorAll( '.pinterest-for-woocommerce-image-wrapper' )
@@ -118,6 +134,120 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		return false;
 	}
 
+	/**
+	 * Whether a node added to the DOM brings a placeholder pinit.js has not
+	 * built yet.
+	 *
+	 * @param {Node} node Added node to inspect.
+	 * @return {boolean} True when the node holds an unbuilt placeholder.
+	 */
+	function containsUnbuiltPin( node ) {
+		if ( node.nodeType !== 1 ) {
+			return false;
+		}
+
+		return (
+			node.matches( UNBUILT_PIN_SELECTOR ) ||
+			!! node.querySelector( UNBUILT_PIN_SELECTOR )
+		);
+	}
+
+	/**
+	 * Re-enable the stylesheet pinit.js injects at runtime.
+	 *
+	 * The Interactivity API router disables every stylesheet that is missing
+	 * from the page it just fetched. The Save button's styles are injected
+	 * into the head by pinit.js after load, so they are never part of a
+	 * server response and get switched off on the first client-side
+	 * navigation, leaving the button as bare "Save" text.
+	 */
+	function restorePinStyles() {
+		document.querySelectorAll( 'style' ).forEach( function ( style ) {
+			if (
+				style.sheet &&
+				style.sheet.disabled &&
+				PIN_STYLE_PATTERN.test( style.textContent )
+			) {
+				style.sheet.disabled = false;
+			}
+		} );
+	}
+
+	let restoreTimer = null;
+	let restorePasses = 0;
+
+	function runRestorePass() {
+		restoreTimer = null;
+		restorePinStyles();
+		restorePasses--;
+
+		if ( restorePasses > 0 ) {
+			restoreTimer = window.setTimeout(
+				runRestorePass,
+				STYLE_RESTORE_DELAY
+			);
+		}
+	}
+
+	function scheduleRestorePinStyles() {
+		restorePasses = STYLE_RESTORE_PASSES;
+
+		if ( restoreTimer ) {
+			return;
+		}
+
+		runRestorePass();
+	}
+
+	let retriesLeft = 0;
+	let retryTimer = null;
+
+	/**
+	 * Ask pinit.js to render the placeholders it has not processed yet.
+	 *
+	 * pinit.js only scans the document when it loads, so markup inserted
+	 * afterwards - client-side pagination, filtering or sorting of the
+	 * Product Collection block, AJAX product grids - keeps its placeholder
+	 * markup and never turns into a button. PinUtils.build() rescans the
+	 * document and skips anything it has already built.
+	 */
+	function buildPins() {
+		retryTimer = null;
+
+		if ( ! document.querySelector( UNBUILT_PIN_SELECTOR ) ) {
+			return;
+		}
+
+		const pinUtils = window.PinUtils;
+
+		if ( pinUtils && typeof pinUtils.build === 'function' ) {
+			try {
+				pinUtils.build();
+			} catch ( error ) {
+				// A failed build must not break the rest of the page.
+			}
+			return;
+		}
+
+		if ( retriesLeft <= 0 ) {
+			return;
+		}
+
+		retriesLeft--;
+		retryTimer = window.setTimeout( buildPins, BUILD_RETRY_DELAY );
+	}
+
+	function scheduleBuildPins() {
+		// Fresh content deserves a fresh budget of attempts.
+		retriesLeft = BUILD_MAX_RETRIES;
+
+		if ( retryTimer ) {
+			return;
+		}
+
+		retryTimer = window.setTimeout( buildPins, 0 );
+	}
+
 	let processScheduled = false;
 
 	function scheduleProcessWrappers() {
@@ -142,11 +272,38 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	// Observe mutations for dynamic elements or asynchronous Pinterest rendering.
 	const observer = new window.MutationObserver( function ( mutations ) {
+		let needsProcess = false;
+		let needsBuild = false;
+
 		for ( const mutation of mutations ) {
-			if ( isPinterestRelatedMutation( mutation ) ) {
-				scheduleProcessWrappers();
+			if ( ! needsProcess && isPinterestRelatedMutation( mutation ) ) {
+				needsProcess = true;
+			}
+
+			if ( ! needsBuild && mutation.type === 'childList' ) {
+				for ( const node of mutation.addedNodes ) {
+					if ( containsUnbuiltPin( node ) ) {
+						needsBuild = true;
+						break;
+					}
+				}
+			}
+
+			if ( needsProcess && needsBuild ) {
 				break;
 			}
+		}
+
+		if ( needsProcess || needsBuild ) {
+			scheduleProcessWrappers();
+			scheduleRestorePinStyles();
+		}
+
+		// Only newly inserted placeholders trigger a rebuild: while pinit.js
+		// works through the initial page it mutates attributes, not nodes, so
+		// we never race its own rendering pass.
+		if ( needsBuild ) {
+			scheduleBuildPins();
 		}
 	} );
 

--- a/assets/source/js/pinterest-for-woocommerce-save-button.test.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.test.js
@@ -38,19 +38,19 @@ function flush( ms = 50 ) {
 	return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
 }
 
-/**
- * Load the script and fire the events it waits for.
- */
-function loadScript() {
-	require( SCRIPT_PATH );
-	document.dispatchEvent( new window.Event( 'DOMContentLoaded' ) );
-}
-
 describe( 'Save to Pinterest button', () => {
-	beforeEach( () => {
-		// The shared preset enables fake timers, which the retry loop needs.
+	// Load the script once: its DOMContentLoaded listener registers a
+	// MutationObserver on the body, and loading it per test would stack one
+	// observer per copy and inflate build() call counts.
+	beforeAll( () => {
+		// The shared preset enables fake timers; switch to real ones so the
+		// MutationObserver callbacks, rAF and retry timers run on their own.
 		jest.useRealTimers();
-		jest.resetModules();
+		require( SCRIPT_PATH );
+		document.dispatchEvent( new window.Event( 'DOMContentLoaded' ) );
+	} );
+
+	beforeEach( () => {
 		document.body.innerHTML = '';
 		document.head
 			.querySelectorAll( 'style' )
@@ -84,7 +84,6 @@ describe( 'Save to Pinterest button', () => {
 		document.body.innerHTML = unbuiltWrapper( 'Save Shirt to Pinterest' );
 		window.PinUtils = { build: jest.fn() };
 
-		loadScript();
 		markAsBuilt(
 			document.querySelector( '.pinterest-for-woocommerce-image-wrapper' )
 		);
@@ -101,11 +100,24 @@ describe( 'Save to Pinterest button', () => {
 		expect( window.PinUtils.build ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'rebuilds when the wrapper itself is the added node', async () => {
+		window.PinUtils = { build: jest.fn() };
+
+		// Some grids append the wrapper directly rather than a parent block.
+		const wrapper = document.createElement( 'div' );
+		wrapper.className = 'pinterest-for-woocommerce-image-wrapper';
+		wrapper.innerHTML =
+			'<span class="screen-reader-text">Save Hoodie to Pinterest</span><a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/"></a>';
+		document.body.appendChild( wrapper );
+		await flush();
+
+		expect( window.PinUtils.build ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'does not rebuild when the added markup holds no unbuilt pin', async () => {
 		document.body.innerHTML = unbuiltWrapper( 'Save Shirt to Pinterest' );
 		window.PinUtils = { build: jest.fn() };
 
-		loadScript();
 		markAsBuilt(
 			document.querySelector( '.pinterest-for-woocommerce-image-wrapper' )
 		);
@@ -120,8 +132,6 @@ describe( 'Save to Pinterest button', () => {
 	} );
 
 	it( 'waits for pinit.js when PinUtils is not available yet', async () => {
-		loadScript();
-
 		const grid = document.createElement( 'div' );
 		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
 		document.body.appendChild( grid );
@@ -135,8 +145,6 @@ describe( 'Save to Pinterest button', () => {
 	} );
 
 	it( 'stops retrying when pinit.js never loads', async () => {
-		loadScript();
-
 		const grid = document.createElement( 'div' );
 		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
 		document.body.appendChild( grid );
@@ -156,8 +164,6 @@ describe( 'Save to Pinterest button', () => {
 		);
 		window.PinUtils = { build: jest.fn() };
 
-		loadScript();
-
 		// The Interactivity API router disables every stylesheet missing from
 		// the page it fetched, including pinit.js's runtime one.
 		pinStyle.sheet.disabled = true;
@@ -170,8 +176,6 @@ describe( 'Save to Pinterest button', () => {
 	it( 'leaves unrelated disabled stylesheets alone', async () => {
 		const otherStyle = addStyle( '.some-theme-thing{color:red}' );
 		window.PinUtils = { build: jest.fn() };
-
-		loadScript();
 
 		otherStyle.sheet.disabled = true;
 		swapInNewPage();
@@ -190,8 +194,6 @@ describe( 'Save to Pinterest button', () => {
 					.forEach( markAsBuilt );
 			} ),
 		};
-
-		loadScript();
 
 		const grid = document.createElement( 'div' );
 		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );

--- a/assets/source/js/pinterest-for-woocommerce-save-button.test.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for the Save to Pinterest button script.
+ *
+ * The script has no exports: requiring it registers the listeners, and the
+ * tests drive it through the DOM the same way a browser would.
+ */
+
+const SCRIPT_PATH = './pinterest-for-woocommerce-save-button';
+
+/**
+ * Markup rendered server side by SaveToPinterest::render_pin().
+ *
+ * @param {string} label Screen reader label.
+ * @return {string} Wrapper markup with an unbuilt Pinterest placeholder.
+ */
+function unbuiltWrapper( label ) {
+	return `<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">${ label }</span><a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/"></a></div>`;
+}
+
+/**
+ * Simulate what pinit.js does to a placeholder once it builds it.
+ *
+ * @param {Element} wrapper Wrapper holding the placeholder.
+ */
+function markAsBuilt( wrapper ) {
+	wrapper
+		.querySelector( 'a[data-pin-do]' )
+		.setAttribute( 'data-pin-log', 'button_pinit' );
+}
+
+/**
+ * Wait long enough for MutationObserver callbacks, rAF and retry timers.
+ *
+ * @param {number} ms Milliseconds to wait.
+ * @return {Promise} Resolves after the delay.
+ */
+function flush( ms = 50 ) {
+	return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+}
+
+/**
+ * Load the script and fire the events it waits for.
+ */
+function loadScript() {
+	require( SCRIPT_PATH );
+	document.dispatchEvent( new window.Event( 'DOMContentLoaded' ) );
+}
+
+describe( 'Save to Pinterest button', () => {
+	beforeEach( () => {
+		// The shared preset enables fake timers, which the retry loop needs.
+		jest.useRealTimers();
+		jest.resetModules();
+		document.body.innerHTML = '';
+		document.head
+			.querySelectorAll( 'style' )
+			.forEach( ( s ) => s.remove() );
+		delete window.PinUtils;
+	} );
+
+	/**
+	 * Stand in for the stylesheet pinit.js injects into the head at runtime.
+	 *
+	 * @param {string} css Stylesheet body.
+	 * @return {HTMLStyleElement} The appended style element.
+	 */
+	function addStyle( css ) {
+		const style = document.createElement( 'style' );
+		style.textContent = css;
+		document.head.appendChild( style );
+		return style;
+	}
+
+	/**
+	 * Add an unbuilt page of products, as a pagination swap would.
+	 */
+	function swapInNewPage() {
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+	}
+
+	it( 'rebuilds pins added to the DOM after the initial render', async () => {
+		document.body.innerHTML = unbuiltWrapper( 'Save Shirt to Pinterest' );
+		window.PinUtils = { build: jest.fn() };
+
+		loadScript();
+		markAsBuilt(
+			document.querySelector( '.pinterest-for-woocommerce-image-wrapper' )
+		);
+		await flush();
+
+		window.PinUtils.build.mockClear();
+
+		// Pagination replaces the product grid with a fresh, unbuilt page.
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+		await flush();
+
+		expect( window.PinUtils.build ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not rebuild when the added markup holds no unbuilt pin', async () => {
+		document.body.innerHTML = unbuiltWrapper( 'Save Shirt to Pinterest' );
+		window.PinUtils = { build: jest.fn() };
+
+		loadScript();
+		markAsBuilt(
+			document.querySelector( '.pinterest-for-woocommerce-image-wrapper' )
+		);
+		await flush();
+
+		window.PinUtils.build.mockClear();
+
+		document.body.appendChild( document.createElement( 'p' ) );
+		await flush();
+
+		expect( window.PinUtils.build ).not.toHaveBeenCalled();
+	} );
+
+	it( 'waits for pinit.js when PinUtils is not available yet', async () => {
+		loadScript();
+
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+		await flush();
+
+		// pinit.js is loaded async/defer, so it can land after the swap.
+		window.PinUtils = { build: jest.fn() };
+		await flush( 500 );
+
+		expect( window.PinUtils.build ).toHaveBeenCalled();
+	} );
+
+	it( 'stops retrying when pinit.js never loads', async () => {
+		loadScript();
+
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+
+		// Long enough for the whole retry budget to be spent.
+		await flush( 2600 );
+
+		window.PinUtils = { build: jest.fn() };
+		await flush( 600 );
+
+		expect( window.PinUtils.build ).not.toHaveBeenCalled();
+	}, 10000 );
+
+	it( 're-enables the Pinterest stylesheet the router switched off', async () => {
+		const pinStyle = addStyle(
+			'.PIN_1788176069676_button_pin{background-image:url(logo.svg)}'
+		);
+		window.PinUtils = { build: jest.fn() };
+
+		loadScript();
+
+		// The Interactivity API router disables every stylesheet missing from
+		// the page it fetched, including pinit.js's runtime one.
+		pinStyle.sheet.disabled = true;
+		swapInNewPage();
+		await flush( 150 );
+
+		expect( pinStyle.sheet.disabled ).toBe( false );
+	} );
+
+	it( 'leaves unrelated disabled stylesheets alone', async () => {
+		const otherStyle = addStyle( '.some-theme-thing{color:red}' );
+		window.PinUtils = { build: jest.fn() };
+
+		loadScript();
+
+		otherStyle.sheet.disabled = true;
+		swapInNewPage();
+		await flush( 150 );
+
+		expect( otherStyle.sheet.disabled ).toBe( true );
+	} );
+
+	it( 'labels pins built after a pagination swap', async () => {
+		window.PinUtils = {
+			build: jest.fn( () => {
+				document
+					.querySelectorAll(
+						'.pinterest-for-woocommerce-image-wrapper'
+					)
+					.forEach( markAsBuilt );
+			} ),
+		};
+
+		loadScript();
+
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapper( 'Save Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+		await flush( 200 );
+
+		const pinLink = document.querySelector( 'a[data-pin-do]' );
+		expect( pinLink.querySelector( '.screen-reader-text' ) ).not.toBeNull();
+		expect( pinLink.getAttribute( 'aria-haspopup' ) ).toBe( 'dialog' );
+	} );
+} );


### PR DESCRIPTION
Fixes #1212

### Problem

On a block theme the Shop page renders through the **Product Collection** block, whose pagination, filtering and sorting update the page with the Interactivity API router rather than a page load. The Save button breaks there in two separate ways.

**1. The button never renders on the new page.**

`pinit.js` scans the document once, when it loads. Placeholders inserted by a client-side update keep their `<a data-pin-do="buttonPin">` markup and never become buttons. This is the reported bug.

Note the markup itself is fine on every page — `woocommerce_before_shop_loop_item` still fires inside blockified templates via `ArchiveProductTemplatesCompatibility`, so the server sends 12 placeholders for page 2 exactly as it does for page 1.

**2. Once rebuilt, the button renders unstyled — plain "Save" text, no Pinterest logo.**

`interactivity-router` disables every stylesheet that is not part of the page it fetched:

```js
var applyStyles = ( styles ) => {
	window.document.querySelectorAll( 'style,link[rel=stylesheet]' ).forEach( ( el ) => {
		if ( el.sheet ) {
			if ( styles.includes( el ) ) { … el.sheet.disabled = false; }
			else { el.sheet.disabled = true; }
		}
	} );
};
```

`pinit.js` injects its widget CSS as a runtime `<style>` in the head, so it is never part of a server response and gets switched off on the first client-side navigation. Measured on a live store: identical class names before and after (`PIN_…_button_pin … _save`), `background-image` going from the logo SVG to `none`, button width 49px → 39px.

### Solution

Both fixes live in `assets/source/js/pinterest-for-woocommerce-save-button.js`, extending the MutationObserver that was already there for the screen-reader labelling.

- When added nodes bring an unbuilt placeholder, call `window.PinUtils.build()`. It skips anything already built, since `pinit.js` drops `data-pin-do` once it renders a button. Bounded retries cover `pinit.js` not having executed yet — it is loaded `async defer` from a CDN.
- Re-enable the disabled Pinterest stylesheet, matched on `_button_pin` in the style element's own text so no other sheet is touched. Run as four passes over 600ms, because the router disables sheets as part of its navigation sequence and a single restore can land too early and be undone.

This covers every client-side Product Collection update, not just pagination: filters, sorting, load-more, and the search/category/tag/brand archives.

### Testing instructions

Needs a **block theme** (TT4 or similar) so the Shop page uses Product Collection, a connected Pinterest account with **Save to Pinterest** enabled, and enough products for several pages.

> [!IMPORTANT]
> The script is enqueued with `PINTEREST_FOR_WOOCOMMERCE_VERSION`, which does not change between builds, so your browser will serve the cached bundle and you will test the old code. Either tick **Disable cache** in the DevTools Network tab, or temporarily change `time()` into the version argument in `SaveToPinterest::enqueue_scripts()`:
>
> ```php
> wp_enqueue_script(
> 	PINTEREST_FOR_WOOCOMMERCE_PREFIX . '-save-button',
> 	Pinterest_For_Woocommerce()->plugin_url() . '/assets/js/pinterest-for-woocommerce-save-button' . $ext . '.js',
> 	array(),
> 	time(), // Dev only — deliberately not part of this PR.
> 	true
> );
> ```
>
> This is intentionally **not** committed: it would disable caching for every visitor. Revert it before reviewing the final diff.

1. `npm run build` (or `npx gulp js`) so `assets/js/` picks up the source change.
2. Open the Shop page. Hover a product with a featured image — the Save button shows with the red Pinterest logo.
3. Click through to page 2 **without reloading**.
4. Hover a product with a featured image. **Expected:** the Save button appears and is styled identically to page 1. **Before this PR:** no button at all.
5. Repeat with a sort change and, if the collection has filters, a filter change.
6. Confirm a full page load of `/shop/page/2/` still behaves as before.

Run the unit tests with `npm run test:js`. Eight cases cover this file: the rebuild trigger, the wrapper itself being the added node, the no-op case, the retry when `PinUtils` is late, giving up when `pinit.js` never loads, the stylesheet restore, leaving unrelated stylesheets alone, and the screen-reader labelling surviving a swap.

### Out of scope

- **Duplicate screen-reader text after a navigation.** Preact reuses the `.screen-reader-text` spans while `processWrappers()` relocates them inside the anchor, so reconciliation can pair a span with the wrong product. A real accessibility defect, worth its own issue and fix.

### Changelog entry

> Fix - Save button does not render after pagination or filtering.


