### PR TITLE
Gate feed generation start on the current cycle

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -346,10 +346,17 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Start the queue processing.
 	 *
+	 * Gates on the current cycle rather than is_running(): a still-pending batch action
+	 * from a superseded cycle must not prevent a new cycle from starting.
+	 *
 	 * @since 1.0.10
 	 */
 	private function start_generation() {
-		if ( $this->is_running() ) {
+		if ( $this->action_scheduler->next_scheduled_action( $this->get_action_full_name( self::CHAIN_START ), null, $this->get_group_name() ) ) {
+			return;
+		}
+
+		if ( $this->is_current_cycle_alive() ) {
 			return;
 		}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -707,8 +707,10 @@ class FeedGenerator extends AbstractChainedJob {
 		update_option( self::OPTION_FEED_DIRTY, 1, false );
 		self::log( 'Feed is dirty.' );
 
-		if ( $this->is_running() ) {
-			// New generation will be started at the end of current one.
+		if ( $this->is_current_cycle_alive() ) {
+			// New generation will be started at the end of the current cycle. Gate on the
+			// cycle rather than is_running() so a stale action from a superseded cycle
+			// cannot suppress the restart.
 			return;
 		}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -352,7 +352,12 @@ class FeedGenerator extends AbstractChainedJob {
 	 * @since 1.0.10
 	 */
 	private function start_generation() {
-		if ( $this->action_scheduler->next_scheduled_action( $this->get_action_full_name( self::CHAIN_START ), null, $this->get_group_name() ) ) {
+		$next_start = $this->action_scheduler->next_scheduled_action(
+			$this->get_action_full_name( self::CHAIN_START ),
+			null,
+			$this->get_group_name()
+		);
+		if ( $next_start ) {
 			return;
 		}
 

--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -346,22 +346,13 @@ class FeedGenerator extends AbstractChainedJob {
 	/**
 	 * Start the queue processing.
 	 *
-	 * Gates on the current cycle rather than is_running(): a still-pending batch action
-	 * from a superseded cycle must not prevent a new cycle from starting.
+	 * Gates on is_generation_active() rather than is_running(): a still-pending batch
+	 * action from a superseded cycle must not prevent a new cycle from starting.
 	 *
 	 * @since 1.0.10
 	 */
 	private function start_generation() {
-		$next_start = $this->action_scheduler->next_scheduled_action(
-			$this->get_action_full_name( self::CHAIN_START ),
-			null,
-			$this->get_group_name()
-		);
-		if ( $next_start ) {
-			return;
-		}
-
-		if ( $this->is_current_cycle_alive() ) {
+		if ( $this->is_generation_active() ) {
 			return;
 		}
 
@@ -707,10 +698,8 @@ class FeedGenerator extends AbstractChainedJob {
 		update_option( self::OPTION_FEED_DIRTY, 1, false );
 		self::log( 'Feed is dirty.' );
 
-		if ( $this->is_current_cycle_alive() ) {
-			// New generation will be started at the end of the current cycle. Gate on the
-			// cycle rather than is_running() so a stale action from a superseded cycle
-			// cannot suppress the restart.
+		if ( $this->is_generation_active() ) {
+			// New generation will be started at the end of the current cycle.
 			return;
 		}
 
@@ -1079,6 +1068,27 @@ class FeedGenerator extends AbstractChainedJob {
 		);
 
 		return is_string( $value ) ? $value : null;
+	}
+
+	/**
+	 * Whether a feed generation is queued or in progress.
+	 *
+	 * True while a chain start action is pending or the current cycle still has live
+	 * batch or end actions. Unlike the framework's is_running(), a leftover action from
+	 * a superseded cycle does not count.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	private function is_generation_active(): bool {
+		$next_start = $this->action_scheduler->next_scheduled_action(
+			$this->get_action_full_name( self::CHAIN_START ),
+			null,
+			$this->get_group_name()
+		);
+
+		return (bool) $next_start || $this->is_current_cycle_alive();
 	}
 
 	/**

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1462,6 +1462,33 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * mark_feed_dirty() must not reschedule the start action while a chain start is
+	 * already queued; that start picks up the dirty flag.
+	 *
+	 * @return void
+	 */
+	public function test_mark_feed_dirty_defers_while_chain_start_pending() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'dead-cycle', false );
+
+		$this->action_scheduler
+			->method( 'next_scheduled_action' )
+			->with( 'pinterest/jobs/generate_feed/chain_start', null, PINTEREST_FOR_WOOCOMMERCE_PREFIX )
+			->willReturn( time() + 10 );
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'search' );
+
+		$this->feed_generator->mark_feed_dirty();
+
+		$this->assertEquals( 1, get_option( FeedGenerator::OPTION_FEED_DIRTY ), 'The feed must still be flagged dirty.' );
+		$this->assertFalse(
+			as_next_scheduled_action( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' ),
+			'A queued chain start must defer the restart.'
+		);
+	}
+
+	/**
 	 * A timed out batch from a superseded cycle must not be rescheduled and must not
 	 * shrink the current cycle's batch size throttling state.
 	 *

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1381,6 +1381,8 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_start_generation_defers_while_chain_start_pending() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'dead-cycle', false );
+
 		$this->action_scheduler
 			->method( 'next_scheduled_action' )
 			->with( 'pinterest/jobs/generate_feed/chain_start', null, PINTEREST_FOR_WOOCOMMERCE_PREFIX )

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1398,6 +1398,70 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * mark_feed_dirty() must reschedule the start action when only actions from a
+	 * superseded cycle are pending, since no live cycle will pick up the dirty flag.
+	 *
+	 * @return void
+	 */
+	public function test_mark_feed_dirty_reschedules_start_when_only_stale_cycle_actions_pending() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
+
+		$stale_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'stale-cycle' ) )
+		);
+
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturnCallback(
+				function ( $args ) use ( $stale_action ) {
+					$is_batch_first_page = 'pinterest/jobs/generate_feed/chain_batch' === $args['hook'] && 0 === $args['offset'];
+					return $is_batch_first_page ? array( $stale_action ) : array();
+				}
+			);
+
+		$this->feed_generator->mark_feed_dirty();
+
+		$next_start = as_next_scheduled_action( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+		$this->assertIsInt( $next_start, 'A stale cycle must not suppress rescheduling the start action.' );
+		$this->assertLessThanOrEqual( time() + 1, $next_start, 'The start action must be rescheduled to run now.' );
+	}
+
+	/**
+	 * mark_feed_dirty() must not reschedule the start action while the current cycle
+	 * is alive; the end of that cycle picks up the dirty flag instead.
+	 *
+	 * @return void
+	 */
+	public function test_mark_feed_dirty_defers_while_current_cycle_alive() {
+		as_unschedule_all_actions( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' );
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
+
+		$live_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'live-cycle' ) )
+		);
+
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturnCallback(
+				function ( $args ) use ( $live_action ) {
+					$is_batch_first_page = 'pinterest/jobs/generate_feed/chain_batch' === $args['hook'] && 0 === $args['offset'];
+					return $is_batch_first_page ? array( $live_action ) : array();
+				}
+			);
+
+		$this->feed_generator->mark_feed_dirty();
+
+		$this->assertEquals( 1, get_option( FeedGenerator::OPTION_FEED_DIRTY ), 'The feed must still be flagged dirty.' );
+		$this->assertFalse(
+			as_next_scheduled_action( 'pinterest-for-woocommerce-start-feed-generation', array(), 'pinterest-for-woocommerce' ),
+			'A live cycle must defer the restart to the end of the cycle.'
+		);
+	}
+
+	/**
 	 * A timed out batch from a superseded cycle must not be rescheduled and must not
 	 * shrink the current cycle's batch size throttling state.
 	 *

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1339,7 +1339,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 		$this->action_scheduler
 			->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( 'pinterest/jobs/generate_feed/chain_start' );
+			->with( 'pinterest/jobs/generate_feed/chain_start', $this->anything(), PINTEREST_FOR_WOOCOMMERCE_PREFIX );
 
 		$this->invoke_protected( $this->feed_generator, 'start_generation' );
 	}
@@ -1383,7 +1383,7 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	public function test_start_generation_defers_while_chain_start_pending() {
 		$this->action_scheduler
 			->method( 'next_scheduled_action' )
-			->with( 'pinterest/jobs/generate_feed/chain_start' )
+			->with( 'pinterest/jobs/generate_feed/chain_start', null, PINTEREST_FOR_WOOCOMMERCE_PREFIX )
 			->willReturn( time() + 10 );
 		$this->action_scheduler
 			->expects( $this->never() )

--- a/tests/Unit/FeedGeneratorTest.php
+++ b/tests/Unit/FeedGeneratorTest.php
@@ -1312,6 +1312,90 @@ class FeedGeneratorTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A pending batch from a superseded cycle must not prevent start_generation()
+	 * from queueing a new chain start.
+	 *
+	 * @return void
+	 */
+	public function test_start_generation_proceeds_when_only_stale_cycle_actions_pending() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
+
+		$stale_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'stale-cycle' ) )
+		);
+
+		$this->action_scheduler
+			->method( 'next_scheduled_action' )
+			->willReturn( false );
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturnCallback(
+				function ( $args ) use ( $stale_action ) {
+					$is_batch_first_page = 'pinterest/jobs/generate_feed/chain_batch' === $args['hook'] && 0 === $args['offset'];
+					return $is_batch_first_page ? array( $stale_action ) : array();
+				}
+			);
+		$this->action_scheduler
+			->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( 'pinterest/jobs/generate_feed/chain_start' );
+
+		$this->invoke_protected( $this->feed_generator, 'start_generation' );
+	}
+
+	/**
+	 * start_generation() must defer while the current cycle still has live chain actions.
+	 *
+	 * @return void
+	 */
+	public function test_start_generation_defers_while_current_cycle_alive() {
+		update_option( FeedGenerator::OPTION_CYCLE_ID, 'live-cycle', false );
+
+		$live_action = new ActionScheduler_Action(
+			'pinterest/jobs/generate_feed/chain_batch',
+			array( 2, array( FeedGenerator::ARG_CYCLE_ID => 'live-cycle' ) )
+		);
+
+		$this->action_scheduler
+			->method( 'next_scheduled_action' )
+			->willReturn( false );
+		$this->action_scheduler
+			->method( 'search' )
+			->willReturnCallback(
+				function ( $args ) use ( $live_action ) {
+					$is_batch_first_page = 'pinterest/jobs/generate_feed/chain_batch' === $args['hook'] && 0 === $args['offset'];
+					return $is_batch_first_page ? array( $live_action ) : array();
+				}
+			);
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+
+		$this->invoke_protected( $this->feed_generator, 'start_generation' );
+	}
+
+	/**
+	 * start_generation() must defer while a chain start action is already queued.
+	 *
+	 * @return void
+	 */
+	public function test_start_generation_defers_while_chain_start_pending() {
+		$this->action_scheduler
+			->method( 'next_scheduled_action' )
+			->with( 'pinterest/jobs/generate_feed/chain_start' )
+			->willReturn( time() + 10 );
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'search' );
+		$this->action_scheduler
+			->expects( $this->never() )
+			->method( 'schedule_immediate' );
+
+		$this->invoke_protected( $this->feed_generator, 'start_generation' );
+	}
+
+	/**
 	 * A timed out batch from a superseded cycle must not be rescheduled and must not
 	 * shrink the current cycle's batch size throttling state.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #1196, addressing the review nit left open there.

`start_generation()` gated on the framework's `is_running()`, which counts any pending `chain_start`/`chain_batch` action regardless of cycle. A still-pending batch from a superseded cycle (which self-terminates when it runs) could make a daily start return early, delaying feed generation by up to a day.

The gate now defers only when a chain start is already queued or the current cycle still has live actions (`is_current_cycle_alive()`), matching the check used by `handle_start_action()`.

`mark_feed_dirty()` had the same gap: a stale action made `is_running()` true, the dirty flag was set, and no live cycle existed to consume it at the end. Both paths now share `is_generation_active()`, and nothing in the plugin calls `is_running()` anymore.

### Detailed test instructions:

1. Set a stale pending batch: with a feed generation cycle finished, schedule a `pinterest/jobs/generate_feed/chain_batch` action whose `cycle_id` arg differs from the `pinterest_for_woocommerce_feed_generation_cycle_id` option.
2. Run the `pinterest-for-woocommerce-start-feed-generation` action from WooCommerce → Status → Scheduled Actions.
3. Before this change the start returned early with no new cycle; now a new `chain_start` is queued and the feed regenerates.
4. With the same stale batch in place, edit and save a product. Before this change the dirty flag was set but no start was rescheduled; now `pinterest-for-woocommerce-start-feed-generation` is rescheduled to run immediately.
5. Unit tests: `vendor/bin/phpunit --filter 'test_start_generation|test_mark_feed_dirty' tests/Unit/FeedGeneratorTest.php`

### Changelog entry

> Fix - Do not let pending actions from a superseded feed generation cycle block a new cycle from starting.
