### PR TITLE
Redirect OAuth callback rejections to the settings page

### DIFF
--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -52,26 +52,13 @@ class Auth extends VendorAPI {
 		 * Fail closed when no state has been issued, and only accept a string that matches it exactly.
 		 */
 		$expected = get_transient( \PINTEREST_FOR_WOOCOMMERCE_CONNECT_NONCE );
+		$state    = $request->get_param( 'state' );
 
-		if ( ! is_string( $expected ) || '' === $expected ) {
-			return $this->reject();
+		if ( is_string( $expected ) && '' !== $expected && is_string( $state ) && hash_equals( $expected, $state ) ) {
+			return true;
 		}
 
-		$state = $request->get_param( 'state' );
-
-		if ( ! is_string( $state ) || ! hash_equals( $expected, $state ) ) {
-			return $this->reject();
-		}
-
-		return true;
-	}
-
-	/**
-	 * Rejects the request, sending the merchant back to the settings page instead of a raw REST error.
-	 *
-	 * @return bool Always false.
-	 */
-	private function reject(): bool {
+		// Send the merchant back to the settings page instead of serving a raw REST error.
 		add_filter( 'rest_pre_serve_request', array( $this, 'redirect_to_settings_page' ), 10, 3 );
 
 		return false;

--- a/src/API/Auth.php
+++ b/src/API/Auth.php
@@ -54,12 +54,27 @@ class Auth extends VendorAPI {
 		$expected = get_transient( \PINTEREST_FOR_WOOCOMMERCE_CONNECT_NONCE );
 
 		if ( ! is_string( $expected ) || '' === $expected ) {
-			return false;
+			return $this->reject();
 		}
 
 		$state = $request->get_param( 'state' );
 
-		return is_string( $state ) && hash_equals( $expected, $state );
+		if ( ! is_string( $state ) || ! hash_equals( $expected, $state ) ) {
+			return $this->reject();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Rejects the request, sending the merchant back to the settings page instead of a raw REST error.
+	 *
+	 * @return bool Always false.
+	 */
+	private function reject(): bool {
+		add_filter( 'rest_pre_serve_request', array( $this, 'redirect_to_settings_page' ), 10, 3 );
+
+		return false;
 	}
 
 

--- a/tests/Unit/Api/AuthTest.php
+++ b/tests/Unit/Api/AuthTest.php
@@ -144,6 +144,38 @@ class AuthTest extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Tests a rejected request is sent back to the settings page rather than served as a raw error.
+	 *
+	 * @return void
+	 */
+	public function test_callback_rejection_redirects_to_settings_page() {
+		rest_get_server()->dispatch( $this->request( 'not-issued' ) );
+
+		$this->assertSame( 10, has_filter( 'rest_pre_serve_request', array( $this->auth(), 'redirect_to_settings_page' ) ) );
+	}
+
+	/**
+	 * Tests an accepted request is served normally with no redirect hooked.
+	 *
+	 * @return void
+	 */
+	public function test_callback_acceptance_does_not_hook_redirect() {
+		$this->issue_state();
+
+		$this->assertTrue( $this->dispatch_until_redirect( $this->request( 'issued-state' ) ) );
+		$this->assertFalse( has_filter( 'rest_pre_serve_request', array( $this->auth(), 'redirect_to_settings_page' ) ) );
+	}
+
+	/**
+	 * Returns the Auth controller instance registered for the callback route.
+	 *
+	 * @return object
+	 */
+	private function auth() {
+		return rest_get_server()->get_routes()[ self::ROUTE ][0]['permission_callback'][0];
+	}
+
+	/**
 	 * Builds a callback request, optionally carrying a state parameter.
 	 *
 	 * @param string|null $state The state parameter, or null to omit it.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Restores the settings-page redirect on a rejected OAuth callback. The `rest_pre_serve_request` hook that produced it was dropped in the 2023 auth refactor, so rejected requests returned the raw REST error (`rest_forbidden` JSON) instead of sending the merchant back to onboarding with a message. This reinstates the redirect for both rejection paths. Follow-up to the OAuth callback state-handling PR that this one is based on.

### Detailed test instructions:

1. Run `vendor/bin/phpunit --filter AuthTest` and confirm it passes.
2. Visit `/wp-json/pinterest/v1/oauth/callback` with no valid state in a browser. Confirm you land on the Pinterest onboarding screen with an error notice, not a raw JSON error.
3. Complete a normal connect flow and confirm it still succeeds.

### Changelog entry

> Fix - Send failed Pinterest OAuth callbacks back to the settings page instead of showing a raw REST error.
