### PR TITLE
Add bookmarklet path tests for Save button a11y

### DIFF
--- a/assets/source/js/pinterest-for-woocommerce-save-button.test.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.test.js
@@ -18,6 +18,17 @@ function unbuiltWrapper( label ) {
 }
 
 /**
+ * Markup rendered server side for a product with a featured image, where the
+ * screen reader label carries the "opens in a new window" hint.
+ *
+ * @param {string} name Product name.
+ * @return {string} Wrapper markup with an unbuilt Pinterest placeholder.
+ */
+function unbuiltWrapperWithHint( name ) {
+	return `<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">${ name }<span class="pinterest-for-woocommerce-new-window-hint"> (opens in a new window)</span></span><a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/"></a></div>`;
+}
+
+/**
  * Simulate what pinit.js does to a placeholder once it builds it.
  *
  * @param {Element} wrapper Wrapper holding the placeholder.
@@ -26,6 +37,22 @@ function markAsBuilt( wrapper ) {
 	wrapper
 		.querySelector( 'a[data-pin-do]' )
 		.setAttribute( 'data-pin-log', 'button_pinit' );
+}
+
+/**
+ * Simulate what pinit.js does on a product with no image: the placeholder is
+ * replaced by a bookmarklet control, which is a span rather than a link.
+ *
+ * @param {Element} wrapper Wrapper holding the placeholder.
+ * @return {Element} The span standing in for the bookmarklet control.
+ */
+function markAsBookmarklet( wrapper ) {
+	const placeholder = wrapper.querySelector( 'a[data-pin-do]' );
+	const span = document.createElement( 'span' );
+	span.setAttribute( 'data-pin-log', 'button_pinit_bookmarklet' );
+	placeholder.replaceWith( span );
+
+	return span;
 }
 
 /**
@@ -203,5 +230,54 @@ describe( 'Save to Pinterest button', () => {
 		const pinLink = document.querySelector( 'a[data-pin-do]' );
 		expect( pinLink.querySelector( '.screen-reader-text' ) ).not.toBeNull();
 		expect( pinLink.getAttribute( 'aria-haspopup' ) ).toBeNull();
+	} );
+
+	it( 'makes the bookmarklet control keyboard operable on products with no image', async () => {
+		const grid = document.createElement( 'div' );
+		grid.innerHTML = unbuiltWrapperWithHint( 'Hoodie to Pinterest' );
+		document.body.appendChild( grid );
+
+		const wrapper = grid.querySelector(
+			'.pinterest-for-woocommerce-image-wrapper'
+		);
+		const control = markAsBookmarklet( wrapper );
+		await flush( 200 );
+
+		// The span is exposed as a button and reachable by keyboard.
+		expect( control.getAttribute( 'role' ) ).toBe( 'button' );
+		expect( control.getAttribute( 'tabindex' ) ).toBe( '0' );
+		expect( control.getAttribute( 'aria-haspopup' ) ).toBe( 'dialog' );
+
+		// The label moves into the control and drops the new-window hint,
+		// since the bookmarklet opens an in-page dialog.
+		const srSpan = control.querySelector( '.screen-reader-text' );
+		expect( srSpan ).not.toBeNull();
+		expect(
+			srSpan.querySelector( '.pinterest-for-woocommerce-new-window-hint' )
+		).toBeNull();
+	} );
+
+	it( 'activates the bookmarklet control on Enter and Spacebar', () => {
+		const control = document.createElement( 'span' );
+		control.setAttribute( 'data-pin-log', 'button_pinit_bookmarklet' );
+		document.body.appendChild( control );
+
+		const click = jest.fn();
+		control.click = click;
+
+		for ( const key of [ 'Enter', ' ' ] ) {
+			const event = new window.KeyboardEvent( 'keydown', {
+				key,
+				bubbles: true,
+				cancelable: true,
+			} );
+			control.dispatchEvent( event );
+
+			// Pinterest only listens for clicks, so the key press is
+			// forwarded as one and the default scroll/submit is suppressed.
+			expect( event.defaultPrevented ).toBe( true );
+		}
+
+		expect( click ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/assets/source/js/pinterest-for-woocommerce-save-button.test.js
+++ b/assets/source/js/pinterest-for-woocommerce-save-button.test.js
@@ -21,11 +21,11 @@ function unbuiltWrapper( label ) {
  * Markup rendered server side for a product with a featured image, where the
  * screen reader label carries the "opens in a new window" hint.
  *
- * @param {string} name Product name.
+ * @param {string} label Screen reader label.
  * @return {string} Wrapper markup with an unbuilt Pinterest placeholder.
  */
-function unbuiltWrapperWithHint( name ) {
-	return `<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">${ name }<span class="pinterest-for-woocommerce-new-window-hint"> (opens in a new window)</span></span><a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/"></a></div>`;
+function unbuiltWrapperWithHint( label ) {
+	return `<div class="pinterest-for-woocommerce-image-wrapper"><span class="screen-reader-text">${ label }<span class="pinterest-for-woocommerce-new-window-hint"> (opens in a new window)</span></span><a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/"></a></div>`;
 }
 
 /**
@@ -232,7 +232,7 @@ describe( 'Save to Pinterest button', () => {
 		expect( pinLink.getAttribute( 'aria-haspopup' ) ).toBeNull();
 	} );
 
-	it( 'makes the bookmarklet control keyboard operable on products with no image', async () => {
+	it( 'makes the bookmarklet control keyboard operable', async () => {
 		const grid = document.createElement( 'div' );
 		grid.innerHTML = unbuiltWrapperWithHint( 'Hoodie to Pinterest' );
 		document.body.appendChild( grid );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #1211, which added keyboard support for the Save button's bookmarklet control (the `span` Pinterest renders on products with no featured image). That PR only flipped the existing `aria-haspopup` assertion, so the new bookmarklet path had no direct coverage.

This adds two tests:

- **Keyboard operable:** once the placeholder becomes a `button_pinit_bookmarklet` span, it gets `role="button"`, `tabindex="0"`, and `aria-haspopup="dialog"`, the screen reader label moves into the control, and the "opens in a new window" hint is dropped (the bookmarklet opens an in-page dialog).
- **Activation:** Enter and Spacebar on the span forward a click and suppress the default, since Pinterest only listens for clicks.

Both fail if the bookmarklet handling is removed from the script. Verified by mutating `role`/`tabindex`, the keydown handler's `preventDefault()`/`click()`, and the hint removal independently: each break is caught by the matching assertion. Also adds a `markAsBookmarklet()` helper and an `unbuiltWrapperWithHint()` helper mirroring what `render_pin()` now emits.

### Detailed test instructions:

1. `nvm use` (Node 14.16.1)
2. `npm run test:js`
3. Confirm the two new cases under "Save to Pinterest button" pass and the suite is green.

### Additional details:

### Changelog entry

> Dev - Add test coverage for the Save button bookmarklet keyboard path.
